### PR TITLE
fix: add permissions and disable auto-publish in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:
@@ -61,7 +64,6 @@ jobs:
         if: matrix.platform == 'mac'
         working-directory: apps/desktop
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Code signing
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -69,21 +71,17 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: pnpm dist:mac
+        run: pnpm dist:mac --publish never
 
       - name: Build distributables (Windows)
         if: matrix.platform == 'win'
         working-directory: apps/desktop
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm dist:win
+        run: pnpm dist:win --publish never
 
       - name: Build distributables (Linux)
         if: matrix.platform == 'linux'
         working-directory: apps/desktop
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: pnpm dist:linux
+        run: pnpm dist:linux --publish never
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add `contents: write` permission for release creation
- Use `--publish never` to let softprops action handle releases
- Prevents race condition between parallel builds trying to create the same release

## Root Cause
The release workflow was failing with 403 Forbidden because:
1. GITHUB_TOKEN didn't have explicit write permissions
2. electron-builder was trying to publish directly during build

🤖 Generated with [Claude Code](https://claude.com/claude-code)