### PR TITLE
docs: add VitePress documentation site

### DIFF
--- a/apps/docs-site/.vitepress/config.ts
+++ b/apps/docs-site/.vitepress/config.ts
@@ -1,0 +1,76 @@
+import { defineConfig } from 'vitepress';
+
+export default defineConfig({
+  title: 'Readied',
+  description: 'Technical documentation for Readied - Markdown-first, offline-forever note app',
+
+  head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
+
+  themeConfig: {
+    logo: '/logo.svg',
+
+    nav: [
+      { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Architecture', link: '/architecture/overview' },
+      { text: 'Decisions', link: '/decisions/' },
+      { text: 'Roadmap', link: '/roadmap/mvp' },
+    ],
+
+    sidebar: {
+      '/guide/': [
+        {
+          text: 'Guide',
+          items: [
+            { text: 'Getting Started', link: '/guide/getting-started' },
+            { text: 'Principles', link: '/guide/principles' },
+          ],
+        },
+      ],
+      '/architecture/': [
+        {
+          text: 'Architecture',
+          items: [
+            { text: 'Overview', link: '/architecture/overview' },
+            { text: 'Core Package', link: '/architecture/core' },
+            { text: 'Storage', link: '/architecture/storage' },
+            { text: 'IPC Contract', link: '/architecture/ipc' },
+            { text: 'Editor', link: '/architecture/editor' },
+            { text: 'Theming', link: '/architecture/theming' },
+          ],
+        },
+      ],
+      '/decisions/': [
+        {
+          text: 'Architecture Decisions',
+          items: [
+            { text: 'Index', link: '/decisions/' },
+            { text: 'ADR-001: Runtime Contract', link: '/decisions/adr-001-runtime-contract' },
+            { text: 'ADR-002: Markdown Model', link: '/decisions/adr-002-markdown-model' },
+            { text: 'ADR-003: Storage', link: '/decisions/adr-003-storage' },
+          ],
+        },
+      ],
+      '/roadmap/': [
+        {
+          text: 'Roadmap',
+          items: [
+            { text: 'MVP', link: '/roadmap/mvp' },
+            { text: 'v0.1', link: '/roadmap/v0.1' },
+            { text: 'v0.2+', link: '/roadmap/v0.2' },
+          ],
+        },
+      ],
+    },
+
+    socialLinks: [{ icon: 'github', link: 'https://github.com/tomymaritano/readide' }],
+
+    footer: {
+      message: 'Released under the MIT License.',
+      copyright: 'Copyright © 2025 Readied',
+    },
+
+    search: {
+      provider: 'local',
+    },
+  },
+});

--- a/apps/docs-site/architecture/core.md
+++ b/apps/docs-site/architecture/core.md
@@ -1,0 +1,92 @@
+# Core Package
+
+`@readied/core` contains all domain logic for Readied.
+
+## Principles
+
+- **Zero dependencies** on Electron, React, or Node-specific APIs
+- **Testable** in pure Node.js
+- **Pure functions** where possible
+
+## Structure
+
+```
+packages/core/
+├── domain/
+│   ├── note.ts          # Note entity
+│   ├── metadata.ts      # NoteMetadata
+│   ├── types.ts         # NoteId, Timestamp, Tag
+│   └── invariants.ts    # Business rules
+├── operations/
+│   ├── createNote.ts
+│   ├── updateNote.ts
+│   ├── deleteNote.ts
+│   ├── archiveNote.ts
+│   └── ...
+├── contracts/
+│   ├── NoteInput.ts     # Input types
+│   ├── NoteSnapshot.ts  # Output types
+│   └── CoreResult.ts    # Result wrapper
+├── repositories/
+│   └── NoteRepository.ts # Interface only
+└── validation/
+    └── schemas.ts       # Zod schemas
+```
+
+## Note Entity
+
+```typescript
+interface Note {
+  readonly id: NoteId;
+  readonly content: string; // Raw markdown
+  readonly metadata: NoteMetadata; // Derived data
+}
+
+interface NoteMetadata {
+  readonly title: string;
+  readonly createdAt: Timestamp;
+  readonly updatedAt: Timestamp;
+  readonly tags: readonly Tag[];
+  readonly wordCount: number;
+  readonly archivedAt: Timestamp | null;
+}
+```
+
+## Operations
+
+Operations are pure functions that take input and a repository:
+
+```typescript
+// createNote.ts
+export async function createNoteOperation(
+  input: CreateNoteInput,
+  repo: NoteRepository
+): Promise<Result<NoteSnapshot>> {
+  // Validate input
+  // Create Note entity
+  // Save via repository
+  // Return snapshot
+}
+```
+
+## Repository Interface
+
+Core defines the interface, storage packages implement it:
+
+```typescript
+interface NoteRepository {
+  get(id: NoteId): Promise<Note | null>;
+  save(note: Note): Promise<void>;
+  delete(id: NoteId): Promise<void>;
+  list(options?: ListOptions): Promise<Note[]>;
+  search(term: string): Promise<Note[]>;
+}
+```
+
+## Testing
+
+```bash
+pnpm --filter @readied/core test
+```
+
+52 tests covering all domain logic.

--- a/apps/docs-site/architecture/editor.md
+++ b/apps/docs-site/architecture/editor.md
@@ -1,0 +1,68 @@
+# Editor
+
+Readied uses CodeMirror 6 for markdown editing.
+
+## Why CodeMirror 6?
+
+| Feature    | Benefit                    |
+| ---------- | -------------------------- |
+| Modular    | Only include what we need  |
+| Performant | Handles large documents    |
+| Extensible | Custom extensions possible |
+| Modern     | Built with TypeScript      |
+| Active     | Well maintained            |
+
+## Integration
+
+```typescript
+import { EditorView, basicSetup } from 'codemirror';
+import { markdown } from '@codemirror/lang-markdown';
+import { languages } from '@codemirror/language-data';
+
+const view = new EditorView({
+  doc: initialContent,
+  extensions: [
+    basicSetup,
+    markdown({ codeLanguages: languages }),
+    // Custom extensions...
+  ],
+  parent: containerElement,
+});
+```
+
+## Key Extensions
+
+- `@codemirror/lang-markdown` - Markdown syntax
+- `@codemirror/language-data` - Code block highlighting
+- `@codemirror/commands` - Keyboard commands
+- Custom theme (matches app design)
+
+## Editor <-> Note Sync
+
+1. User types in editor
+2. Content saved on debounced change
+3. Note updated via IPC
+4. Sidebar reflects new metadata
+
+```typescript
+// Debounced save
+const saveNote = useDebouncedCallback((content: string) => {
+  window.readied.notes.update({ id: noteId, content });
+}, 500);
+```
+
+## Styling
+
+Editor styles are isolated from the main UI:
+
+```css
+/* Editor-specific styles */
+.cm-editor {
+  height: 100%;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.cm-content {
+  padding: 1rem;
+}
+```

--- a/apps/docs-site/architecture/ipc.md
+++ b/apps/docs-site/architecture/ipc.md
@@ -1,0 +1,85 @@
+# IPC Contract
+
+Electron's Inter-Process Communication (IPC) connects the renderer to the main process.
+
+## Architecture
+
+```
+Renderer (React)
+    ↓ window.readied.notes.create()
+Preload (Bridge)
+    ↓ ipcRenderer.invoke('notes:create')
+Main (Handlers)
+    ↓ createNoteOperation()
+Core + Storage
+```
+
+## Preload API
+
+The preload script exposes a typed API:
+
+```typescript
+interface ReadiedAPI {
+  notes: {
+    create: (input: CreateInput) => Promise<Result<NoteSnapshot>>;
+    get: (id: string) => Promise<Result<NoteSnapshot>>;
+    update: (input: UpdateInput) => Promise<Result<NoteSnapshot>>;
+    delete: (id: string) => Promise<Result<void>>;
+    archive: (id: string) => Promise<Result<NoteSnapshot>>;
+    restore: (id: string) => Promise<Result<NoteSnapshot>>;
+    list: (options?: ListOptions) => Promise<NoteSnapshot[]>;
+    search: (query: string) => Promise<NoteSnapshot[]>;
+    tags: () => Promise<string[]>;
+    count: () => Promise<NoteCounts>;
+  };
+  data: {
+    backup: () => Promise<BackupResult>;
+    export: () => Promise<ExportResult>;
+    import: () => Promise<ImportResult>;
+    paths: () => Promise<DataPaths>;
+    openFolder: () => Promise<void>;
+  };
+  app: {
+    version: () => string;
+  };
+}
+
+// Exposed as window.readied
+contextBridge.exposeInMainWorld('readied', api);
+```
+
+## Main Process Handlers
+
+```typescript
+// Register handlers on app ready
+ipcMain.handle('notes:create', async (_event, input) => {
+  return createNoteOperation(input, noteRepository);
+});
+
+ipcMain.handle('notes:list', async (_event, options) => {
+  const notes = await noteRepository.list(options);
+  return notes.map(toSnapshot);
+});
+```
+
+## Security Rules
+
+| Rule               | Description                      |
+| ------------------ | -------------------------------- |
+| No nodeIntegration | Renderer is sandboxed            |
+| contextIsolation   | Preload runs in isolated context |
+| No executeSQL      | Raw SQL never exposed            |
+| Typed channels     | All IPC is typed                 |
+
+## Usage in Renderer
+
+```typescript
+// In React component
+const result = await window.readied.notes.create({
+  content: '# Hello World',
+});
+
+if (result.ok) {
+  console.log('Created:', result.data.id);
+}
+```

--- a/apps/docs-site/architecture/overview.md
+++ b/apps/docs-site/architecture/overview.md
@@ -1,0 +1,103 @@
+# Architecture Overview
+
+Readied follows a clean architecture with strict separation of concerns.
+
+## Monorepo Structure
+
+```
+readied/
+├── apps/
+│   ├── desktop/           # Electron app
+│   │   ├── src/main/      # Main process (SQLite, IPC)
+│   │   ├── src/preload/   # Secure bridge
+│   │   └── src/renderer/  # React UI
+│   ├── docs-site/         # This documentation (VitePress)
+│   └── site/              # Marketing site (Astro)
+├── packages/
+│   ├── core/              # Domain logic + markdown parsing
+│   ├── storage-core/      # Storage interfaces + utilities
+│   └── storage-sqlite/    # SQLite implementation
+└── docs/                  # Static documentation assets
+```
+
+## Package Dependencies
+
+```mermaid
+graph TD
+    A[desktop] --> B[core]
+    A --> C[storage-sqlite]
+    C --> D[storage-core]
+    B -.-> D
+```
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Renderer Process                         │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
+│  │   React UI  │ -> │  TanStack   │ -> │   Preload   │     │
+│  │             │    │   Query     │    │   Bridge    │     │
+│  └─────────────┘    └─────────────┘    └──────┬──────┘     │
+└────────────────────────────────────────────────┼────────────┘
+                                                 │ IPC
+┌────────────────────────────────────────────────┼────────────┐
+│                      Main Process              │            │
+│  ┌─────────────┐    ┌─────────────┐    ┌──────┴──────┐     │
+│  │   SQLite    │ <- │    Core     │ <- │     IPC     │     │
+│  │   (better   │    │  Operations │    │   Handlers  │     │
+│  │   -sqlite3) │    │             │    │             │     │
+│  └─────────────┘    └─────────────┘    └─────────────┘     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Key Boundaries
+
+### 1. Core Package (`@readied/core`)
+
+- Pure domain logic
+- No Electron or React dependencies
+- Testable in Node.js
+- Defines Note entity, operations, and contracts
+
+### 2. Storage Core (`@readied/storage-core`)
+
+- Database adapter interfaces
+- Migration runner
+- Backup/Export/Import utilities
+- No native dependencies
+
+### 3. Storage SQLite (`@readied/storage-sqlite`)
+
+- SQLite implementation (better-sqlite3)
+- Repository implementations
+- Migration definitions
+- **Only package with native deps**
+
+### 4. Desktop App (`@readied/desktop`)
+
+- Electron + electron-vite
+- Main process: SQLite, IPC handlers
+- Renderer: React + CodeMirror 6
+- Preload: Typed API bridge
+
+## Security Model
+
+| Rule               | Description                 |
+| ------------------ | --------------------------- |
+| No nodeIntegration | Renderer is sandboxed       |
+| IPC whitelist      | Typed channels only         |
+| No executeSQL      | No raw SQL in renderer      |
+| Preload minimal    | Only necessary APIs exposed |
+
+## Technology Stack
+
+| Layer    | Technology               |
+| -------- | ------------------------ |
+| Runtime  | Electron                 |
+| Build    | electron-vite            |
+| Database | SQLite (better-sqlite3)  |
+| Editor   | CodeMirror 6             |
+| UI State | TanStack Query + Zustand |
+| Styling  | Tailwind CSS             |
+| Monorepo | pnpm + turborepo         |

--- a/apps/docs-site/architecture/storage.md
+++ b/apps/docs-site/architecture/storage.md
@@ -1,0 +1,86 @@
+# Storage
+
+Storage is split into two packages for isolation of native dependencies.
+
+## Packages
+
+### @readied/storage-core
+
+Interfaces and utilities with **no native dependencies**:
+
+- `DatabaseAdapter` interface
+- `Migration` types and runner
+- `DataPaths` management
+- Backup system
+- Export/Import utilities
+
+### @readied/storage-sqlite
+
+SQLite implementation using `better-sqlite3`:
+
+- `DatabaseConnection` adapter
+- `SQLiteNoteRepository`
+- Migration definitions
+
+## Why Split?
+
+Native modules (like better-sqlite3) cause issues:
+
+- Need rebuilding for each Electron version
+- Platform-specific binaries
+- Can't run in pure Node without native compilation
+
+By isolating native deps to `storage-sqlite`, we can:
+
+- Test storage-core anywhere
+- Swap implementations if needed
+- Keep clean dependency graph
+
+## Database Adapter
+
+```typescript
+interface DatabaseAdapter {
+  exec(sql: string): void;
+  prepare<T>(sql: string): PreparedStatement<T>;
+  transaction<T>(fn: () => T): T;
+  close(): void;
+  get isOpen(): boolean;
+}
+```
+
+## Migrations
+
+Forward-only migrations run on startup:
+
+```typescript
+const migrations: Migration[] = [
+  {
+    version: 1,
+    name: 'initial_schema',
+    up: `CREATE TABLE notes (...)`,
+  },
+];
+
+// Run pending migrations
+runMigrations(db, migrations);
+```
+
+## Backup System
+
+```typescript
+// Create backup
+createBackup({
+  backupDir: paths.backups,
+  databasePath: paths.database,
+});
+
+// List backups
+const backups = listBackups(paths.backups);
+
+// Restore
+restoreBackup(backupPath, databasePath);
+```
+
+## Export/Import
+
+See [Data Management](/guide/getting-started#import--export).

--- a/apps/docs-site/architecture/theming.md
+++ b/apps/docs-site/architecture/theming.md
@@ -1,0 +1,70 @@
+# Theming
+
+Readied uses CSS variables for theming.
+
+## Design Tokens
+
+```css
+:root {
+  /* Colors */
+  --color-bg: #0a0b0d;
+  --color-bg-secondary: #131417;
+  --color-text: #e4e4e7;
+  --color-text-muted: #71717a;
+  --color-accent: #3b82f6;
+  --color-border: #27272a;
+
+  /* Typography */
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+
+  /* Spacing */
+  --spacing-1: 0.25rem;
+  --spacing-2: 0.5rem;
+  --spacing-4: 1rem;
+  --spacing-8: 2rem;
+
+  /* Radius */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+}
+```
+
+## Component Styling
+
+Using Tailwind CSS with design tokens:
+
+```tsx
+<button
+  className="
+  bg-[var(--color-accent)]
+  text-white
+  px-4 py-2
+  rounded-[var(--radius-md)]
+  hover:opacity-90
+"
+>
+  Create Note
+</button>
+```
+
+## Dark Mode
+
+Currently dark-only. Light mode planned for v0.2+.
+
+## Editor Theme
+
+CodeMirror has its own theme system, synchronized with app tokens:
+
+```typescript
+const editorTheme = EditorView.theme({
+  '&': {
+    backgroundColor: 'var(--color-bg)',
+    color: 'var(--color-text)',
+  },
+  '.cm-cursor': {
+    borderLeftColor: 'var(--color-accent)',
+  },
+});
+```

--- a/apps/docs-site/decisions/adr-001-runtime-contract.md
+++ b/apps/docs-site/decisions/adr-001-runtime-contract.md
@@ -1,0 +1,109 @@
+# ADR-001: Runtime Contract
+
+## Status
+
+Accepted
+
+## Context
+
+Readied is an Electron desktop app with complex domain logic (note management, markdown parsing, metadata extraction). We need to decide how to structure the codebase to ensure:
+
+1. **Testability** - Domain logic should be testable without spinning up Electron
+2. **Portability** - Core logic could potentially run in other contexts (CLI, web worker)
+3. **Maintainability** - Clear boundaries prevent accidental coupling
+4. **Security** - Renderer process should have limited access to system resources
+
+## Decision
+
+We adopt a **strict separation of concerns** with these boundaries:
+
+### Core Package (`@readied/core`)
+
+- Contains all domain logic
+- **Zero dependencies** on Electron, React, or Node.js-specific APIs
+- Testable in pure Node.js with Vitest
+- Exposes Commands (mutations) and Queries (reads)
+- Uses ports/adapters pattern for I/O
+
+```typescript
+// Core exposes operations, not implementation details
+export { createNoteOperation } from './operations/createNote';
+export { getNoteOperation } from './operations/getNote';
+
+// Repository is an interface, not an implementation
+export interface NoteRepository {
+  get(id: NoteId): Promise<Note | null>;
+  save(note: Note): Promise<void>;
+}
+```
+
+### Storage Packages
+
+- `@readied/storage-core` - Interfaces and utilities (no native deps)
+- `@readied/storage-sqlite` - SQLite implementation (native deps isolated)
+
+### Desktop App
+
+- Main process: Database initialization, IPC handlers
+- Preload: Minimal typed API bridge
+- Renderer: React UI, calls preload API
+
+### Communication Contract
+
+```
+Renderer -> Preload -> IPC -> Main -> Core -> Storage
+```
+
+All IPC channels are typed. No raw SQL exposed to renderer.
+
+## Consequences
+
+### Positive
+
+- **Testable**: Core has 52 unit tests running in <500ms
+- **Portable**: Core could run in Deno, Bun, or web workers
+- **Secure**: Renderer can't access filesystem directly
+- **Maintainable**: Changes to UI don't affect domain logic
+
+### Negative
+
+- **Boilerplate**: More layers means more code
+- **Indirection**: Data flows through multiple boundaries
+- **Learning curve**: Contributors must understand the architecture
+
+### Risks
+
+- Over-engineering for a solo project
+- Mitigation: Keep packages minimal, split only when there's pain
+
+## Alternatives Considered
+
+### 1. Single Package
+
+Put everything in one package with folder-based separation.
+
+**Rejected because:**
+
+- Easy to accidentally couple layers
+- Can't enforce boundaries at build time
+- Testing requires mocking Electron
+
+### 2. Domain-Driven Modules
+
+Split by domain (notes, tags, links) instead of by layer.
+
+**Rejected because:**
+
+- Cross-cutting concerns (storage, IPC) become messy
+- Harder to swap implementations
+- Less clear security boundaries
+
+### 3. Full Monolith
+
+No separation, everything in desktop app.
+
+**Rejected because:**
+
+- Untestable without Electron
+- Impossible to reuse logic
+- Security risks from coupled code

--- a/apps/docs-site/decisions/adr-002-markdown-model.md
+++ b/apps/docs-site/decisions/adr-002-markdown-model.md
@@ -1,0 +1,136 @@
+# ADR-002: Markdown Model
+
+## Status
+
+Accepted
+
+## Context
+
+A note-taking app must decide how to represent notes internally. The key question:
+
+> **What is the source of truth for a note's content?**
+
+Options:
+
+1. **Markdown text** - Store raw markdown, parse on demand
+2. **AST (Abstract Syntax Tree)** - Store parsed structure
+3. **Hybrid** - Store both, keep them in sync
+
+This decision affects:
+
+- Data portability
+- Export fidelity
+- Parse error handling
+- Feature implementation complexity
+
+## Decision
+
+**Markdown text is the canonical source of truth.**
+
+### Preservation Invariants
+
+| Invariant                 | Rule                                                  |
+| ------------------------- | ----------------------------------------------------- |
+| Raw text is sacred        | User-typed markdown is NEVER auto-modified            |
+| AST is ephemeral          | Exists only for parsing, never persisted as authority |
+| Parse errors don't block  | If parse fails, save raw markdown anyway              |
+| No normalization          | Never reformat whitespace, headings, lists            |
+| No serialization from AST | Never reconstruct markdown from parsed AST            |
+
+### Implementation
+
+```typescript
+interface Note {
+  id: NoteId;
+  content: string; // RAW MARKDOWN - canonical source
+  metadata: NoteMetadata; // Derived from content, computed on save
+}
+
+interface NoteMetadata {
+  title: string; // Extracted from first H1 or filename
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  tags: readonly Tag[]; // Extracted from #tags in content
+  wordCount: number;
+}
+```
+
+### Derived Data
+
+These are computed from markdown on save, stored for queries:
+
+- Title (first H1 or "Untitled")
+- Tags (from #hashtags in content)
+- Word count
+- Backlinks (from [[wikilinks]])
+
+### Golden Rule
+
+> "If the user typed it, we keep it."
+
+**Consequences:**
+
+- No "prettify markdown" feature
+- No auto-fix for broken links
+- No whitespace normalization
+- Export = exact copy of stored markdown
+
+## Consequences
+
+### Positive
+
+- **Portable**: Export is always valid, standalone markdown
+- **Predictable**: User knows exactly what's stored
+- **Recoverable**: Parse errors can't corrupt data
+- **Simple**: One source of truth, no sync issues
+- **Compatible**: Works with any markdown ecosystem
+
+### Negative
+
+- **Performance**: Must parse on every read for features
+- **Consistency**: Derived data could get out of sync
+- **Features limited**: Can't do AST-based transformations
+
+### Risks
+
+- Performance with large notes (>100KB)
+- Mitigation: Cache parsed results, lazy parsing
+
+## Alternatives Considered
+
+### 1. AST as Source of Truth
+
+Store the parsed AST, serialize to markdown on export.
+
+**Rejected because:**
+
+- Information loss during parsing (whitespace, formatting choices)
+- Different markdown flavors produce different ASTs
+- Reconstruction never produces identical output
+- Lock-in to specific parser implementation
+
+### 2. Hybrid Storage
+
+Store both raw markdown and AST, keep in sync.
+
+**Rejected because:**
+
+- Complexity of keeping them synchronized
+- Which one wins on conflict?
+- Double storage space
+- More code to maintain
+
+### 3. Block-Based (Notion-style)
+
+Use structured blocks as the model.
+
+**Rejected because:**
+
+- Not markdown-first
+- Export requires serialization
+- Different product identity
+- Higher complexity
+
+## Related Decisions
+
+- [ADR-003: Storage](/decisions/adr-003-storage) - How markdown is persisted

--- a/apps/docs-site/decisions/adr-003-storage.md
+++ b/apps/docs-site/decisions/adr-003-storage.md
@@ -1,0 +1,185 @@
+# ADR-003: Storage Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+A desktop note app needs persistent storage. Requirements:
+
+1. **Offline-first** - No network required
+2. **Queryable** - Search, filter, sort notes
+3. **Portable** - User can backup/move data
+4. **Performant** - Handle 10k+ notes
+5. **Reliable** - No data loss
+
+Options:
+
+1. **Filesystem** - One file per note
+2. **SQLite** - Embedded relational database
+3. **LevelDB/RocksDB** - Key-value stores
+4. **IndexedDB** - Browser storage (renderer only)
+
+## Decision
+
+**SQLite in the main process with better-sqlite3.**
+
+### Schema
+
+```sql
+CREATE TABLE notes (
+  id TEXT PRIMARY KEY,
+  content TEXT NOT NULL,           -- Full markdown
+  title TEXT NOT NULL,             -- Derived from content
+  created_at TEXT NOT NULL,        -- ISO 8601
+  updated_at TEXT NOT NULL,        -- ISO 8601
+  archived_at TEXT,                -- Soft delete
+  revision INTEGER DEFAULT 1,      -- Optimistic locking
+  device_id TEXT                   -- Future sync support
+);
+
+CREATE INDEX idx_notes_updated_at ON notes(updated_at);
+CREATE INDEX idx_notes_archived_at ON notes(archived_at);
+CREATE INDEX idx_notes_title ON notes(title);
+```
+
+### Access Pattern
+
+```
+Renderer -> IPC -> Main Process -> Repository -> SQLite
+```
+
+- No raw SQL in renderer
+- Typed repository interface
+- Batch APIs for performance
+
+### Data Location
+
+| Platform | Path                                     |
+| -------- | ---------------------------------------- |
+| macOS    | `~/Library/Application Support/Readied/` |
+| Windows  | `%APPDATA%/Readied/`                     |
+| Linux    | `~/.config/Readied/`                     |
+
+### Directory Structure
+
+```
+Readied/
+├── readied.db          # SQLite database
+├── backups/            # Automatic backups
+├── logs/               # Application logs
+└── config.json         # User preferences
+```
+
+## Consequences
+
+### Positive
+
+- **Queryable**: Full SQL for search, filter, sort
+- **Reliable**: SQLite is battle-tested, ACID compliant
+- **Portable**: Single file, easy to backup
+- **Performant**: WAL mode, proper indices
+- **Sync-ready**: Schema includes revision, deviceId
+
+### Negative
+
+- **Native dependency**: better-sqlite3 requires rebuild per platform
+- **Single process**: Can't access from renderer directly
+- **Learning curve**: SQL knowledge required
+
+### Risks
+
+- better-sqlite3 build issues on some platforms
+- Mitigation: Prebuilt binaries, electron-rebuild
+
+## Implementation Details
+
+### Migrations
+
+Forward-only, versioned migrations:
+
+```typescript
+const migrations: Migration[] = [
+  {
+    version: 1,
+    name: 'initial_schema',
+    up: `CREATE TABLE notes (...)`,
+  },
+  {
+    version: 2,
+    name: 'add_archived_at',
+    up: `ALTER TABLE notes ADD COLUMN archived_at TEXT`,
+  },
+];
+```
+
+### Backup Strategy
+
+- Automatic backup before migrations
+- Manual backup via IPC
+- Rotating backups (keep last 5)
+
+### Search (v0.1)
+
+Simple LIKE-based search:
+
+```sql
+SELECT * FROM notes
+WHERE content LIKE '%term%' OR title LIKE '%term%'
+ORDER BY updated_at DESC
+LIMIT 50
+```
+
+**Deferred**: FTS5 for full-text search (v0.2+)
+
+## Alternatives Considered
+
+### 1. Filesystem (One File Per Note)
+
+Store each note as a `.md` file.
+
+**Rejected because:**
+
+- No efficient queries (must scan all files)
+- Metadata in frontmatter is fragile
+- Sync conflicts harder to resolve
+- Can't do ACID transactions
+
+### 2. LevelDB / RocksDB
+
+Key-value store with good performance.
+
+**Rejected because:**
+
+- No SQL queries
+- Custom indexing required
+- Less tooling available
+- Not as portable
+
+### 3. IndexedDB
+
+Browser storage in renderer process.
+
+**Rejected because:**
+
+- Only accessible in renderer
+- Storage limits
+- Less reliable than SQLite
+- No cross-process access
+
+### 4. PostgreSQL / MySQL
+
+Full database server.
+
+**Rejected because:**
+
+- Requires separate process
+- Overkill for single-user app
+- Complex installation
+- Not truly offline
+
+## Related Decisions
+
+- [ADR-001: Runtime Contract](/decisions/adr-001-runtime-contract) - Storage isolation
+- [ADR-002: Markdown Model](/decisions/adr-002-markdown-model) - What we store

--- a/apps/docs-site/decisions/index.md
+++ b/apps/docs-site/decisions/index.md
@@ -1,0 +1,61 @@
+# Architecture Decision Records
+
+This section documents significant architectural decisions made during Readied's development.
+
+## What is an ADR?
+
+An Architecture Decision Record (ADR) captures a single architectural decision along with its context and consequences. ADRs help future maintainers understand why decisions were made.
+
+## ADR Index
+
+| ADR                                            | Title            | Status   |
+| ---------------------------------------------- | ---------------- | -------- |
+| [ADR-001](/decisions/adr-001-runtime-contract) | Runtime Contract | Accepted |
+| [ADR-002](/decisions/adr-002-markdown-model)   | Markdown Model   | Accepted |
+| [ADR-003](/decisions/adr-003-storage)          | Storage Strategy | Accepted |
+
+## ADR Template
+
+When adding a new ADR, use this template:
+
+```markdown
+# ADR-XXX: [Title]
+
+## Status
+
+Accepted | Superseded | Deprecated
+
+## Context
+
+What problem are we solving?
+
+## Decision
+
+What did we decide?
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Risks
+
+- ...
+
+## Alternatives Considered
+
+1. Option A — rejected because...
+2. Option B — rejected because...
+```
+
+## Principles for ADRs
+
+1. **One decision per ADR** - Keep them focused
+2. **Immutable once accepted** - Create new ADR to supersede
+3. **Include context** - Future you won't remember why
+4. **Document alternatives** - Show due diligence

--- a/apps/docs-site/guide/getting-started.md
+++ b/apps/docs-site/guide/getting-started.md
@@ -1,0 +1,67 @@
+# Getting Started
+
+Readied is a Markdown-first, offline-forever desktop note app for developers.
+
+## Installation
+
+Download the latest release from [GitHub Releases](https://github.com/tomymaritano/readide/releases).
+
+| Platform              | Download                        |
+| --------------------- | ------------------------------- |
+| macOS (Apple Silicon) | `Readied-x.x.x-arm64.dmg`       |
+| macOS (Intel)         | `Readied-x.x.x.dmg`             |
+| Windows               | `Readied.Setup.x.x.x.exe`       |
+| Linux (AppImage)      | `Readied-x.x.x-x86_64.AppImage` |
+| Linux (Debian)        | `Readied-x.x.x-amd64.deb`       |
+
+## First Launch
+
+1. Open Readied
+2. Your notes are stored locally in:
+   - **macOS**: `~/Library/Application Support/Readied/`
+   - **Windows**: `%APPDATA%/Readied/`
+   - **Linux**: `~/.config/Readied/`
+3. Start writing in Markdown!
+
+## Key Features
+
+### Markdown First
+
+- Full Markdown syntax support
+- Syntax highlighting for code blocks
+- Your markdown is **never auto-modified**
+
+### Offline Forever
+
+- No account required
+- No internet connection needed
+- Your data stays on your machine
+
+### Import & Export
+
+- Import from Obsidian vaults
+- Import plain Markdown folders
+- Export to Markdown + JSON
+
+## Development
+
+```bash
+# Clone the repository
+git clone https://github.com/tomymaritano/readide.git readied
+cd readied
+
+# Install dependencies
+pnpm install
+
+# Run in development mode
+pnpm dev
+
+# Build for production
+pnpm build
+```
+
+## Next Steps
+
+- Read the [Principles](/guide/principles) to understand the philosophy
+- Explore the [Architecture](/architecture/overview) to understand how it works
+- Check the [ADRs](/decisions/) for key technical decisions

--- a/apps/docs-site/guide/principles.md
+++ b/apps/docs-site/guide/principles.md
@@ -1,0 +1,74 @@
+# Principles
+
+These principles guide every technical and product decision in Readied.
+
+## Core Principles
+
+### 1. Markdown is Sacred
+
+> "If the user typed it, we keep it."
+
+- User-typed markdown is **NEVER** auto-modified
+- No normalization of whitespace, headings, or lists
+- No auto-fix for broken links
+- No "prettify markdown" feature
+- Export = exact copy of stored markdown
+
+### 2. Offline First
+
+- 100% functional without internet connection
+- Sync is a feature, not a requirement
+- No features require online connectivity
+- Data lives on user's machine
+
+### 3. Data Ownership
+
+- Zero lock-in
+- User data belongs to the user
+- Export anytime in standard formats
+- App removal does NOT delete data
+
+### 4. Core Independence
+
+- Core domain logic runs without Electron, React, or UI
+- Testable in pure Node.js
+- No framework dependencies in business logic
+
+## Technical Principles
+
+### Strict Separation
+
+```
+Core ≠ UI ≠ Infra ≠ Packaging
+```
+
+- React never decides domain logic
+- SQLite queries never in renderer
+- IPC channels are typed contracts
+
+### Minimal Dependencies
+
+- Every library needs written justification
+- No "just in case" abstractions
+- Prefer standard APIs over libraries
+
+### Forward-Only Migrations
+
+- Schema changes are inevitable
+- Plan for them from day 1
+- Never rollback schema
+- Automatic backup before migration
+
+## What Readied is NOT
+
+| Not This           | Because                      |
+| ------------------ | ---------------------------- |
+| Notion clone       | No blocks-first architecture |
+| Collaboration tool | Single-user product          |
+| Mobile app         | Desktop first                |
+| AI-powered         | Not core value prop          |
+| Cloud-required     | Offline-first identity       |
+
+## One-Liner
+
+> "Your notes survive the app."

--- a/apps/docs-site/index.md
+++ b/apps/docs-site/index.md
@@ -1,0 +1,29 @@
+---
+layout: home
+
+hero:
+  name: Readied
+  text: Technical Documentation
+  tagline: Markdown-first, offline-forever note app for developers
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: Architecture
+      link: /architecture/overview
+
+features:
+  - icon: 📝
+    title: Markdown Sacred
+    details: Your markdown is never auto-modified. What you type is what you get.
+  - icon: 🔌
+    title: Offline Forever
+    details: 100% functional without internet. Your notes live on your machine.
+  - icon: 🏗️
+    title: Clean Architecture
+    details: Core domain logic runs without Electron, React, or UI dependencies.
+  - icon: 📦
+    title: Portable Data
+    details: Export anytime. Import from Obsidian. Your notes survive the app.
+---

--- a/apps/docs-site/package.json
+++ b/apps/docs-site/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@readied/docs",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Technical documentation for Readied",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview"
+  },
+  "devDependencies": {
+    "vitepress": "^1.5.0"
+  }
+}

--- a/apps/docs-site/roadmap/mvp.md
+++ b/apps/docs-site/roadmap/mvp.md
@@ -1,0 +1,60 @@
+# MVP Roadmap
+
+Readied MVP (v0.1) focuses on core functionality.
+
+## Completed Phases
+
+### Phase 0: Bootstrap ✅
+
+- Monorepo with pnpm + turborepo
+- CLAUDE.md and plan.md
+- Package structure defined
+
+### Phase 1: Core ✅
+
+- Note entity and operations
+- Metadata extraction (title, tags, word count)
+- 52 unit tests passing
+
+### Phase 2: Storage ✅
+
+- SQLite with better-sqlite3
+- Repository implementation
+- Migration system
+
+### Phase 3: Desktop ✅
+
+- Electron + electron-vite
+- IPC handlers
+- React renderer
+
+### Phase 4: Editor ✅
+
+- CodeMirror 6 integration
+- Markdown syntax highlighting
+- Auto-save
+
+### Phase 5: Features ✅
+
+- Note list (sidebar)
+- Search
+- Tags
+- Archive/Restore
+- Keyboard shortcuts
+
+### Phase 6: Release ✅
+
+- GitHub Actions CI/CD
+- Code signing (macOS)
+- Notarization (macOS)
+- Multi-platform builds
+
+## Current Status
+
+**v0.1.0 Released!** 🎉
+
+Download from [GitHub Releases](https://github.com/tomymaritano/readide/releases).
+
+## What's Next
+
+See [v0.2 Roadmap](/roadmap/v0.2) for upcoming features.

--- a/apps/docs-site/roadmap/v0.1.md
+++ b/apps/docs-site/roadmap/v0.1.md
@@ -1,0 +1,51 @@
+# v0.1 - Initial Release
+
+**Status:** Released ✅
+
+## Features
+
+### Core
+
+- Create, edit, delete notes
+- Archive and restore
+- Duplicate notes
+- Markdown-first editing
+
+### Editor
+
+- CodeMirror 6
+- Syntax highlighting
+- Code block support
+- Auto-save
+
+### Organization
+
+- Note list sidebar
+- Search (title + content)
+- Tags (extracted from #hashtags)
+- Sort by date or title
+
+### Data Management
+
+- SQLite storage
+- Automatic backups
+- Export to Markdown + JSON
+- Import from Obsidian/Markdown
+
+### Infrastructure
+
+- macOS, Windows, Linux builds
+- Code signing (macOS)
+- Notarization (macOS)
+- Auto-updates
+
+## Known Limitations
+
+- Dark mode only
+- No image support
+- No sync
+- Basic search (no FTS)
+
+## Download
+
+[GitHub Releases](https://github.com/tomymaritano/readide/releases/tag/v0.1.0)

--- a/apps/docs-site/roadmap/v0.2.md
+++ b/apps/docs-site/roadmap/v0.2.md
@@ -1,0 +1,64 @@
+# v0.2+ - Future Plans
+
+**Status:** Planning
+
+## Planned Features
+
+### Full-Text Search
+
+- FTS5 for fast search
+- Ranking by relevance
+- Fuzzy matching
+
+### Image Support
+
+- Paste images
+- Drag & drop
+- Local storage (not embedded in DB)
+
+### Backlinks
+
+- Automatic backlink detection
+- Backlinks panel
+- [[wikilink]] support
+
+### Graph View
+
+- Visual note connections
+- Interactive exploration
+- Filter by tag
+
+### Light Mode
+
+- Light theme option
+- System preference detection
+- Per-note theme override?
+
+### Monetization
+
+- License validation
+- Trial mode (14 days)
+- Lemon Squeezy integration
+
+## Deferred Features
+
+| Feature       | When  | Why                             |
+| ------------- | ----- | ------------------------------- |
+| Sync          | v1.0+ | Complex, need solid local first |
+| Mobile        | v1.0+ | Desktop-first identity          |
+| Plugins       | Never | Security + maintenance          |
+| Collaboration | Never | Single-user product             |
+| AI features   | TBD   | Not core value prop             |
+
+## Non-Goals
+
+Things we explicitly won't build:
+
+- Block-based editing (Notion-style)
+- Real-time collaboration
+- Cloud-only storage
+- Arbitrary plugin system
+
+## Contributing
+
+Want to help? See [GitHub Issues](https://github.com/tomymaritano/readide/issues).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,12 @@ importers:
         specifier: ^5.4.11
         version: 5.4.21(@types/node@25.0.3)
 
+  apps/docs-site:
+    devDependencies:
+      vitepress:
+        specifier: ^1.5.0
+        version: 1.6.4(@algolia/client-search@5.46.2)(@types/node@25.0.3)(@types/react@18.3.27)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3)
+
   packages/core:
     dependencies:
       zod:
@@ -180,6 +186,82 @@ packages:
 
   7zip-bin@5.2.0:
     resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
+
+  '@algolia/abtesting@1.12.2':
+    resolution: {integrity: sha512-oWknd6wpfNrmRcH0vzed3UPX0i17o4kYLM5OMITyMVM2xLgaRbIafoxL0e8mcrNNb0iORCJA0evnNDKRYth5WQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/autocomplete-core@1.17.7':
+    resolution: {integrity: sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==}
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7':
+    resolution: {integrity: sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==}
+    peerDependencies:
+      search-insights: '>= 1 < 3'
+
+  '@algolia/autocomplete-preset-algolia@1.17.7':
+    resolution: {integrity: sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/autocomplete-shared@1.17.7':
+    resolution: {integrity: sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+
+  '@algolia/client-abtesting@5.46.2':
+    resolution: {integrity: sha512-oRSUHbylGIuxrlzdPA8FPJuwrLLRavOhAmFGgdAvMcX47XsyM+IOGa9tc7/K5SPvBqn4nhppOCEz7BrzOPWc4A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-analytics@5.46.2':
+    resolution: {integrity: sha512-EPBN2Oruw0maWOF4OgGPfioTvd+gmiNwx0HmD9IgmlS+l75DatcBkKOPNJN+0z3wBQWUO5oq602ATxIfmTQ8bA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-common@5.46.2':
+    resolution: {integrity: sha512-Hj8gswSJNKZ0oyd0wWissqyasm+wTz1oIsv5ZmLarzOZAp3vFEda8bpDQ8PUhO+DfkbiLyVnAxsPe4cGzWtqkg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-insights@5.46.2':
+    resolution: {integrity: sha512-6dBZko2jt8FmQcHCbmNLB0kCV079Mx/DJcySTL3wirgDBUH7xhY1pOuUTLMiGkqM5D8moVZTvTdRKZUJRkrwBA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-personalization@5.46.2':
+    resolution: {integrity: sha512-1waE2Uqh/PHNeDXGn/PM/WrmYOBiUGSVxAWqiJIj73jqPqvfzZgzdakHscIVaDl6Cp+j5dwjsZ5LCgaUr6DtmA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-query-suggestions@5.46.2':
+    resolution: {integrity: sha512-EgOzTZkyDcNL6DV0V/24+oBJ+hKo0wNgyrOX/mePBM9bc9huHxIY2352sXmoZ648JXXY2x//V1kropF/Spx83w==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/client-search@5.46.2':
+    resolution: {integrity: sha512-ZsOJqu4HOG5BlvIFnMU0YKjQ9ZI6r3C31dg2jk5kMWPSdhJpYL9xa5hEe7aieE+707dXeMI4ej3diy6mXdZpgA==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/ingestion@1.46.2':
+    resolution: {integrity: sha512-1Uw2OslTWiOFDtt83y0bGiErJYy5MizadV0nHnOoHFWMoDqWW0kQoMFI65pXqRSkVvit5zjXSLik2xMiyQJDWQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/monitoring@1.46.2':
+    resolution: {integrity: sha512-xk9f+DPtNcddWN6E7n1hyNNsATBCHIqAvVGG2EAGHJc4AFYL18uM/kMTiOKXE/LKDPyy1JhIerrh9oYb7RBrgw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/recommend@5.46.2':
+    resolution: {integrity: sha512-NApbTPj9LxGzNw4dYnZmj2BoXiAc8NmbbH6qBNzQgXklGklt/xldTvu+FACN6ltFsTzoNU6j2mWNlHQTKGC5+Q==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-browser-xhr@5.46.2':
+    resolution: {integrity: sha512-ekotpCwpSp033DIIrsTpYlGUCF6momkgupRV/FA3m62SreTSZUKjgK6VTNyG7TtYfq9YFm/pnh65bATP/ZWJEg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-fetch@5.46.2':
+    resolution: {integrity: sha512-gKE+ZFi/6y7saTr34wS0SqYFDcjHW4Wminv8PDZEi0/mE99+hSrbKgJWxo2ztb5eqGirQTgIh1AMVacGGWM1iw==}
+    engines: {node: '>= 14.0.0'}
+
+  '@algolia/requester-node-http@5.46.2':
+    resolution: {integrity: sha512-ciPihkletp7ttweJ8Zt+GukSVLp2ANJHU+9ttiSxsJZThXc4Y2yJ8HGVWesW5jN1zrsZsezN71KrMx/iZsOYpg==}
+    engines: {node: '>= 14.0.0'}
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
@@ -387,6 +469,29 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@docsearch/css@3.8.2':
+    resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
+
+  '@docsearch/js@3.8.2':
+    resolution: {integrity: sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==}
+
+  '@docsearch/react@3.8.2':
+    resolution: {integrity: sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+      search-insights: '>= 1 < 3'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      search-insights:
+        optional: true
 
   '@electron/asar@3.2.18':
     resolution: {integrity: sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==}
@@ -1195,20 +1300,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@2.5.0':
+    resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
+
   '@shikijs/core@3.20.0':
     resolution: {integrity: sha512-f2ED7HYV4JEk827mtMDwe/yQ25pRiXZmtHjWF8uzZKuKiEsJR7Ce1nuQ+HhV9FzDcbIo4ObBCD9GPTzNuy9S1g==}
+
+  '@shikijs/engine-javascript@2.5.0':
+    resolution: {integrity: sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==}
 
   '@shikijs/engine-javascript@3.20.0':
     resolution: {integrity: sha512-OFx8fHAZuk7I42Z9YAdZ95To6jDePQ9Rnfbw9uSRTSbBhYBp1kEOKv/3jOimcj3VRUKusDYM6DswLauwfhboLg==}
 
+  '@shikijs/engine-oniguruma@2.5.0':
+    resolution: {integrity: sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==}
+
   '@shikijs/engine-oniguruma@3.20.0':
     resolution: {integrity: sha512-Yx3gy7xLzM0ZOjqoxciHjA7dAt5tyzJE3L4uQoM83agahy+PlW244XJSrmJRSBvGYELDhYXPacD4R/cauV5bzQ==}
+
+  '@shikijs/langs@2.5.0':
+    resolution: {integrity: sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==}
 
   '@shikijs/langs@3.20.0':
     resolution: {integrity: sha512-le+bssCxcSHrygCWuOrYJHvjus6zhQ2K7q/0mgjiffRbkhM4o1EWu2m+29l0yEsHDbWaWPNnDUTRVVBvBBeKaA==}
 
+  '@shikijs/themes@2.5.0':
+    resolution: {integrity: sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==}
+
   '@shikijs/themes@3.20.0':
     resolution: {integrity: sha512-U1NSU7Sl26Q7ErRvJUouArxfM2euWqq1xaSrbqMu2iqa+tSp0D1Yah8216sDYbdDHw4C8b75UpE65eWorm2erQ==}
+
+  '@shikijs/transformers@2.5.0':
+    resolution: {integrity: sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==}
+
+  '@shikijs/types@2.5.0':
+    resolution: {integrity: sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==}
 
   '@shikijs/types@3.20.0':
     resolution: {integrity: sha512-lhYAATn10nkZcBQ0BlzSbJA3wcmL5MXUUF8d2Zzon6saZDlToKaiRX60n2+ZaHJCmXEcZRWNzn+k9vplr8Jhsw==}
@@ -1280,8 +1406,17 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1317,6 +1452,9 @@ packages:
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -1484,6 +1622,13 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-vue@5.2.4':
+    resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0
+      vue: ^3.2.25
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1512,6 +1657,94 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@vue/compiler-core@3.5.26':
+    resolution: {integrity: sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==}
+
+  '@vue/compiler-dom@3.5.26':
+    resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
+
+  '@vue/compiler-sfc@3.5.26':
+    resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
+
+  '@vue/compiler-ssr@3.5.26':
+    resolution: {integrity: sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==}
+
+  '@vue/devtools-api@7.7.9':
+    resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
+
+  '@vue/devtools-kit@7.7.9':
+    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
+
+  '@vue/devtools-shared@7.7.9':
+    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
+
+  '@vue/reactivity@3.5.26':
+    resolution: {integrity: sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==}
+
+  '@vue/runtime-core@3.5.26':
+    resolution: {integrity: sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==}
+
+  '@vue/runtime-dom@3.5.26':
+    resolution: {integrity: sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==}
+
+  '@vue/server-renderer@3.5.26':
+    resolution: {integrity: sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==}
+    peerDependencies:
+      vue: 3.5.26
+
+  '@vue/shared@3.5.26':
+    resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
+
+  '@vueuse/core@12.8.2':
+    resolution: {integrity: sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==}
+
+  '@vueuse/integrations@12.8.2':
+    resolution: {integrity: sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
+
+  '@vueuse/metadata@12.8.2':
+    resolution: {integrity: sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==}
+
+  '@vueuse/shared@12.8.2':
+    resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -1557,6 +1790,10 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  algoliasearch@5.46.2:
+    resolution: {integrity: sha512-qqAXW9QvKf2tTyhpDA4qXv1IfBwD2eduSW6tUEBFIfCeE9gn9HQ9I5+MaKoenRuHrzk5sQoNh1/iof8mY7uD6Q==}
+    engines: {node: '>= 14.0.0'}
 
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
@@ -1660,6 +1897,9 @@ packages:
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1903,6 +2143,10 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
@@ -2122,6 +2366,9 @@ packages:
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -2146,6 +2393,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.0:
+    resolution: {integrity: sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -2344,6 +2595,9 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
+  focus-trap@7.7.1:
+    resolution: {integrity: sha512-Pkp8m55GjxBLnhBoT6OXdMvfRr4TjMAKLvFM566zlIryq5plbhaTmLAJWTGR0EkRwLjEte1lCOG9MxF1ipJrOg==}
+
   fontace@0.3.1:
     resolution: {integrity: sha512-9f5g4feWT1jWT8+SbL85aLIRLIXUaDygaM2xPXRmzPYxrOMNok79Lr3FGJoKVNKibE0WCunNiEVG2mwuE+2qEg==}
 
@@ -2529,6 +2783,9 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2663,6 +2920,10 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -2809,6 +3070,9 @@ packages:
   make-fetch-happen@14.0.3:
     resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+
+  mark.js@8.11.1:
+    resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -3036,6 +3300,9 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -3043,6 +3310,9 @@ packages:
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
     engines: {node: '>= 18'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -3166,6 +3436,9 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
+  oniguruma-to-es@3.1.1:
+    resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
+
   oniguruma-to-es@4.3.4:
     resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
 
@@ -3267,6 +3540,9 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -3299,6 +3575,9 @@ packages:
     resolution: {integrity: sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  preact@10.28.1:
+    resolution: {integrity: sha512-u1/ixq/lVQI0CakKNvLDEcW5zfCjUQfZdK9qqWuIJtsezuyG6pk9TWj75GMuI/EzRSZB/VAE43sNWWZfiy8psw==}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -3476,6 +3755,9 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rimraf@2.6.3:
     resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3510,6 +3792,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
@@ -3541,6 +3826,9 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shiki@2.5.0:
+    resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
 
   shiki@3.20.0:
     resolution: {integrity: sha512-kgCOlsnyWb+p0WU+01RjkCH+eBVsjL1jOwUYWv0YDWkM2/A46+LDKVs5yZCUXjJG6bj4ndFoAg5iLIIue6dulg==}
@@ -3605,6 +3893,10 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
@@ -3672,6 +3964,10 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3685,6 +3981,9 @@ packages:
     resolution: {integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==}
     engines: {node: '>=16'}
     hasBin: true
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -4104,6 +4403,18 @@ packages:
       vite:
         optional: true
 
+  vitepress@1.6.4:
+    resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
+    hasBin: true
+    peerDependencies:
+      markdown-it-mathjax3: ^4
+      postcss: ^8
+    peerDependenciesMeta:
+      markdown-it-mathjax3:
+        optional: true
+      postcss:
+        optional: true
+
   vitest@2.1.9:
     resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4127,6 +4438,14 @@ packages:
       happy-dom:
         optional: true
       jsdom:
+        optional: true
+
+  vue@3.5.26:
+    resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
         optional: true
 
   w3c-keyname@2.2.8:
@@ -4257,6 +4576,118 @@ packages:
 snapshots:
 
   7zip-bin@5.2.0: {}
+
+  '@algolia/abtesting@1.12.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-plugin-algolia-insights': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)(search-insights@2.17.3)
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+      - search-insights
+
+  '@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - algoliasearch
+
+  '@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)':
+    dependencies:
+      '@algolia/autocomplete-shared': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)
+      '@algolia/client-search': 5.46.2
+      algoliasearch: 5.46.2
+
+  '@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)':
+    dependencies:
+      '@algolia/client-search': 5.46.2
+      algoliasearch: 5.46.2
+
+  '@algolia/client-abtesting@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/client-analytics@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/client-common@5.46.2': {}
+
+  '@algolia/client-insights@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/client-personalization@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/client-query-suggestions@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/client-search@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/ingestion@1.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/monitoring@1.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/recommend@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
+
+  '@algolia/requester-browser-xhr@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+
+  '@algolia/requester-fetch@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
+
+  '@algolia/requester-node-http@5.46.2':
+    dependencies:
+      '@algolia/client-common': 5.46.2
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
@@ -4678,6 +5109,33 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+
+  '@docsearch/css@3.8.2': {}
+
+  '@docsearch/js@3.8.2(@algolia/client-search@5.46.2)(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
+    dependencies:
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.46.2)(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
+      preact: 10.28.1
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/react'
+      - react
+      - react-dom
+      - search-insights
+
+  '@docsearch/react@3.8.2(@algolia/client-search@5.46.2)(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
+    dependencies:
+      '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)(search-insights@2.17.3)
+      '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.46.2)(algoliasearch@5.46.2)
+      '@docsearch/css': 3.8.2
+      algoliasearch: 5.46.2
+    optionalDependencies:
+      '@types/react': 18.3.27
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      search-insights: 2.17.3
+    transitivePeerDependencies:
+      - '@algolia/client-search'
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -5421,6 +5879,15 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.54.0':
     optional: true
 
+  '@shikijs/core@2.5.0':
+    dependencies:
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
   '@shikijs/core@3.20.0':
     dependencies:
       '@shikijs/types': 3.20.0
@@ -5428,24 +5895,53 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
+  '@shikijs/engine-javascript@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 3.1.1
+
   '@shikijs/engine-javascript@3.20.0':
     dependencies:
       '@shikijs/types': 3.20.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.4
 
+  '@shikijs/engine-oniguruma@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@shikijs/engine-oniguruma@3.20.0':
     dependencies:
       '@shikijs/types': 3.20.0
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@shikijs/langs@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
   '@shikijs/langs@3.20.0':
     dependencies:
       '@shikijs/types': 3.20.0
 
+  '@shikijs/themes@2.5.0':
+    dependencies:
+      '@shikijs/types': 2.5.0
+
   '@shikijs/themes@3.20.0':
     dependencies:
       '@shikijs/types': 3.20.0
+
+  '@shikijs/transformers@2.5.0':
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/types': 2.5.0
+
+  '@shikijs/types@2.5.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   '@shikijs/types@3.20.0':
     dependencies:
@@ -5531,9 +6027,18 @@ snapshots:
     dependencies:
       '@types/node': 25.0.3
 
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -5574,6 +6079,8 @@ snapshots:
 
   '@types/verror@1.10.11':
     optional: true
+
+  '@types/web-bluetooth@0.0.21': {}
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -5744,6 +6251,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.0.3))(vue@3.5.26(typescript@5.9.3))':
+    dependencies:
+      vite: 5.4.21(@types/node@25.0.3)
+      vue: 3.5.26(typescript@5.9.3)
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -5784,6 +6296,105 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@vue/compiler-core@3.5.26':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/shared': 3.5.26
+      entities: 7.0.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.26':
+    dependencies:
+      '@vue/compiler-core': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/compiler-sfc@3.5.26':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/compiler-core': 3.5.26
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.26':
+    dependencies:
+      '@vue/compiler-dom': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/devtools-api@7.7.9':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.9':
+    dependencies:
+      rfdc: 1.4.1
+
+  '@vue/reactivity@3.5.26':
+    dependencies:
+      '@vue/shared': 3.5.26
+
+  '@vue/runtime-core@3.5.26':
+    dependencies:
+      '@vue/reactivity': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/runtime-dom@3.5.26':
+    dependencies:
+      '@vue/reactivity': 3.5.26
+      '@vue/runtime-core': 3.5.26
+      '@vue/shared': 3.5.26
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.9.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
+      vue: 3.5.26(typescript@5.9.3)
+
+  '@vue/shared@3.5.26': {}
+
+  '@vueuse/core@12.8.2(typescript@5.9.3)':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 12.8.2
+      '@vueuse/shared': 12.8.2(typescript@5.9.3)
+      vue: 3.5.26(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/integrations@12.8.2(focus-trap@7.7.1)(typescript@5.9.3)':
+    dependencies:
+      '@vueuse/core': 12.8.2(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@5.9.3)
+      vue: 3.5.26(typescript@5.9.3)
+    optionalDependencies:
+      focus-trap: 7.7.1
+    transitivePeerDependencies:
+      - typescript
+
+  '@vueuse/metadata@12.8.2': {}
+
+  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+    dependencies:
+      vue: 3.5.26(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
   '@xmldom/xmldom@0.8.11': {}
 
   abbrev@1.1.1: {}
@@ -5823,6 +6434,23 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  algoliasearch@5.46.2:
+    dependencies:
+      '@algolia/abtesting': 1.12.2
+      '@algolia/client-abtesting': 5.46.2
+      '@algolia/client-analytics': 5.46.2
+      '@algolia/client-common': 5.46.2
+      '@algolia/client-insights': 5.46.2
+      '@algolia/client-personalization': 5.46.2
+      '@algolia/client-query-suggestions': 5.46.2
+      '@algolia/client-search': 5.46.2
+      '@algolia/ingestion': 1.46.2
+      '@algolia/monitoring': 1.46.2
+      '@algolia/recommend': 5.46.2
+      '@algolia/requester-browser-xhr': 5.46.2
+      '@algolia/requester-fetch': 5.46.2
+      '@algolia/requester-node-http': 5.46.2
 
   ansi-align@3.0.1:
     dependencies:
@@ -6038,6 +6666,8 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+
+  birpc@2.9.0: {}
 
   bl@4.1.0:
     dependencies:
@@ -6323,6 +6953,10 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
+
   core-util-is@1.0.2:
     optional: true
 
@@ -6603,6 +7237,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  emoji-regex-xs@1.0.0: {}
+
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
@@ -6626,6 +7262,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -6870,6 +7508,10 @@ snapshots:
   flatted@3.3.3: {}
 
   flattie@1.1.1: {}
+
+  focus-trap@7.7.1:
+    dependencies:
+      tabbable: 6.4.0
 
   fontace@0.3.1:
     dependencies:
@@ -7169,6 +7811,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hookable@5.5.3: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -7291,6 +7935,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-unicode-supported@0.1.0: {}
+
+  is-what@5.5.0: {}
 
   is-wsl@3.1.0:
     dependencies:
@@ -7452,6 +8098,8 @@ snapshots:
       ssri: 12.0.0
     transitivePeerDependencies:
       - supports-color
+
+  mark.js@8.11.1: {}
 
   markdown-table@3.0.4: {}
 
@@ -7855,6 +8503,8 @@ snapshots:
 
   minipass@7.1.2: {}
 
+  minisearch@7.2.0: {}
+
   minizlib@2.1.2:
     dependencies:
       minipass: 3.3.6
@@ -7863,6 +8513,8 @@ snapshots:
   minizlib@3.1.0:
     dependencies:
       minipass: 7.1.2
+
+  mitt@3.0.1: {}
 
   mkdirp-classic@0.5.3: {}
 
@@ -7974,6 +8626,12 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
+  oniguruma-to-es@3.1.1:
+    dependencies:
+      emoji-regex-xs: 1.0.0
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   oniguruma-to-es@4.3.4:
     dependencies:
       oniguruma-parser: 0.12.1
@@ -8081,6 +8739,8 @@ snapshots:
 
   pend@1.2.0: {}
 
+  perfect-debounce@1.0.0: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -8117,6 +8777,8 @@ snapshots:
     dependencies:
       commander: 9.5.0
     optional: true
+
+  preact@10.28.1: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -8331,6 +8993,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  rfdc@1.4.1: {}
+
   rimraf@2.6.3:
     dependencies:
       glob: 7.2.3
@@ -8391,6 +9055,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  search-insights@2.17.3: {}
+
   semver-compare@1.0.0:
     optional: true
 
@@ -8442,6 +9108,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shiki@2.5.0:
+    dependencies:
+      '@shikijs/core': 2.5.0
+      '@shikijs/engine-javascript': 2.5.0
+      '@shikijs/engine-oniguruma': 2.5.0
+      '@shikijs/langs': 2.5.0
+      '@shikijs/themes': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   shiki@3.20.0:
     dependencies:
@@ -8517,6 +9194,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  speakingurl@14.0.1: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -8583,6 +9262,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -8606,6 +9289,8 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
       sax: 1.4.3
+
+  tabbable@6.4.0: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -8969,6 +9654,55 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.0.3)
 
+  vitepress@1.6.4(@algolia/client-search@5.46.2)(@types/node@25.0.3)(@types/react@18.3.27)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.3):
+    dependencies:
+      '@docsearch/css': 3.8.2
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.46.2)(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
+      '@iconify-json/simple-icons': 1.2.64
+      '@shikijs/core': 2.5.0
+      '@shikijs/transformers': 2.5.0
+      '@shikijs/types': 2.5.0
+      '@types/markdown-it': 14.1.2
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.0.3))(vue@3.5.26(typescript@5.9.3))
+      '@vue/devtools-api': 7.7.9
+      '@vue/shared': 3.5.26
+      '@vueuse/core': 12.8.2(typescript@5.9.3)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.7.1)(typescript@5.9.3)
+      focus-trap: 7.7.1
+      mark.js: 8.11.1
+      minisearch: 7.2.0
+      shiki: 2.5.0
+      vite: 5.4.21(@types/node@25.0.3)
+      vue: 3.5.26(typescript@5.9.3)
+    optionalDependencies:
+      postcss: 8.5.6
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+      - '@types/node'
+      - '@types/react'
+      - async-validator
+      - axios
+      - change-case
+      - drauu
+      - fuse.js
+      - idb-keyval
+      - jwt-decode
+      - less
+      - lightningcss
+      - nprogress
+      - qrcode
+      - react
+      - react-dom
+      - sass
+      - sass-embedded
+      - search-insights
+      - sortablejs
+      - stylus
+      - sugarss
+      - terser
+      - typescript
+      - universal-cookie
+
   vitest@2.1.9(@types/node@25.0.3):
     dependencies:
       '@vitest/expect': 2.1.9
@@ -9003,6 +9737,16 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vue@3.5.26(typescript@5.9.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-sfc': 3.5.26
+      '@vue/runtime-dom': 3.5.26
+      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.9.3))
+      '@vue/shared': 3.5.26
+    optionalDependencies:
+      typescript: 5.9.3
 
   w3c-keyname@2.2.8: {}
 


### PR DESCRIPTION
## Summary

- Adds VitePress documentation site at `apps/docs-site/`
- Complete guide, architecture, ADRs, and roadmap documentation
- Ready to deploy to GitHub Pages or Vercel

## Documentation Structure

```
apps/docs-site/
├── guide/
│   ├── getting-started.md
│   └── principles.md
├── architecture/
│   ├── overview.md
│   ├── core.md
│   ├── storage.md
│   ├── ipc.md
│   ├── editor.md
│   └── theming.md
├── decisions/
│   ├── index.md
│   ├── adr-001-runtime-contract.md
│   ├── adr-002-markdown-model.md
│   └── adr-003-storage.md
└── roadmap/
    ├── mvp.md
    ├── v0.1.md
    └── v0.2.md
```

## Test plan

- [x] `pnpm --filter @readied/docs build` succeeds
- [ ] Review documentation content for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)