### PR TITLE
fix: exclude builder-debug.yml from release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
             apps/desktop/release/*.exe
             apps/desktop/release/*.AppImage
             apps/desktop/release/*.deb
-            apps/desktop/release/*.yml
+            apps/desktop/release/latest*.yml
             apps/desktop/release/*.blockmap
           if-no-files-found: ignore
 
@@ -123,7 +123,7 @@ jobs:
             artifacts/**/*.exe
             artifacts/**/*.AppImage
             artifacts/**/*.deb
-            artifacts/**/*.yml
+            artifacts/**/latest*.yml
             artifacts/**/*.blockmap
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Release v0.1.2 failed because `*.yml` pattern matches `builder-debug.yml` (electron-builder debug file).
Each platform generates this file, causing upload conflicts.

## Solution

Change `*.yml` to `latest*.yml` to only include auto-updater files:
- `latest-mac.yml`
- `latest-linux.yml`
- `latest.yml`

## After merge

Delete tag v0.1.2 and re-create to trigger new release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)