### PR TITLE
feat: add GitHub Pages deployment for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/docs-site/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build docs
+        run: pnpm --filter @readied/docs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs-site/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/docs-site/.vitepress/config.ts
+++ b/apps/docs-site/.vitepress/config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitepress';
 export default defineConfig({
   title: 'Readied',
   description: 'Technical documentation for Readied - Markdown-first, offline-forever note app',
+  base: '/readide/',
 
   head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
 


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow for automatic docs deployment
- Configure VitePress base path for GitHub Pages subdirectory

## After Merge

**Manual step required:**
1. Go to repo Settings → Pages
2. Set Source to "GitHub Actions"

## Result

Docs will be available at: `https://tomymaritano.github.io/readide/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)