### PR TITLE
fix: add base path to hero image

### DIFF
--- a/apps/docs-site/index.md
+++ b/apps/docs-site/index.md
@@ -6,7 +6,7 @@ hero:
   text: Developer Note-Taking
   tagline: Markdown-first, offline-forever note app built for developers who value their data
   image:
-    src: /logo.svg
+    src: /readide/logo.svg
     alt: Readied Logo
   actions:
     - theme: brand


### PR DESCRIPTION
The hero image wasn't showing because it needed the /readide/ base path prefix for GitHub Pages deployment.