### PR TITLE
feat(product-config): add facade API

### DIFF
--- a/packages/product-config/__tests__/facade.test.ts
+++ b/packages/product-config/__tests__/facade.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { getProductConfig } from '../src/facade.js';
+
+describe('getProductConfig', () => {
+  const config = getProductConfig();
+
+  it('returns defined config', () => {
+    expect(config).toBeDefined();
+  });
+
+  describe('trial', () => {
+    it('has trialDays > 0', () => {
+      expect(config.trialDays).toBeGreaterThan(0);
+    });
+
+    it('has trialDescription', () => {
+      expect(config.trialDescription).toBeTruthy();
+    });
+  });
+
+  describe('free plan', () => {
+    it('has name "Free"', () => {
+      expect(config.plans.free.name).toBe('Free');
+    });
+
+    it('has description', () => {
+      expect(config.plans.free.description).toBeTruthy();
+    });
+
+    it('has features', () => {
+      expect(config.plans.free.features.length).toBeGreaterThan(0);
+    });
+
+    it('has no pricing (free tier)', () => {
+      expect(config.plans.free.pricing).toBeUndefined();
+    });
+  });
+
+  describe('pro plan', () => {
+    it('has name "Pro"', () => {
+      expect(config.plans.pro.name).toBe('Pro');
+    });
+
+    it('has description', () => {
+      expect(config.plans.pro.description).toBeTruthy();
+    });
+
+    it('has features', () => {
+      expect(config.plans.pro.features.length).toBeGreaterThan(0);
+    });
+
+    it('has pricing defined', () => {
+      expect(config.plans.pro.pricing).toBeDefined();
+    });
+
+    it('has monthly pricing with amountCents > 0', () => {
+      expect(config.plans.pro.pricing?.intervals.monthly.amountCents).toBeGreaterThan(0);
+    });
+
+    it('has annual pricing with amountCents > 0', () => {
+      expect(config.plans.pro.pricing?.intervals.annual.amountCents).toBeGreaterThan(0);
+    });
+
+    it('has annual savings percentage', () => {
+      expect(config.plans.pro.pricing?.annualSavings).toBeTruthy();
+    });
+  });
+
+  describe('guarantees', () => {
+    it('has refund guarantee', () => {
+      expect(config.guarantees.refund).toBeDefined();
+      expect(config.guarantees.refund.description).toBeTruthy();
+    });
+
+    it('has noLockIn guarantee', () => {
+      expect(config.guarantees.noLockIn).toBeDefined();
+      expect(config.guarantees.noLockIn.description).toBeTruthy();
+    });
+
+    it('has freeTierForever guarantee', () => {
+      expect(config.guarantees.freeTierForever).toBeDefined();
+      expect(config.guarantees.freeTierForever.description).toBeTruthy();
+    });
+
+    it('has cancelAnytime guarantee', () => {
+      expect(config.guarantees.cancelAnytime).toBeDefined();
+      expect(config.guarantees.cancelAnytime.description).toBeTruthy();
+    });
+  });
+});
+
+describe('contract stability', () => {
+  const config = getProductConfig();
+
+  it('maintains stable plan IDs', () => {
+    expect(Object.keys(config.plans)).toContain('free');
+    expect(Object.keys(config.plans)).toContain('pro');
+  });
+
+  it('maintains stable billing intervals', () => {
+    const intervals = config.plans.pro.pricing?.intervals;
+    expect(intervals).toHaveProperty('monthly');
+    expect(intervals).toHaveProperty('annual');
+  });
+
+  it('maintains stable guarantee IDs', () => {
+    expect(Object.keys(config.guarantees)).toContain('refund');
+    expect(Object.keys(config.guarantees)).toContain('noLockIn');
+    expect(Object.keys(config.guarantees)).toContain('freeTierForever');
+    expect(Object.keys(config.guarantees)).toContain('cancelAnytime');
+  });
+});

--- a/packages/product-config/package.json
+++ b/packages/product-config/package.json
@@ -12,9 +12,12 @@
     }
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
   }
 }

--- a/packages/product-config/src/facade.ts
+++ b/packages/product-config/src/facade.ts
@@ -1,0 +1,102 @@
+/**
+ * Facade API for product configuration
+ *
+ * This provides a STABLE public interface for consumers.
+ * Use getProductConfig() instead of importing raw data exports.
+ */
+
+// ═══════════════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════════════
+
+export type BillingInterval = 'monthly' | 'annual';
+export type PlanId = 'free' | 'pro';
+export type GuaranteeId = 'refund' | 'noLockIn' | 'freeTierForever' | 'cancelAnytime';
+
+export interface PlanPricing {
+  readonly label: string;
+  readonly amountCents: number;
+}
+
+export interface PlanConfig {
+  readonly name: string;
+  readonly description: string;
+  readonly features: readonly string[];
+  readonly pricing?: {
+    readonly intervals: Record<BillingInterval, PlanPricing>;
+    readonly annualSavings?: string;
+  };
+}
+
+export interface ProductConfig {
+  readonly trialDays: number;
+  readonly trialDescription: string;
+  readonly plans: Record<PlanId, PlanConfig>;
+  readonly guarantees: Record<GuaranteeId, { readonly description: string }>;
+}
+
+// ═══════════════════════════════════════════════════════════════
+// FACADE
+// ═══════════════════════════════════════════════════════════════
+
+/**
+ * Returns a stable public config shape.
+ *
+ * This is the PREFERRED API - consumers should use this function
+ * instead of importing raw data exports (PRICING, PLANS, etc.)
+ *
+ * @example
+ * ```typescript
+ * const config = getProductConfig();
+ * console.log(config.plans.pro.pricing?.intervals.monthly.label); // '$2.99/mo'
+ * console.log(config.trialDays); // 14
+ * ```
+ */
+export function getProductConfig(): ProductConfig {
+  return {
+    trialDays: 14,
+    trialDescription: '14-day Pro trial, no credit card required',
+    plans: {
+      free: {
+        name: 'Free',
+        description: 'Perfect for personal note-taking',
+        features: [
+          'Unlimited local notes',
+          'Full markdown editor',
+          'Export to markdown',
+          'Import from folder',
+          'Basic search',
+          '100% offline',
+          'No account required',
+        ],
+      },
+      pro: {
+        name: 'Pro',
+        description: 'For power users who want sync and advanced features',
+        features: [
+          'Everything in Free',
+          'Cloud sync across devices',
+          'Automatic backlinks',
+          'Visual graph view',
+          'Custom themes',
+          'Advanced search',
+          'Import Obsidian vault',
+          'Priority support',
+        ],
+        pricing: {
+          intervals: {
+            monthly: { label: '$2.99/mo', amountCents: 299 },
+            annual: { label: '$29/year', amountCents: 2900 },
+          },
+          annualSavings: '19%',
+        },
+      },
+    },
+    guarantees: {
+      refund: { description: '14-day money-back guarantee, no questions asked' },
+      noLockIn: { description: 'Export anytime. Your notes are standard Markdown.' },
+      freeTierForever: { description: 'Free tier works forever. No tricks, no time limits.' },
+      cancelAnytime: { description: 'Cancel your Pro subscription anytime. Keep using Free.' },
+    },
+  };
+}

--- a/packages/product-config/src/index.ts
+++ b/packages/product-config/src/index.ts
@@ -1,15 +1,42 @@
-// Pricing
+// ═══════════════════════════════════════════════════════════════
+// PUBLIC API (PREFERRED)
+// ═══════════════════════════════════════════════════════════════
+
+export {
+  getProductConfig,
+  type ProductConfig,
+  type PlanConfig,
+  type PlanPricing,
+  type PlanId,
+  type BillingInterval,
+  type GuaranteeId,
+} from './facade.js';
+
+// ═══════════════════════════════════════════════════════════════
+// RAW DATA (DEPRECATED - use getProductConfig() instead)
+// ═══════════════════════════════════════════════════════════════
+
+/** @deprecated Use getProductConfig().plans instead */
+export { PLANS, GUARANTEES } from './plans.js';
+
+/** @deprecated Use getProductConfig() instead */
 export { PRICING } from './pricing.js';
+
+/** @deprecated Use getProductConfig().trialDays instead */
+export { TRIAL } from './trial.js';
+
+/** @deprecated Use types from facade.js */
 export type { PricingConfig } from './pricing.js';
 
-// Trial
-export { TRIAL } from './trial.js';
+/** @deprecated Use types from facade.js */
 export type { TrialConfig } from './trial.js';
 
-// Plans
-export { PLANS, GUARANTEES } from './plans.js';
+/** @deprecated Use types from facade.js */
 export type { PlansConfig, GuaranteesConfig } from './plans.js';
 
-// URLs
+// ═══════════════════════════════════════════════════════════════
+// URLS (not deprecated - not part of product config)
+// ═══════════════════════════════════════════════════════════════
+
 export { URLS } from './urls.js';
 export type { UrlsConfig } from './urls.js';

--- a/packages/product-config/vitest.config.ts
+++ b/packages/product-config/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.3)
 
   packages/storage-core:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `getProductConfig()` facade function that returns a stable `ProductConfig` shape
- Export types: `ProductConfig`, `PlanConfig`, `PlanPricing`, `PlanId`, `BillingInterval`, `GuaranteeId`
- Mark raw data exports (`PRICING`, `PLANS`, `TRIAL`, `GUARANTEES`) as `@deprecated`
- Add vitest config and 21 contract tests to ensure API stability

## Motivation

Previously, consumers directly imported raw data exports like `PRICING.pro.monthly.label`. When the internal structure changed (e.g., migration from perpetual license to subscription model), consumers broke.

The facade provides a **stable API contract**:
- Consumers depend on the `ProductConfig` shape, not internal structure
- Internal refactors don't break consumers
- Tests guarantee the contract is maintained

## Test plan

- [x] All 21 facade tests pass
- [x] Typecheck passes
- [x] Build succeeds

## Next Steps (PR 2)

Migrate `marketing-site` to use `getProductConfig()` instead of raw exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)