### PR TITLE
refactor(marketing): use getProductConfig() facade

### DIFF
--- a/apps/marketing-site/src/pages/faq.astro
+++ b/apps/marketing-site/src/pages/faq.astro
@@ -2,7 +2,11 @@
 import Base from '../layouts/Base.astro';
 import Footer from '../components/Footer.astro';
 import { Icon } from 'astro-icon/components';
-import { PRICING, TRIAL, GUARANTEES, URLS } from '@readied/product-config';
+import { getProductConfig, URLS } from '@readied/product-config';
+
+const config = getProductConfig();
+const { plans, guarantees, trialDescription } = config;
+const proPricing = plans.pro.pricing!;
 
 const faqs = [
   {
@@ -26,11 +30,11 @@ const faqs = [
   {
     category: 'Pricing',
     questions: [
-      { q: 'How much does Readied cost?', a: `Free tier is free forever. Pro is ${PRICING.pro.monthly.label} or ${PRICING.pro.annual.label} (${PRICING.pro.annual.savings} off).` },
-      { q: 'Is there a free tier?', a: GUARANTEES.freeTierForever.description },
-      { q: 'Can I try Pro before subscribing?', a: `Yes! ${PRICING.trial.description}. No credit card needed.` },
-      { q: 'What about refunds?', a: GUARANTEES.refund.description },
-      { q: 'Can I cancel anytime?', a: GUARANTEES.cancelAnytime.description },
+      { q: 'How much does Readied cost?', a: `Free tier is free forever. Pro is ${proPricing.intervals.monthly.label} or ${proPricing.intervals.annual.label} (${proPricing.annualSavings} off).` },
+      { q: 'Is there a free tier?', a: guarantees.freeTierForever.description },
+      { q: 'Can I try Pro before subscribing?', a: `Yes! ${trialDescription}. No credit card needed.` },
+      { q: 'What about refunds?', a: guarantees.refund.description },
+      { q: 'Can I cancel anytime?', a: guarantees.cancelAnytime.description },
     ]
   },
   {
@@ -38,7 +42,7 @@ const faqs = [
     questions: [
       { q: 'What platforms are supported?', a: 'macOS 11+ (Apple Silicon and Intel) and Windows 10+ (64-bit).' },
       { q: 'Can I export my data?', a: 'Your data is already Markdown files on your disk. Nothing to export. Open them with any editor.' },
-      { q: 'What if Readied stops being developed?', a: GUARANTEES.freeTierForever.description },
+      { q: 'What if Readied stops being developed?', a: guarantees.freeTierForever.description },
       { q: 'Is the source code available?', a: 'Yes, the source is available on GitHub for transparency. The license is source-available, not open-source.' },
     ]
   }

--- a/apps/marketing-site/src/pages/pricing.astro
+++ b/apps/marketing-site/src/pages/pricing.astro
@@ -2,13 +2,17 @@
 import Base from '../layouts/Base.astro';
 import Footer from '../components/Footer.astro';
 import { Icon } from 'astro-icon/components';
-import { PRICING, PLANS, GUARANTEES } from '@readied/product-config';
+import { getProductConfig } from '@readied/product-config';
+
+const config = getProductConfig();
+const { plans, guarantees, trialDays, trialDescription } = config;
+const proPricing = plans.pro.pricing!;
 
 const faqs = [
-  { q: 'What if you stop developing Readied?', a: GUARANTEES.freeTierForever.description },
-  { q: 'Can I cancel my Pro subscription?', a: GUARANTEES.cancelAnytime.description },
-  { q: 'Can I export my data?', a: GUARANTEES.noLockIn.description },
-  { q: 'What about refunds?', a: GUARANTEES.refund.description }
+  { q: 'What if you stop developing Readied?', a: guarantees.freeTierForever.description },
+  { q: 'Can I cancel my Pro subscription?', a: guarantees.cancelAnytime.description },
+  { q: 'Can I export my data?', a: guarantees.noLockIn.description },
+  { q: 'What about refunds?', a: guarantees.refund.description }
 ];
 ---
 
@@ -25,17 +29,17 @@ const faqs = [
         <!-- Free Tier -->
         <div class="pricing-card glass">
           <div class="card-header">
-            <div class="plan-name">{PLANS.free.name}</div>
+            <div class="plan-name">{plans.free.name}</div>
             <div class="price">
-              <span class="amount">{PRICING.free.label}</span>
+              <span class="amount">Free</span>
               <span class="period">forever</span>
             </div>
           </div>
 
-          <p class="plan-description">{PLANS.free.description}</p>
+          <p class="plan-description">{plans.free.description}</p>
 
           <ul class="features">
-            {PLANS.free.features.map((f) => (
+            {plans.free.features.map((f) => (
               <li>
                 <Icon name="lucide:check" size={16} class="icon-check" />
                 {f}
@@ -52,23 +56,23 @@ const faqs = [
         <!-- Pro Tier -->
         <div class="pricing-card pricing-card-pro glass">
           <div class="card-header">
-            <div class="plan-name">{PLANS.pro.name}</div>
+            <div class="plan-name">{plans.pro.name}</div>
             <div class="price-options">
               <div class="price">
-                <span class="amount">{PRICING.pro.monthly.label}</span>
+                <span class="amount">{proPricing.intervals.monthly.label}</span>
               </div>
               <span class="price-or">or</span>
               <div class="price">
-                <span class="amount">{PRICING.pro.annual.label}</span>
-                <span class="savings">Save {PRICING.pro.annual.savings}</span>
+                <span class="amount">{proPricing.intervals.annual.label}</span>
+                <span class="savings">Save {proPricing.annualSavings}</span>
               </div>
             </div>
           </div>
 
-          <p class="plan-description">{PLANS.pro.description}</p>
+          <p class="plan-description">{plans.pro.description}</p>
 
           <ul class="features">
-            {PLANS.pro.features.map((f) => (
+            {plans.pro.features.map((f) => (
               <li>
                 <Icon name="lucide:check" size={16} class="icon-accent" />
                 {f}
@@ -78,12 +82,12 @@ const faqs = [
 
           <div class="trial-info glass">
             <Icon name="lucide:sparkles" size={16} class="icon-accent" />
-            <span>{PRICING.trial.description}</span>
+            <span>{trialDescription}</span>
           </div>
 
           <a href="/download" class="btn btn-primary btn-lg" data-magnetic="0.2">
             <Icon name="lucide:zap" size={20} />
-            Start {PRICING.trial.days}-day free trial
+            Start {trialDays}-day free trial
           </a>
 
           <div class="card-glow"></div>


### PR DESCRIPTION
## Summary

- Migrate `pricing.astro` to use `getProductConfig()` instead of `PRICING`, `PLANS`, `GUARANTEES`
- Migrate `faq.astro` to use `getProductConfig()` instead of `PRICING`, `GUARANTEES`
- Keep `URLS` import (not deprecated)

## Before

```typescript
import { PRICING, PLANS, GUARANTEES } from '@readied/product-config';
// Access internal structure directly
PRICING.pro.monthly.label
PLANS.free.features
```

## After

```typescript
import { getProductConfig } from '@readied/product-config';
const config = getProductConfig();
// Use stable facade API
config.plans.pro.pricing?.intervals.monthly.label
config.plans.free.features
```

## Test plan

- [x] Build passes
- [x] All pages render correctly

## Related

Follows #23 (facade API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)