### PR TITLE
refactor(marketing): Source of Truth architecture for pricing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,32 @@ cd packages/storage-sqlite && pnpm rebuild better-sqlite3 && pnpm test
 3. `pnpm typecheck` — Validate TypeScript
 4. `pnpm build && pnpm --filter @readied/desktop dist:mac` — Build for production
 
+## Pricing/Copy Changes
+
+**Source of Truth:** `packages/product-config/src/facade.ts`
+
+All pricing, plans, and guarantees live in ONE place. Marketing pages consume it.
+
+**Golden Rule:** If the business model changes, one PR must touch:
+
+1. `packages/product-config/src/facade.ts` — Update SoT
+2. Marketing pages that consume facade — Auto-updated via import
+3. `terms.astro` + `privacy.astro` — Align vocabulary manually
+
+**Pages consuming facade:**
+
+- `pricing.astro` ✅
+- `faq.astro` ✅
+- `Hero.astro` ✅
+- `Audience.astro` ✅
+
+**Legal pages checklist (before merge):**
+
+- [ ] Model matches facade? (free vs subscription)
+- [ ] "Free tier" and "Pro" used consistently?
+- [ ] Trial days = `config.trialDays`?
+- [ ] Refund days = 14?
+
 ## Documentation
 
 - **Architecture decisions:** `plan.md`

--- a/apps/marketing-site/src/components/Audience.astro
+++ b/apps/marketing-site/src/components/Audience.astro
@@ -1,5 +1,8 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { getProductConfig } from '@readied/product-config';
+
+const config = getProductConfig();
 ---
 
 <section class="cta-section">
@@ -16,19 +19,19 @@ import { Icon } from 'astro-icon/components';
         <div class="cta-actions">
           <a href="/download" class="btn btn-primary btn-lg" data-magnetic="0.2">
             <Icon name="lucide:download" size={20} />
-            Start 14-day trial
+            Start {config.trialDays}-day trial
           </a>
           <a href="/pricing" class="btn btn-ghost btn-lg" data-magnetic="0.2">View pricing</a>
         </div>
 
         <div class="trust-signals" data-stagger="100">
           <div class="signal glass hover-float">
-            <span class="signal-value" data-counter="79" data-counter-prefix="$">$0</span>
-            <span class="signal-label">One-time payment</span>
+            <span class="signal-value">Free</span>
+            <span class="signal-label">forever</span>
           </div>
           <div class="signal glass hover-float">
-            <span class="signal-value" data-counter="14">0</span>
-            <span class="signal-label">days free trial</span>
+            <span class="signal-value" data-counter={config.trialDays}>0</span>
+            <span class="signal-label">days Pro trial</span>
           </div>
           <div class="signal glass hover-float">
             <span class="signal-value" data-counter="100" data-counter-suffix="%">0%</span>

--- a/apps/marketing-site/src/components/Hero.astro
+++ b/apps/marketing-site/src/components/Hero.astro
@@ -1,5 +1,8 @@
 ---
 import { Icon } from 'astro-icon/components';
+import { getProductConfig } from '@readied/product-config';
+
+const config = getProductConfig();
 ---
 
 <section class="hero" id="hero-bg">
@@ -52,7 +55,7 @@ import { Icon } from 'astro-icon/components';
           <span class="meta-divider">·</span>
           <span class="meta-item">macOS 12+ & Windows 10+</span>
           <span class="meta-divider">·</span>
-          <span class="meta-item">14-day free trial</span>
+          <span class="meta-item">{config.trialDays}-day free trial</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- Migrates landing page components to consume `getProductConfig()` instead of hardcoded values
- **Fixes critical bug:** Audience.astro showed "$79 one-time" (wrong) — now shows "Free forever"
- Documents the golden rule for pricing changes in CLAUDE.md

## Architecture

```
product-config/facade.ts (SoT)
        ↓
   Marketing pages consume via import
        ↓
   Legal pages: semi-manual, checklist before merge
```

## Changes

| File | Change |
|------|--------|
| `Hero.astro` | Uses `config.trialDays` for trial copy |
| `Audience.astro` | Fixes pricing signals, uses `config.trialDays` |
| `CLAUDE.md` | Documents golden rule for pricing changes |

## Golden Rule (now documented)

If the business model changes, one PR must touch:
1. `product-config/facade.ts` — Update SoT
2. Marketing pages — Auto-updated via import
3. `terms.astro` + `privacy.astro` — Align vocabulary manually

## Test plan

- [x] Marketing site builds successfully
- [ ] Verify landing page shows "Free forever" instead of "$79"

🤖 Generated with [Claude Code](https://claude.com/claude-code)