### PR TITLE
fix: sync desktop version to 0.1.6

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@readied/desktop",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "description": "Markdown-first, offline-forever note app for developers",
   "author": {


### PR DESCRIPTION
## Summary

Fix release build - desktop package.json was still at 0.1.5 while root was 0.1.6.

electron-builder uses the desktop package.json version for binary names, causing "0.1.5" in asset filenames for the v0.1.6 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)