### PR TITLE
feat: Phase 2 — Advanced Plugin System (v0.7.0)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -73,6 +73,7 @@ import { GitService } from './services/gitService.js';
 import { registerLicenseHandlers } from './handlers/licenseHandlers.js';
 import { registerShareHandlers } from './handlers/shareHandlers.js';
 import { scanPlugins } from './pluginScanner.js';
+import { startPluginWatcher, stopPluginWatcher } from './pluginWatcher.js';
 
 // Database and repository (initialized on app ready)
 let db: ReturnType<typeof createDatabase> | null = null;
@@ -2030,6 +2031,12 @@ app
     registerGitHandlers(); // Git operations for git-backed notebooks
     registerPluginConfigHandlers();
     registerPluginDiscoveryHandlers();
+
+    // Start plugin hot-reload watcher in dev mode
+    if (process.env.NODE_ENV === 'development' && dataPaths) {
+      startPluginWatcher(dataPaths.plugins);
+    }
+
     registerDataHandlers();
 
     // Initialize license storage
@@ -2126,6 +2133,7 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
+  stopPluginWatcher();
   if (db) {
     db.close();
     getLogger().info('Database closed');

--- a/apps/desktop/src/main/pluginWatcher.ts
+++ b/apps/desktop/src/main/pluginWatcher.ts
@@ -1,0 +1,66 @@
+/**
+ * Plugin Hot Reload Watcher (dev mode only)
+ *
+ * Watches the plugins directory for file changes and broadcasts
+ * a reload event to all renderer windows via IPC.
+ * Uses Node's built-in fs.watch with debouncing.
+ */
+
+import { watch, type FSWatcher } from 'fs';
+import { existsSync } from 'fs';
+import { BrowserWindow } from 'electron';
+
+let watcher: FSWatcher | null = null;
+
+/**
+ * Start watching the plugins directory for changes.
+ * Only call this in development mode.
+ */
+export function startPluginWatcher(pluginsDir: string): void {
+  if (watcher) return; // Already watching
+
+  if (!existsSync(pluginsDir)) {
+    console.log('[pluginWatcher] Plugins directory does not exist, skipping watch:', pluginsDir);
+    return;
+  }
+
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const broadcastReload = () => {
+    BrowserWindow.getAllWindows().forEach(win => {
+      if (!win.isDestroyed()) {
+        win.webContents.send('plugins:reload');
+      }
+    });
+  };
+
+  try {
+    watcher = watch(pluginsDir, { recursive: true }, (_eventType, filename) => {
+      // Ignore hidden files and temp files
+      if (filename && (filename.startsWith('.') || filename.endsWith('~'))) return;
+
+      // Debounce: wait 300ms after last change before reloading
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        console.log('[pluginWatcher] Plugin file changed, broadcasting reload');
+        broadcastReload();
+        debounceTimer = null;
+      }, 300);
+    });
+
+    console.log('[pluginWatcher] Watching for plugin changes:', pluginsDir);
+  } catch (error) {
+    console.error('[pluginWatcher] Failed to start watcher:', error);
+  }
+}
+
+/**
+ * Stop watching the plugins directory.
+ */
+export function stopPluginWatcher(): void {
+  if (watcher) {
+    watcher.close();
+    watcher = null;
+    console.log('[pluginWatcher] Stopped watching plugins directory');
+  }
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -253,9 +253,15 @@ export interface SubscriptionStatus {
 
 /** Scanned plugin from filesystem */
 export interface PluginConfigSchemaField {
-  type: 'string' | 'number' | 'boolean';
+  type: 'string' | 'number' | 'boolean' | 'enum' | 'range';
   default: unknown;
   description?: string;
+  /** For 'enum' type: available options */
+  options?: Array<{ value: string; label: string }>;
+  /** For 'range' type */
+  min?: number;
+  max?: number;
+  step?: number;
 }
 
 export interface ScannedPlugin {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -27,7 +27,7 @@ import { useDebouncedSearch } from './hooks/useDebouncedSearch';
 import { useCommandKeybindings } from './hooks/useCommandKeybindings';
 import { useRegisterAppCommands } from './hooks/useRegisterAppCommands';
 import { EditorView } from '@codemirror/view';
-import { PluginHost, createEditorAPI, createAppAPI, editorPluginStore } from '@readied/plugin-api';
+import { PluginHost, createEditorAPI, createAppAPI, editorPluginStore, useCssVariables } from '@readied/plugin-api';
 import type { EditorAPIWithEvents, AppAPIWithEvents } from '@readied/plugin-api';
 import type { RegisteredCommand } from '@readied/command-registry';
 import { getEditorView, registry as commandRegistry } from './hooks/useCommandRegistry';
@@ -71,6 +71,7 @@ const queryClient = new QueryClient({
 function NotesApp() {
   usePerformanceMode();
   useAppearanceSettings();
+  useCssVariables();
 
   // Resizable layout
   const { sidebarWidth, notelistWidth, startResizeSidebar, startResizeNotelist } =
@@ -154,6 +155,31 @@ function NotesApp() {
         async getBacklinks(noteId) {
           const links = await window.readied.links.getBacklinks(noteId);
           return links.map(l => ({ noteId: l.noteId, noteTitle: l.noteTitle }));
+        },
+        async listNotes() {
+          const notes = await window.readied.notes.list();
+          return notes.map(n => ({
+            id: n.id,
+            title: n.title,
+            notebookId: n.notebookId,
+            tags: [...n.tags],
+            wordCount: n.wordCount,
+            createdAt: n.createdAt,
+            updatedAt: n.updatedAt,
+            isPinned: n.isPinned,
+            status: n.status,
+          }));
+        },
+        async listNotebooks() {
+          const notebooks = await window.readied.notebooks.list();
+          return notebooks.map(nb => ({
+            id: nb.id,
+            name: nb.name,
+            parentId: nb.parentId,
+          }));
+        },
+        async listTags() {
+          return window.readied.notes.tags();
         },
       }),
     []

--- a/apps/desktop/src/renderer/components/editor/MarkdownPreview.tsx
+++ b/apps/desktop/src/renderer/components/editor/MarkdownPreview.tsx
@@ -1,4 +1,12 @@
-import { useMemo, useRef, useImperativeHandle, forwardRef, useEffect, useState } from 'react';
+import {
+  useMemo,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -6,6 +14,12 @@ import { Clock, CalendarPlus, ListChecks } from 'lucide-react';
 import { remarkWikilink } from '@readied/wikilinks';
 import { extractEmbedTargets } from '@readied/embeds';
 import { countMarkdownTasks } from '@readied/tasks';
+import {
+  remarkPluginStore,
+  rehypePluginStore,
+  previewComponentStore,
+  codeBlockStore,
+} from '@readied/plugin-api';
 import { formatDateTime } from '../../utils/date';
 import { useEditorBufferStore, selectContentForNote } from '../../stores/editorBufferStore';
 
@@ -52,6 +66,24 @@ export const MarkdownPreview = forwardRef<MarkdownPreviewHandle, MarkdownPreview
     const [internalResolvedEmbeds, setInternalResolvedEmbeds] = useState<
       Record<string, string | null>
     >({});
+
+    // Subscribe to plugin preview stores
+    const pluginRemarkRegs = useSyncExternalStore(
+      remarkPluginStore.subscribe,
+      () => remarkPluginStore.getState().registrations
+    );
+    const pluginRehypeRegs = useSyncExternalStore(
+      rehypePluginStore.subscribe,
+      () => rehypePluginStore.getState().registrations
+    );
+    const pluginComponentRegs = useSyncExternalStore(
+      previewComponentStore.subscribe,
+      () => previewComponentStore.getState().registrations
+    );
+    const pluginCodeBlockRegs = useSyncExternalStore(
+      codeBlockStore.subscribe,
+      () => codeBlockStore.getState().registrations
+    );
 
     // Use live buffer content if available for this note, otherwise fall back to prop
     const liveContent = useEditorBufferStore(selectContentForNote(noteId));
@@ -218,8 +250,17 @@ export const MarkdownPreview = forwardRef<MarkdownPreviewHandle, MarkdownPreview
         </div>
 
         <Markdown
-          remarkPlugins={[remarkGfm, remarkWikilink]}
-          rehypePlugins={[rehypeRaw]}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          remarkPlugins={[
+            remarkGfm,
+            remarkWikilink,
+            ...pluginRemarkRegs.map(r => r.plugin),
+          ] as any[]}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          rehypePlugins={[
+            rehypeRaw,
+            ...pluginRehypeRegs.map(r => r.plugin),
+          ] as any[]}
           components={
             {
               input: ({ type, checked, ...props }) => {
@@ -231,6 +272,28 @@ export const MarkdownPreview = forwardRef<MarkdownPreviewHandle, MarkdownPreview
               // Custom embed-image element bypasses rehype URL sanitization
               'embed-image': ({ src, alt }: { src?: string; alt?: string }) => (
                 <img src={src} alt={alt} className="embed embed-image" loading="lazy" />
+              ),
+              // Code block renderer delegation to plugins
+              code: ({ className, children, ...props }) => {
+                const match = /language-(\w+)/.exec(className || '');
+                const lang = match?.[1];
+                if (lang) {
+                  const reg = pluginCodeBlockRegs.find(r => r.language === lang);
+                  if (reg) {
+                    const CodeRenderer = reg.component;
+                    const code = String(children).replace(/\n$/, '');
+                    return <CodeRenderer code={code} language={lang} />;
+                  }
+                }
+                return (
+                  <code className={className} {...props}>
+                    {children}
+                  </code>
+                );
+              },
+              // Plugin-registered preview components
+              ...Object.fromEntries(
+                pluginComponentRegs.map(r => [r.tagName, r.component])
               ),
             } as Record<string, React.ComponentType<unknown>>
           }

--- a/apps/desktop/src/renderer/pages/settings/components/controls.module.css
+++ b/apps/desktop/src/renderer/pages/settings/components/controls.module.css
@@ -117,6 +117,60 @@
   cursor: not-allowed;
 }
 
+/* Range Input (Slider) */
+.rangeInput {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 160px;
+}
+
+.rangeSlider {
+  flex: 1;
+  height: 6px;
+  cursor: pointer;
+  appearance: none;
+  background: var(--bg-hover);
+  border-radius: 3px;
+  border: 1px solid var(--border-strong);
+  transition: all 0.2s ease;
+}
+
+.rangeSlider:hover {
+  background: var(--bg-active);
+  border-color: var(--border-hover);
+}
+
+.rangeSlider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  border: 2px solid var(--accent);
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: all 0.15s ease;
+}
+
+.rangeSlider::-webkit-slider-thumb:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 0 3px var(--accent-muted);
+}
+
+.rangeSlider:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.rangeValue {
+  font-size: 0.8125rem;
+  color: var(--text-muted);
+  min-width: 2.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Select (Dropdown) */
 .select {
   min-width: 160px;

--- a/apps/desktop/src/renderer/pages/settings/components/controls.tsx
+++ b/apps/desktop/src/renderer/pages/settings/components/controls.tsx
@@ -95,6 +95,39 @@ export function TextInput({ id, value, onChange, placeholder, disabled }: TextIn
 }
 
 // ============================================================================
+// RangeInput (Slider)
+// ============================================================================
+
+export interface RangeInputProps {
+  id?: string;
+  value: number;
+  onChange: (value: number) => void;
+  min: number;
+  max: number;
+  step?: number;
+  disabled?: boolean;
+}
+
+export function RangeInput({ id, value, onChange, min, max, step = 1, disabled }: RangeInputProps) {
+  return (
+    <div className={styles.rangeInput}>
+      <input
+        type="range"
+        id={id}
+        value={value}
+        onChange={e => onChange(parseFloat(e.target.value))}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        className={styles.rangeSlider}
+      />
+      <span className={styles.rangeValue}>{value}</span>
+    </div>
+  );
+}
+
+// ============================================================================
 // Select (Dropdown)
 // ============================================================================
 

--- a/apps/desktop/src/renderer/pages/settings/sections/PluginsSection.tsx
+++ b/apps/desktop/src/renderer/pages/settings/sections/PluginsSection.tsx
@@ -8,7 +8,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, FolderOpen, ChevronDown } from 'lucide-react';
 import type { PluginConfigSchemaField } from '../../../../preload/index';
-import { Toggle, TextInput, NumberInput } from '../components/controls';
+import { Toggle, TextInput, NumberInput, RangeInput, Select } from '../components/controls';
 import styles from './Section.module.css';
 
 // ============================================================================
@@ -171,6 +171,24 @@ function PluginCard({
                           id={fieldId}
                           value={(value as number) ?? 0}
                           onChange={v => onConfigChange?.(key, v)}
+                        />
+                      )}
+                      {field.type === 'enum' && field.options && (
+                        <Select
+                          id={fieldId}
+                          value={(value as string) ?? ''}
+                          onChange={v => onConfigChange?.(key, v)}
+                          options={field.options}
+                        />
+                      )}
+                      {field.type === 'range' && (
+                        <RangeInput
+                          id={fieldId}
+                          value={(value as number) ?? field.min ?? 0}
+                          onChange={v => onConfigChange?.(key, v)}
+                          min={field.min ?? 0}
+                          max={field.max ?? 100}
+                          step={field.step}
                         />
                       )}
                     </div>

--- a/packages/plugin-api/src/app/createAppAPI.ts
+++ b/packages/plugin-api/src/app/createAppAPI.ts
@@ -1,4 +1,4 @@
-import type { AppAPI, NoteInfo } from '../types';
+import type { AppAPI, NoteInfo, NoteSummaryInfo, NotebookInfo } from '../types';
 
 /** Extended AppAPI with internal notify methods (called by host, not plugins) */
 export interface AppAPIWithEvents extends AppAPI {
@@ -14,6 +14,9 @@ export interface AppAPIBridge {
   getNoteById(id: string): Promise<NoteInfo | null>;
   getNoteTags(noteId: string): Promise<string[]>;
   getBacklinks(noteId: string): Promise<Array<{ noteId: string; noteTitle: string }>>;
+  listNotes(): Promise<NoteSummaryInfo[]>;
+  listNotebooks(): Promise<NotebookInfo[]>;
+  listTags(): Promise<string[]>;
 }
 
 /**
@@ -33,6 +36,9 @@ export function createAppAPI(bridge: AppAPIBridge): AppAPIWithEvents {
     getNoteById: id => bridge.getNoteById(id),
     getNoteTags: noteId => bridge.getNoteTags(noteId),
     getBacklinks: noteId => bridge.getBacklinks(noteId),
+    listNotes: () => bridge.listNotes(),
+    listNotebooks: () => bridge.listNotebooks(),
+    listTags: () => bridge.listTags(),
 
     // Event subscriptions (return unsubscribe fn)
     onNoteSelected(cb) {

--- a/packages/plugin-api/src/index.ts
+++ b/packages/plugin-api/src/index.ts
@@ -3,10 +3,13 @@ export type {
   EditorAPI,
   AppAPI,
   NoteInfo,
+  NoteSummaryInfo,
+  NotebookInfo,
   PluginManifest,
   PluginContext,
   PluginDisposable,
   PluginConfigSchema,
+  PluginConfigSchemaField,
   PluginConfigAPI,
   PluginLogger,
   PluginCommandOptions,
@@ -16,6 +19,7 @@ export type {
 export type { LayoutZoneName, ZoneEntry, ZoneComponentProps, LayoutManager } from './layout/types';
 export { layoutStore, createLayoutManager } from './layout/layoutStore';
 export { LayoutZone } from './layout/LayoutZone';
+export { PluginErrorBoundary } from './layout/PluginErrorBoundary';
 
 // Editor
 export type { EditorAPIWithEvents } from './editor/createEditorAPI';
@@ -27,6 +31,21 @@ export { createDecorationAPI } from './editor/decorationAPI';
 // App
 export type { AppAPIWithEvents, AppAPIBridge } from './app/createAppAPI';
 export { createAppAPI } from './app/createAppAPI';
+
+// Preview
+export { previewComponentStore } from './preview/previewComponentStore';
+export type { PreviewComponentRegistration } from './preview/previewComponentStore';
+export { remarkPluginStore } from './preview/remarkPluginStore';
+export type { RemarkPluginRegistration } from './preview/remarkPluginStore';
+export { rehypePluginStore } from './preview/rehypePluginStore';
+export type { RehypePluginRegistration } from './preview/rehypePluginStore';
+export { codeBlockStore } from './preview/codeBlockStore';
+export type { CodeBlockRegistration, CodeBlockRendererProps } from './preview/codeBlockStore';
+
+// Theme
+export { cssVariableStore } from './theme/cssVariableStore';
+export type { CssVariableRegistration } from './theme/cssVariableStore';
+export { useCssVariables } from './theme/useCssVariables';
 
 // Validation
 export { validateManifest, assertValidManifest } from './validation';

--- a/packages/plugin-api/src/layout/LayoutZone.tsx
+++ b/packages/plugin-api/src/layout/LayoutZone.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore, type ComponentType, type ReactNode } from 'react';
 import { layoutStore } from './layoutStore';
 import type { LayoutZoneName, ZoneEntry } from './types';
+import { PluginErrorBoundary } from './PluginErrorBoundary';
 
 interface LayoutZoneProps {
   name: LayoutZoneName;
@@ -52,8 +53,12 @@ export function LayoutZone({ name, className, wrapper: Wrapper }: LayoutZoneProp
   return (
     <div className={className} data-layout-zone={name}>
       {entries.map(entry => {
-        const { component: Component, meta, id } = entry;
-        const rendered = <Component key={id} meta={meta} />;
+        const { component: Component, meta, id, pluginId } = entry;
+        const rendered = (
+          <PluginErrorBoundary key={id} pluginId={pluginId}>
+            <Component meta={meta} />
+          </PluginErrorBoundary>
+        );
 
         if (Wrapper) {
           return (

--- a/packages/plugin-api/src/layout/PluginErrorBoundary.tsx
+++ b/packages/plugin-api/src/layout/PluginErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+interface Props {
+  pluginId: string;
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Error boundary for plugin-rendered UI.
+ * Catches render errors from plugin components and shows a fallback
+ * instead of crashing the host application.
+ */
+export class PluginErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(`[plugin:${this.props.pluginId}] Render error:`, error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div
+          style={{
+            padding: '0.5rem',
+            fontSize: '0.75rem',
+            color: '#ef4444',
+            background: 'rgba(239, 68, 68, 0.08)',
+            borderRadius: '4px',
+            border: '1px solid rgba(239, 68, 68, 0.2)',
+          }}
+          title={this.state.error?.message}
+        >
+          Plugin error: {this.props.pluginId}
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/plugin-api/src/lifecycle/PluginHost.tsx
+++ b/packages/plugin-api/src/lifecycle/PluginHost.tsx
@@ -53,14 +53,19 @@ export function PluginHost({
         if (cancelled) return;
         const loaded = registry.load(manifest);
         if (!loaded) continue; // validation failed, skip
-        await registry.activate(
-          manifest.id,
-          editorAPI,
-          appAPI,
-          registerCommand,
-          configBridge,
-          getView
-        );
+        try {
+          await registry.activate(
+            manifest.id,
+            editorAPI,
+            appAPI,
+            registerCommand,
+            configBridge,
+            getView
+          );
+        } catch (error) {
+          // Individual plugin failure should not prevent other plugins from loading
+          console.error(`[PluginHost] Failed to activate ${manifest.id}:`, error);
+        }
         if (cancelled) return; // cleanup started during activate — stop
       }
     };

--- a/packages/plugin-api/src/lifecycle/PluginRegistry.ts
+++ b/packages/plugin-api/src/lifecycle/PluginRegistry.ts
@@ -9,12 +9,19 @@ import type {
   AppAPI,
   PluginCommandOptions,
 } from '../types';
+import type { ComponentType } from 'react';
 import { createLayoutManager } from '../layout/layoutStore';
 import { editorPluginStore } from '../editor/editorPluginStore';
 import { createDecorationAPI } from '../editor/decorationAPI';
 import { validateManifest } from '../validation';
+import { remarkPluginStore } from '../preview/remarkPluginStore';
+import { rehypePluginStore } from '../preview/rehypePluginStore';
+import { previewComponentStore } from '../preview/previewComponentStore';
+import { codeBlockStore } from '../preview/codeBlockStore';
+import type { CodeBlockRendererProps } from '../preview/codeBlockStore';
+import { cssVariableStore } from '../theme/cssVariableStore';
 
-type PluginState = 'loaded' | 'active' | 'deactivated';
+type PluginState = 'loaded' | 'active' | 'deactivated' | 'error';
 
 /** Shape expected by the host's command registry */
 export interface RegisterCommandFn {
@@ -44,6 +51,10 @@ interface PluginEntry {
   commandUnregisters: Array<() => void>;
   /** Event unsubscribers tracked by the auto-cleanup wrapper */
   eventUnsubscribers: Array<() => void>;
+  /** Number of times activate() has thrown */
+  errorCount: number;
+  /** Last error message if state is 'error' */
+  lastError?: string;
 }
 
 export class PluginRegistry {
@@ -70,6 +81,7 @@ export class PluginRegistry {
       state: 'loaded',
       commandUnregisters: [],
       eventUnsubscribers: [],
+      errorCount: 0,
     });
 
     return true;
@@ -225,6 +237,40 @@ export class PluginRegistry {
         return () => editorPluginStore.getState().unregister(extId);
       },
       registerCommand,
+      registerRemarkPlugin: (regId: string, plugin: unknown): (() => void) => {
+        remarkPluginStore.getState().register({ id: regId, pluginId: id, plugin });
+        return () => remarkPluginStore.getState().unregister(regId);
+      },
+      registerRehypePlugin: (regId: string, plugin: unknown): (() => void) => {
+        rehypePluginStore.getState().register({ id: regId, pluginId: id, plugin });
+        return () => rehypePluginStore.getState().unregister(regId);
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registerPreviewComponent: (
+        regId: string,
+        tagName: string,
+        component: ComponentType<any>
+      ): (() => void) => {
+        previewComponentStore.getState().register({
+          id: regId,
+          pluginId: id,
+          tagName,
+          component,
+        });
+        return () => previewComponentStore.getState().unregister(regId);
+      },
+      registerCodeBlockRenderer: (
+        regId: string,
+        language: string,
+        component: ComponentType<CodeBlockRendererProps>
+      ): (() => void) => {
+        codeBlockStore.getState().register({ id: regId, pluginId: id, language, component });
+        return () => codeBlockStore.getState().unregister(regId);
+      },
+      registerCssVariables: (regId: string, variables: Record<string, string>): (() => void) => {
+        cssVariableStore.getState().register({ id: regId, pluginId: id, variables });
+        return () => cssVariableStore.getState().unregister(regId);
+      },
       config,
       log: {
         info: (msg: string, ...args: unknown[]) => console.log(`[${id}]`, msg, ...args),
@@ -234,10 +280,31 @@ export class PluginRegistry {
       app: trackedApp,
     };
 
-    const disposable = entry.manifest.activate(context);
+    try {
+      const disposable = entry.manifest.activate(context);
+      entry.state = 'active';
+      entry.disposable = disposable ?? undefined;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[plugin:${id}] activate() threw:`, error);
+      entry.errorCount++;
+      entry.lastError = message;
+      entry.state = 'error';
 
-    entry.state = 'active';
-    entry.disposable = disposable ?? undefined;
+      // Cleanup any partial registrations the plugin may have made before crashing
+      editorPluginStore.getState().unregisterAll(id);
+      remarkPluginStore.getState().unregisterAll(id);
+      rehypePluginStore.getState().unregisterAll(id);
+      previewComponentStore.getState().unregisterAll(id);
+      codeBlockStore.getState().unregisterAll(id);
+      cssVariableStore.getState().unregisterAll(id);
+      const layoutManager = createLayoutManager(id);
+      layoutManager.removeAllForPlugin(id);
+      for (const unregister of entry.commandUnregisters) {
+        unregister();
+      }
+      entry.commandUnregisters = [];
+    }
   }
 
   /** Deactivate an active plugin */
@@ -245,11 +312,19 @@ export class PluginRegistry {
     const entry = this.plugins.get(id);
     if (!entry || entry.state !== 'active') return;
 
-    // Call disposable
-    entry.disposable?.dispose();
+    // Call disposable (guarded)
+    try {
+      entry.disposable?.dispose();
+    } catch (error) {
+      console.error(`[plugin:${id}] dispose() threw:`, error);
+    }
 
-    // Call deactivate lifecycle
-    entry.manifest.deactivate?.();
+    // Call deactivate lifecycle (guarded)
+    try {
+      entry.manifest.deactivate?.();
+    } catch (error) {
+      console.error(`[plugin:${id}] deactivate() threw:`, error);
+    }
 
     // Cleanup layout entries
     const layoutManager = createLayoutManager(id);
@@ -257,6 +332,15 @@ export class PluginRegistry {
 
     // Cleanup editor extensions
     editorPluginStore.getState().unregisterAll(id);
+
+    // Cleanup preview stores
+    remarkPluginStore.getState().unregisterAll(id);
+    rehypePluginStore.getState().unregisterAll(id);
+    previewComponentStore.getState().unregisterAll(id);
+    codeBlockStore.getState().unregisterAll(id);
+
+    // Cleanup theme stores
+    cssVariableStore.getState().unregisterAll(id);
 
     // Safety net: unregister any remaining plugin commands
     for (const unregister of entry.commandUnregisters) {
@@ -288,5 +372,17 @@ export class PluginRegistry {
   /** Get all loaded plugin ids */
   getLoadedIds(): string[] {
     return Array.from(this.plugins.keys());
+  }
+
+  /** Check if a plugin is in error state */
+  hasError(id: string): boolean {
+    return this.plugins.get(id)?.state === 'error';
+  }
+
+  /** Get error info for a plugin */
+  getError(id: string): { message: string; count: number } | null {
+    const entry = this.plugins.get(id);
+    if (!entry || entry.state !== 'error') return null;
+    return { message: entry.lastError ?? 'Unknown error', count: entry.errorCount };
   }
 }

--- a/packages/plugin-api/src/preview/codeBlockStore.ts
+++ b/packages/plugin-api/src/preview/codeBlockStore.ts
@@ -1,0 +1,49 @@
+import { createStore } from 'zustand/vanilla';
+import type { ComponentType } from 'react';
+
+export interface CodeBlockRendererProps {
+  code: string;
+  language: string;
+}
+
+export interface CodeBlockRegistration {
+  id: string;
+  pluginId: string;
+  language: string;
+  component: ComponentType<CodeBlockRendererProps>;
+}
+
+interface CodeBlockState {
+  registrations: CodeBlockRegistration[];
+  register(registration: CodeBlockRegistration): void;
+  unregister(id: string): void;
+  unregisterAll(pluginId: string): void;
+  getRenderer(language: string): ComponentType<CodeBlockRendererProps> | undefined;
+}
+
+export const codeBlockStore = createStore<CodeBlockState>((set, get) => ({
+  registrations: [],
+
+  register(registration) {
+    set(state => ({
+      registrations: [...state.registrations.filter(r => r.id !== registration.id), registration],
+    }));
+  },
+
+  unregister(id) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.id !== id),
+    }));
+  },
+
+  unregisterAll(pluginId) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.pluginId !== pluginId),
+    }));
+  },
+
+  getRenderer(language) {
+    const reg = get().registrations.find(r => r.language === language);
+    return reg?.component;
+  },
+}));

--- a/packages/plugin-api/src/preview/previewComponentStore.ts
+++ b/packages/plugin-api/src/preview/previewComponentStore.ts
@@ -1,0 +1,47 @@
+import { createStore } from 'zustand/vanilla';
+import type { ComponentType } from 'react';
+
+export interface PreviewComponentRegistration {
+  id: string;
+  pluginId: string;
+  tagName: string;
+  component: ComponentType<any>;
+}
+
+interface PreviewComponentState {
+  registrations: PreviewComponentRegistration[];
+  register(registration: PreviewComponentRegistration): void;
+  unregister(id: string): void;
+  unregisterAll(pluginId: string): void;
+  getComponents(): Record<string, ComponentType<any>>;
+}
+
+export const previewComponentStore = createStore<PreviewComponentState>((set, get) => ({
+  registrations: [],
+
+  register(registration) {
+    set(state => ({
+      registrations: [...state.registrations.filter(r => r.id !== registration.id), registration],
+    }));
+  },
+
+  unregister(id) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.id !== id),
+    }));
+  },
+
+  unregisterAll(pluginId) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.pluginId !== pluginId),
+    }));
+  },
+
+  getComponents() {
+    const result: Record<string, ComponentType<any>> = {};
+    for (const reg of get().registrations) {
+      result[reg.tagName] = reg.component;
+    }
+    return result;
+  },
+}));

--- a/packages/plugin-api/src/preview/rehypePluginStore.ts
+++ b/packages/plugin-api/src/preview/rehypePluginStore.ts
@@ -1,0 +1,42 @@
+import { createStore } from 'zustand/vanilla';
+
+export interface RehypePluginRegistration {
+  id: string;
+  pluginId: string;
+  /** unified rehype plugin — typed as unknown for loose coupling */
+  plugin: unknown;
+}
+
+interface RehypePluginState {
+  registrations: RehypePluginRegistration[];
+  register(registration: RehypePluginRegistration): void;
+  unregister(id: string): void;
+  unregisterAll(pluginId: string): void;
+  getPlugins(): unknown[];
+}
+
+export const rehypePluginStore = createStore<RehypePluginState>((set, get) => ({
+  registrations: [],
+
+  register(registration) {
+    set(state => ({
+      registrations: [...state.registrations.filter(r => r.id !== registration.id), registration],
+    }));
+  },
+
+  unregister(id) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.id !== id),
+    }));
+  },
+
+  unregisterAll(pluginId) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.pluginId !== pluginId),
+    }));
+  },
+
+  getPlugins() {
+    return get().registrations.map(r => r.plugin);
+  },
+}));

--- a/packages/plugin-api/src/preview/remarkPluginStore.ts
+++ b/packages/plugin-api/src/preview/remarkPluginStore.ts
@@ -1,0 +1,42 @@
+import { createStore } from 'zustand/vanilla';
+
+export interface RemarkPluginRegistration {
+  id: string;
+  pluginId: string;
+  /** unified remark plugin — typed as unknown for loose coupling */
+  plugin: unknown;
+}
+
+interface RemarkPluginState {
+  registrations: RemarkPluginRegistration[];
+  register(registration: RemarkPluginRegistration): void;
+  unregister(id: string): void;
+  unregisterAll(pluginId: string): void;
+  getPlugins(): unknown[];
+}
+
+export const remarkPluginStore = createStore<RemarkPluginState>((set, get) => ({
+  registrations: [],
+
+  register(registration) {
+    set(state => ({
+      registrations: [...state.registrations.filter(r => r.id !== registration.id), registration],
+    }));
+  },
+
+  unregister(id) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.id !== id),
+    }));
+  },
+
+  unregisterAll(pluginId) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.pluginId !== pluginId),
+    }));
+  },
+
+  getPlugins() {
+    return get().registrations.map(r => r.plugin);
+  },
+}));

--- a/packages/plugin-api/src/theme/cssVariableStore.ts
+++ b/packages/plugin-api/src/theme/cssVariableStore.ts
@@ -1,0 +1,56 @@
+/**
+ * CSS Variable Store
+ *
+ * Zustand vanilla store for plugin-registered CSS custom properties.
+ * Plugins can inject variables to override theme tokens or add custom ones.
+ */
+
+import { createStore } from 'zustand/vanilla';
+
+export interface CssVariableRegistration {
+  /** Unique registration ID */
+  id: string;
+  /** Plugin that registered these variables */
+  pluginId: string;
+  /** CSS custom properties to apply (e.g. { '--accent': '#ff0000' }) */
+  variables: Record<string, string>;
+}
+
+interface CssVariableState {
+  registrations: CssVariableRegistration[];
+  register(registration: CssVariableRegistration): void;
+  unregister(id: string): void;
+  unregisterAll(pluginId: string): void;
+  /** Get merged variables (later registrations override earlier ones) */
+  getMergedVariables(): Record<string, string>;
+}
+
+export const cssVariableStore = createStore<CssVariableState>((set, get) => ({
+  registrations: [],
+
+  register(registration) {
+    set(state => ({
+      registrations: [...state.registrations.filter(r => r.id !== registration.id), registration],
+    }));
+  },
+
+  unregister(id) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.id !== id),
+    }));
+  },
+
+  unregisterAll(pluginId) {
+    set(state => ({
+      registrations: state.registrations.filter(r => r.pluginId !== pluginId),
+    }));
+  },
+
+  getMergedVariables() {
+    const merged: Record<string, string> = {};
+    for (const reg of get().registrations) {
+      Object.assign(merged, reg.variables);
+    }
+    return merged;
+  },
+}));

--- a/packages/plugin-api/src/theme/useCssVariables.ts
+++ b/packages/plugin-api/src/theme/useCssVariables.ts
@@ -1,0 +1,37 @@
+/**
+ * useCssVariables Hook
+ *
+ * Subscribes to the CSS variable store and applies plugin-registered
+ * CSS custom properties to document.documentElement.
+ */
+
+import { useEffect, useSyncExternalStore } from 'react';
+import { cssVariableStore } from './cssVariableStore';
+
+const subscribe = (cb: () => void) => cssVariableStore.subscribe(cb);
+const getSnapshot = () => cssVariableStore.getState().registrations;
+
+/**
+ * Apply plugin-registered CSS variables to the document root.
+ * Call this once in the app root (e.g. App.tsx).
+ */
+export function useCssVariables(): void {
+  const registrations = useSyncExternalStore(subscribe, getSnapshot);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const merged = cssVariableStore.getState().getMergedVariables();
+
+    // Apply all merged variables
+    for (const [prop, value] of Object.entries(merged)) {
+      root.style.setProperty(prop, value);
+    }
+
+    // On cleanup, remove the variables we set
+    return () => {
+      for (const prop of Object.keys(merged)) {
+        root.style.removeProperty(prop);
+      }
+    };
+  }, [registrations]);
+}

--- a/packages/plugin-api/src/types.ts
+++ b/packages/plugin-api/src/types.ts
@@ -1,6 +1,8 @@
 import type { Extension } from '@codemirror/state';
+import type { ComponentType } from 'react';
 import type { LayoutManager } from './layout/types';
 import type { EditorDecorationAPI } from './editor/decorationAPI';
+import type { CodeBlockRendererProps } from './preview/codeBlockStore';
 
 /** Controlled subset of editor operations for plugins */
 export interface EditorAPI {
@@ -23,6 +25,26 @@ export interface NoteInfo {
   content: string;
 }
 
+/** Note summary for listing (no full content) */
+export interface NoteSummaryInfo {
+  id: string;
+  title: string;
+  notebookId: string;
+  tags: string[];
+  wordCount: number;
+  createdAt: string;
+  updatedAt: string;
+  isPinned: boolean;
+  status: string;
+}
+
+/** Notebook info exposed to plugins (read-only) */
+export interface NotebookInfo {
+  id: string;
+  name: string;
+  parentId: string | null;
+}
+
 /** Read-only app operations for plugins */
 export interface AppAPI {
   // Core (Phase 1)
@@ -34,18 +56,33 @@ export interface AppAPI {
   getNoteTags(noteId: string): Promise<string[]>;
   getBacklinks(noteId: string): Promise<Array<{ noteId: string; noteTitle: string }>>;
 
+  // Data listing (Phase 2 — read-only)
+  listNotes(): Promise<NoteSummaryInfo[]>;
+  listNotebooks(): Promise<NotebookInfo[]>;
+  listTags(): Promise<string[]>;
+
   // Events (Phase 3.2)
   onNoteSelected(callback: (note: NoteInfo | null) => void): () => void;
   onNoteCreated(callback: (note: NoteInfo) => void): () => void;
   onNoteDeleted(callback: (noteId: string) => void): () => void;
 }
 
+export interface PluginConfigSchemaField {
+  type: 'string' | 'number' | 'boolean' | 'enum' | 'range';
+  default: unknown;
+  description?: string;
+  /** For 'enum' type: available options */
+  options?: Array<{ value: string; label: string }>;
+  /** For 'range' type: minimum value */
+  min?: number;
+  /** For 'range' type: maximum value */
+  max?: number;
+  /** For 'range' type: step increment */
+  step?: number;
+}
+
 export interface PluginConfigSchema {
-  [key: string]: {
-    type: 'string' | 'number' | 'boolean';
-    default: unknown;
-    description?: string;
-  };
+  [key: string]: PluginConfigSchemaField;
 }
 
 export interface PluginConfigAPI {
@@ -81,6 +118,21 @@ export interface PluginContext {
     options: PluginCommandOptions,
     execute: () => boolean | void | Promise<boolean | void>
   ): () => void;
+  /** Register a remark (mdast) plugin for the markdown preview pipeline */
+  registerRemarkPlugin(id: string, plugin: unknown): () => void;
+  /** Register a rehype (hast) plugin for the markdown preview pipeline */
+  registerRehypePlugin(id: string, plugin: unknown): () => void;
+  /** Register a custom React component to replace an HTML element in the preview */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerPreviewComponent(id: string, tagName: string, component: ComponentType<any>): () => void;
+  /** Register a custom renderer for fenced code blocks of a specific language */
+  registerCodeBlockRenderer(
+    id: string,
+    language: string,
+    component: ComponentType<CodeBlockRendererProps>
+  ): () => void;
+  /** Register CSS custom properties (theme overrides or custom variables) */
+  registerCssVariables(id: string, variables: Record<string, string>): () => void;
   config: PluginConfigAPI;
   log: PluginLogger;
   app: AppAPI;

--- a/packages/plugin-api/tests/createAppAPI.test.ts
+++ b/packages/plugin-api/tests/createAppAPI.test.ts
@@ -9,6 +9,9 @@ function makeBridge(overrides: Partial<AppAPIBridge> = {}): AppAPIBridge {
     getNoteById: async () => null,
     getNoteTags: async () => [],
     getBacklinks: async () => [],
+    listNotes: async () => [],
+    listNotebooks: async () => [],
+    listTags: async () => [],
     ...overrides,
   };
 }
@@ -31,6 +34,36 @@ describe('createAppAPI', () => {
       const note = { id: '1', title: 'Test', content: 'body' };
       const api = createAppAPI(makeBridge({ getNoteById: async () => note }));
       expect(await api.getNoteById('1')).toBe(note);
+    });
+
+    it('delegates listNotes to bridge', async () => {
+      const notes = [
+        {
+          id: '1',
+          title: 'Note',
+          notebookId: 'nb-1',
+          tags: ['tag1'],
+          wordCount: 42,
+          createdAt: '2025-01-01',
+          updatedAt: '2025-01-02',
+          isPinned: false,
+          status: 'active',
+        },
+      ];
+      const api = createAppAPI(makeBridge({ listNotes: async () => notes }));
+      expect(await api.listNotes()).toBe(notes);
+    });
+
+    it('delegates listNotebooks to bridge', async () => {
+      const notebooks = [{ id: 'nb-1', name: 'Inbox', parentId: null }];
+      const api = createAppAPI(makeBridge({ listNotebooks: async () => notebooks }));
+      expect(await api.listNotebooks()).toBe(notebooks);
+    });
+
+    it('delegates listTags to bridge', async () => {
+      const tags = ['javascript', 'react'];
+      const api = createAppAPI(makeBridge({ listTags: async () => tags }));
+      expect(await api.listTags()).toBe(tags);
     });
   });
 

--- a/packages/plugin-api/tests/cssVariableStore.test.ts
+++ b/packages/plugin-api/tests/cssVariableStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { cssVariableStore } from '../src/theme/cssVariableStore';
+
+describe('cssVariableStore', () => {
+  beforeEach(() => {
+    // Clear all registrations between tests
+    const state = cssVariableStore.getState();
+    for (const r of state.registrations) {
+      state.unregister(r.id);
+    }
+  });
+
+  it('starts with empty registrations', () => {
+    expect(cssVariableStore.getState().registrations).toEqual([]);
+  });
+
+  it('registers CSS variables', () => {
+    cssVariableStore.getState().register({
+      id: 'theme-1',
+      pluginId: 'my-plugin',
+      variables: { '--accent': '#ff0000', '--bg-base': '#111' },
+    });
+
+    expect(cssVariableStore.getState().registrations).toHaveLength(1);
+    expect(cssVariableStore.getState().registrations[0].variables).toEqual({
+      '--accent': '#ff0000',
+      '--bg-base': '#111',
+    });
+  });
+
+  it('replaces registration with same id', () => {
+    const store = cssVariableStore.getState();
+    store.register({ id: 'theme-1', pluginId: 'p1', variables: { '--a': '1' } });
+    store.register({ id: 'theme-1', pluginId: 'p1', variables: { '--a': '2' } });
+
+    expect(cssVariableStore.getState().registrations).toHaveLength(1);
+    expect(cssVariableStore.getState().registrations[0].variables['--a']).toBe('2');
+  });
+
+  it('unregisters by id', () => {
+    const store = cssVariableStore.getState();
+    store.register({ id: 'theme-1', pluginId: 'p1', variables: { '--a': '1' } });
+    store.register({ id: 'theme-2', pluginId: 'p1', variables: { '--b': '2' } });
+
+    store.unregister('theme-1');
+
+    expect(cssVariableStore.getState().registrations).toHaveLength(1);
+    expect(cssVariableStore.getState().registrations[0].id).toBe('theme-2');
+  });
+
+  it('unregisters all by pluginId', () => {
+    const store = cssVariableStore.getState();
+    store.register({ id: 'r1', pluginId: 'p1', variables: { '--a': '1' } });
+    store.register({ id: 'r2', pluginId: 'p1', variables: { '--b': '2' } });
+    store.register({ id: 'r3', pluginId: 'p2', variables: { '--c': '3' } });
+
+    store.unregisterAll('p1');
+
+    expect(cssVariableStore.getState().registrations).toHaveLength(1);
+    expect(cssVariableStore.getState().registrations[0].pluginId).toBe('p2');
+  });
+
+  it('getMergedVariables merges all registrations', () => {
+    const store = cssVariableStore.getState();
+    store.register({ id: 'r1', pluginId: 'p1', variables: { '--a': '1', '--b': '2' } });
+    store.register({ id: 'r2', pluginId: 'p2', variables: { '--c': '3' } });
+
+    const merged = cssVariableStore.getState().getMergedVariables();
+    expect(merged).toEqual({ '--a': '1', '--b': '2', '--c': '3' });
+  });
+
+  it('getMergedVariables: later registration overrides earlier', () => {
+    const store = cssVariableStore.getState();
+    store.register({ id: 'r1', pluginId: 'p1', variables: { '--accent': 'red' } });
+    store.register({ id: 'r2', pluginId: 'p2', variables: { '--accent': 'blue' } });
+
+    const merged = cssVariableStore.getState().getMergedVariables();
+    expect(merged['--accent']).toBe('blue');
+  });
+});

--- a/packages/plugin-api/tests/previewStores.test.ts
+++ b/packages/plugin-api/tests/previewStores.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { previewComponentStore } from '../src/preview/previewComponentStore';
+import { codeBlockStore } from '../src/preview/codeBlockStore';
+
+describe('previewComponentStore', () => {
+  beforeEach(() => {
+    const state = previewComponentStore.getState();
+    for (const r of state.registrations) {
+      state.unregister(r.id);
+    }
+  });
+
+  it('starts with empty registrations', () => {
+    expect(previewComponentStore.getState().registrations).toEqual([]);
+  });
+
+  it('registers a preview component', () => {
+    const FakeComponent = () => null;
+    previewComponentStore.getState().register({
+      id: 'comp-1',
+      pluginId: 'test-plugin',
+      tagName: 'my-widget',
+      component: FakeComponent,
+    });
+
+    expect(previewComponentStore.getState().registrations).toHaveLength(1);
+    expect(previewComponentStore.getState().registrations[0]!.tagName).toBe('my-widget');
+  });
+
+  it('getComponents returns tagName -> component map', () => {
+    const CompA = () => null;
+    const CompB = () => null;
+
+    previewComponentStore.getState().register({
+      id: 'comp-1',
+      pluginId: 'plugin-a',
+      tagName: 'table',
+      component: CompA,
+    });
+    previewComponentStore.getState().register({
+      id: 'comp-2',
+      pluginId: 'plugin-b',
+      tagName: 'blockquote',
+      component: CompB,
+    });
+
+    const components = previewComponentStore.getState().getComponents();
+    expect(components['table']).toBe(CompA);
+    expect(components['blockquote']).toBe(CompB);
+  });
+
+  it('unregisterAll removes all for a pluginId', () => {
+    previewComponentStore.getState().register({
+      id: 'comp-1',
+      pluginId: 'plugin-a',
+      tagName: 'table',
+      component: () => null,
+    });
+    previewComponentStore.getState().register({
+      id: 'comp-2',
+      pluginId: 'plugin-b',
+      tagName: 'blockquote',
+      component: () => null,
+    });
+
+    previewComponentStore.getState().unregisterAll('plugin-a');
+
+    expect(previewComponentStore.getState().registrations).toHaveLength(1);
+    expect(previewComponentStore.getState().registrations[0]!.pluginId).toBe('plugin-b');
+  });
+});
+
+describe('codeBlockStore', () => {
+  beforeEach(() => {
+    const state = codeBlockStore.getState();
+    for (const r of state.registrations) {
+      state.unregister(r.id);
+    }
+  });
+
+  it('starts with empty registrations', () => {
+    expect(codeBlockStore.getState().registrations).toEqual([]);
+  });
+
+  it('registers a code block renderer', () => {
+    const MermaidRenderer = () => null;
+    codeBlockStore.getState().register({
+      id: 'mermaid-renderer',
+      pluginId: 'mermaid-plugin',
+      language: 'mermaid',
+      component: MermaidRenderer,
+    });
+
+    expect(codeBlockStore.getState().registrations).toHaveLength(1);
+    expect(codeBlockStore.getState().registrations[0]!.language).toBe('mermaid');
+  });
+
+  it('getRenderer returns component for matching language', () => {
+    const MermaidRenderer = () => null;
+    codeBlockStore.getState().register({
+      id: 'mermaid-renderer',
+      pluginId: 'mermaid-plugin',
+      language: 'mermaid',
+      component: MermaidRenderer,
+    });
+
+    expect(codeBlockStore.getState().getRenderer('mermaid')).toBe(MermaidRenderer);
+    expect(codeBlockStore.getState().getRenderer('python')).toBeUndefined();
+  });
+
+  it('replaces registration with same id', () => {
+    codeBlockStore.getState().register({
+      id: 'renderer-1',
+      pluginId: 'test-plugin',
+      language: 'mermaid',
+      component: () => null,
+    });
+    const NewRenderer = () => null;
+    codeBlockStore.getState().register({
+      id: 'renderer-1',
+      pluginId: 'test-plugin',
+      language: 'mermaid',
+      component: NewRenderer,
+    });
+
+    expect(codeBlockStore.getState().registrations).toHaveLength(1);
+    expect(codeBlockStore.getState().getRenderer('mermaid')).toBe(NewRenderer);
+  });
+
+  it('unregisterAll removes all for a pluginId', () => {
+    codeBlockStore.getState().register({
+      id: 'renderer-1',
+      pluginId: 'plugin-a',
+      language: 'mermaid',
+      component: () => null,
+    });
+    codeBlockStore.getState().register({
+      id: 'renderer-2',
+      pluginId: 'plugin-a',
+      language: 'chart',
+      component: () => null,
+    });
+    codeBlockStore.getState().register({
+      id: 'renderer-3',
+      pluginId: 'plugin-b',
+      language: 'math',
+      component: () => null,
+    });
+
+    codeBlockStore.getState().unregisterAll('plugin-a');
+
+    expect(codeBlockStore.getState().registrations).toHaveLength(1);
+    expect(codeBlockStore.getState().registrations[0]!.pluginId).toBe('plugin-b');
+  });
+});

--- a/packages/plugin-api/tests/registry.test.ts
+++ b/packages/plugin-api/tests/registry.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { PluginRegistry } from '../src/lifecycle/PluginRegistry';
 import type { PluginManifest, EditorAPI, AppAPI } from '../src/types';
 import type { RegisterCommandFn, ConfigBridge } from '../src/lifecycle/PluginRegistry';
+import { remarkPluginStore } from '../src/preview/remarkPluginStore';
+import { rehypePluginStore } from '../src/preview/rehypePluginStore';
+import { previewComponentStore } from '../src/preview/previewComponentStore';
+import { codeBlockStore } from '../src/preview/codeBlockStore';
 
 function makeManifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
   return {
@@ -35,6 +39,9 @@ function makeAppAPI(): AppAPI {
     getNoteById: async () => null,
     getNoteTags: async () => [],
     getBacklinks: async () => [],
+    listNotes: async () => [],
+    listNotebooks: async () => [],
+    listTags: async () => [],
     onNoteSelected: () => () => {},
     onNoteCreated: () => () => {},
     onNoteDeleted: () => () => {},
@@ -93,9 +100,34 @@ describe('PluginRegistry', () => {
       expect(ctx).toHaveProperty('editor');
       expect(ctx).toHaveProperty('registerExtensions');
       expect(ctx).toHaveProperty('registerCommand');
+      expect(ctx).toHaveProperty('registerRemarkPlugin');
+      expect(ctx).toHaveProperty('registerRehypePlugin');
+      expect(ctx).toHaveProperty('registerPreviewComponent');
+      expect(ctx).toHaveProperty('registerCodeBlockRenderer');
+      expect(ctx).toHaveProperty('registerCssVariables');
       expect(ctx).toHaveProperty('config');
       expect(ctx).toHaveProperty('log');
       expect(ctx).toHaveProperty('app');
+    });
+
+    it('exposes data listing methods on context.app', async () => {
+      let receivedApp: unknown = null;
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            receivedApp = ctx.app;
+          },
+        })
+      );
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      const app = receivedApp as Record<string, unknown>;
+      expect(app).toHaveProperty('listNotes');
+      expect(app).toHaveProperty('listNotebooks');
+      expect(app).toHaveProperty('listTags');
+      expect(typeof app.listNotes).toBe('function');
+      expect(typeof app.listNotebooks).toBe('function');
+      expect(typeof app.listTags).toBe('function');
     });
 
     it('does nothing for non-existent plugin', async () => {
@@ -429,6 +461,253 @@ describe('PluginRegistry', () => {
 
       expect(logSpy).toHaveBeenCalledWith('[test-plugin]', 'hello');
       logSpy.mockRestore();
+    });
+  });
+
+  describe('preview plugin registration', () => {
+    beforeEach(() => {
+      // Clean all preview stores
+      for (const r of remarkPluginStore.getState().registrations) {
+        remarkPluginStore.getState().unregister(r.id);
+      }
+      for (const r of rehypePluginStore.getState().registrations) {
+        rehypePluginStore.getState().unregister(r.id);
+      }
+      for (const r of previewComponentStore.getState().registrations) {
+        previewComponentStore.getState().unregister(r.id);
+      }
+      for (const r of codeBlockStore.getState().registrations) {
+        codeBlockStore.getState().unregister(r.id);
+      }
+    });
+
+    it('registerRemarkPlugin adds to remarkPluginStore', async () => {
+      const fakePlugin = () => {};
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            ctx.registerRemarkPlugin('my-remark', fakePlugin);
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      const regs = remarkPluginStore.getState().registrations;
+      expect(regs).toHaveLength(1);
+      expect(regs[0]!.id).toBe('my-remark');
+      expect(regs[0]!.pluginId).toBe('test-plugin');
+      expect(regs[0]!.plugin).toBe(fakePlugin);
+    });
+
+    it('registerRehypePlugin adds to rehypePluginStore', async () => {
+      const fakePlugin = () => {};
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            ctx.registerRehypePlugin('my-rehype', fakePlugin);
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      const regs = rehypePluginStore.getState().registrations;
+      expect(regs).toHaveLength(1);
+      expect(regs[0]!.id).toBe('my-rehype');
+      expect(regs[0]!.pluginId).toBe('test-plugin');
+    });
+
+    it('registerPreviewComponent adds to previewComponentStore', async () => {
+      const FakeComp = () => null;
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            ctx.registerPreviewComponent('my-comp', 'table', FakeComp);
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      const regs = previewComponentStore.getState().registrations;
+      expect(regs).toHaveLength(1);
+      expect(regs[0]!.tagName).toBe('table');
+    });
+
+    it('registerCodeBlockRenderer adds to codeBlockStore', async () => {
+      const MermaidRenderer = () => null;
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            ctx.registerCodeBlockRenderer('mermaid', 'mermaid', MermaidRenderer);
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      const regs = codeBlockStore.getState().registrations;
+      expect(regs).toHaveLength(1);
+      expect(regs[0]!.language).toBe('mermaid');
+    });
+
+    it('unregister functions remove from stores', async () => {
+      let unregRemark: () => void;
+      let unregRehype: () => void;
+
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            unregRemark = ctx.registerRemarkPlugin('remark-1', () => {});
+            unregRehype = ctx.registerRehypePlugin('rehype-1', () => {});
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+      expect(remarkPluginStore.getState().registrations).toHaveLength(1);
+      expect(rehypePluginStore.getState().registrations).toHaveLength(1);
+
+      unregRemark!();
+      unregRehype!();
+
+      expect(remarkPluginStore.getState().registrations).toHaveLength(0);
+      expect(rehypePluginStore.getState().registrations).toHaveLength(0);
+    });
+
+    it('deactivate cleans up all preview stores', async () => {
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            ctx.registerRemarkPlugin('remark-1', () => {});
+            ctx.registerRehypePlugin('rehype-1', () => {});
+            ctx.registerPreviewComponent('comp-1', 'table', () => null);
+            ctx.registerCodeBlockRenderer('code-1', 'mermaid', () => null);
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      // Verify all stores have registrations
+      expect(remarkPluginStore.getState().registrations).toHaveLength(1);
+      expect(rehypePluginStore.getState().registrations).toHaveLength(1);
+      expect(previewComponentStore.getState().registrations).toHaveLength(1);
+      expect(codeBlockStore.getState().registrations).toHaveLength(1);
+
+      registry.deactivate('test-plugin');
+
+      // All stores should be empty
+      expect(remarkPluginStore.getState().registrations).toHaveLength(0);
+      expect(rehypePluginStore.getState().registrations).toHaveLength(0);
+      expect(previewComponentStore.getState().registrations).toHaveLength(0);
+      expect(codeBlockStore.getState().registrations).toHaveLength(0);
+    });
+  });
+
+  describe('error isolation', () => {
+    it('catches activate() errors and marks plugin as error', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      registry.load(
+        makeManifest({
+          activate: () => {
+            throw new Error('Plugin crashed!');
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      expect(registry.isActive('test-plugin')).toBe(false);
+      expect(registry.hasError('test-plugin')).toBe(true);
+      expect(registry.getError('test-plugin')).toEqual({
+        message: 'Plugin crashed!',
+        count: 1,
+      });
+
+      consoleSpy.mockRestore();
+    });
+
+    it('cleans up partial registrations on activate error', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      // Clean preview stores
+      for (const r of remarkPluginStore.getState().registrations) {
+        remarkPluginStore.getState().unregister(r.id);
+      }
+
+      registry.load(
+        makeManifest({
+          activate: ctx => {
+            // Register something before crashing
+            ctx.registerRemarkPlugin('partial-remark', () => {});
+            throw new Error('Crash after partial setup');
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      // Partial registrations should be cleaned up
+      expect(remarkPluginStore.getState().registrations).toHaveLength(0);
+      expect(registry.hasError('test-plugin')).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('catches dispose() errors without crashing deactivate', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      registry.load(
+        makeManifest({
+          activate: () => ({
+            dispose() {
+              throw new Error('dispose crashed');
+            },
+          }),
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+      expect(registry.isActive('test-plugin')).toBe(true);
+
+      // Should not throw
+      expect(() => registry.deactivate('test-plugin')).not.toThrow();
+      expect(registry.isActive('test-plugin')).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('catches deactivate() lifecycle errors without crashing', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      registry.load(
+        makeManifest({
+          deactivate: () => {
+            throw new Error('deactivate lifecycle crashed');
+          },
+        })
+      );
+
+      await registry.activate('test-plugin', makeEditorAPI(), makeAppAPI());
+
+      expect(() => registry.deactivate('test-plugin')).not.toThrow();
+      expect(registry.isActive('test-plugin')).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
+    it('getError returns null for non-error plugins', () => {
+      registry.load(makeManifest());
+      expect(registry.getError('test-plugin')).toBeNull();
+      expect(registry.hasError('test-plugin')).toBe(false);
+    });
+
+    it('getError returns null for unknown plugins', () => {
+      expect(registry.getError('nonexistent')).toBeNull();
+      expect(registry.hasError('nonexistent')).toBe(false);
     });
   });
 });

--- a/packages/plugin-api/tests/rehypePluginStore.test.ts
+++ b/packages/plugin-api/tests/rehypePluginStore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { rehypePluginStore } from '../src/preview/rehypePluginStore';
+
+describe('rehypePluginStore', () => {
+  beforeEach(() => {
+    const state = rehypePluginStore.getState();
+    for (const r of state.registrations) {
+      state.unregister(r.id);
+    }
+  });
+
+  it('starts with empty registrations', () => {
+    expect(rehypePluginStore.getState().registrations).toEqual([]);
+  });
+
+  it('registers a rehype plugin', () => {
+    const fakePlugin = () => {};
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'test-plugin',
+      plugin: fakePlugin,
+    });
+
+    expect(rehypePluginStore.getState().registrations).toHaveLength(1);
+    expect(rehypePluginStore.getState().registrations[0]!.id).toBe('rehype-1');
+  });
+
+  it('replaces registration with same id', () => {
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+
+    expect(rehypePluginStore.getState().registrations).toHaveLength(1);
+  });
+
+  it('unregisters by id', () => {
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+    rehypePluginStore.getState().unregister('rehype-1');
+
+    expect(rehypePluginStore.getState().registrations).toEqual([]);
+  });
+
+  it('unregisterAll removes all for a pluginId', () => {
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'plugin-a',
+      plugin: () => {},
+    });
+    rehypePluginStore.getState().register({
+      id: 'rehype-2',
+      pluginId: 'plugin-a',
+      plugin: () => {},
+    });
+    rehypePluginStore.getState().register({
+      id: 'rehype-3',
+      pluginId: 'plugin-b',
+      plugin: () => {},
+    });
+
+    rehypePluginStore.getState().unregisterAll('plugin-a');
+
+    const remaining = rehypePluginStore.getState().registrations;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.pluginId).toBe('plugin-b');
+  });
+
+  it('getPlugins returns flat array of plugin functions', () => {
+    const pluginA = () => {};
+    const pluginB = () => {};
+
+    rehypePluginStore.getState().register({
+      id: 'rehype-1',
+      pluginId: 'plugin-a',
+      plugin: pluginA,
+    });
+    rehypePluginStore.getState().register({
+      id: 'rehype-2',
+      pluginId: 'plugin-b',
+      plugin: pluginB,
+    });
+
+    expect(rehypePluginStore.getState().getPlugins()).toEqual([pluginA, pluginB]);
+  });
+});

--- a/packages/plugin-api/tests/remarkPluginStore.test.ts
+++ b/packages/plugin-api/tests/remarkPluginStore.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { remarkPluginStore } from '../src/preview/remarkPluginStore';
+
+describe('remarkPluginStore', () => {
+  beforeEach(() => {
+    const state = remarkPluginStore.getState();
+    for (const r of state.registrations) {
+      state.unregister(r.id);
+    }
+  });
+
+  it('starts with empty registrations', () => {
+    expect(remarkPluginStore.getState().registrations).toEqual([]);
+  });
+
+  it('registers a remark plugin', () => {
+    const fakePlugin = () => {};
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'test-plugin',
+      plugin: fakePlugin,
+    });
+
+    expect(remarkPluginStore.getState().registrations).toHaveLength(1);
+    expect(remarkPluginStore.getState().registrations[0]!.id).toBe('remark-1');
+  });
+
+  it('replaces registration with same id', () => {
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+
+    expect(remarkPluginStore.getState().registrations).toHaveLength(1);
+  });
+
+  it('unregisters by id', () => {
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'test-plugin',
+      plugin: () => {},
+    });
+    remarkPluginStore.getState().unregister('remark-1');
+
+    expect(remarkPluginStore.getState().registrations).toEqual([]);
+  });
+
+  it('unregisterAll removes all for a pluginId', () => {
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'plugin-a',
+      plugin: () => {},
+    });
+    remarkPluginStore.getState().register({
+      id: 'remark-2',
+      pluginId: 'plugin-a',
+      plugin: () => {},
+    });
+    remarkPluginStore.getState().register({
+      id: 'remark-3',
+      pluginId: 'plugin-b',
+      plugin: () => {},
+    });
+
+    remarkPluginStore.getState().unregisterAll('plugin-a');
+
+    const remaining = remarkPluginStore.getState().registrations;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.pluginId).toBe('plugin-b');
+  });
+
+  it('getPlugins returns flat array of plugin functions', () => {
+    const pluginA = () => {};
+    const pluginB = () => {};
+
+    remarkPluginStore.getState().register({
+      id: 'remark-1',
+      pluginId: 'plugin-a',
+      plugin: pluginA,
+    });
+    remarkPluginStore.getState().register({
+      id: 'remark-2',
+      pluginId: 'plugin-b',
+      plugin: pluginB,
+    });
+
+    expect(remarkPluginStore.getState().getPlugins()).toEqual([pluginA, pluginB]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Remark/rehype plugin hooks**: plugins can extend the markdown preview pipeline with custom remark, rehype plugins, preview components, and code block renderers via `registerRemarkPlugin()`, `registerRehypePlugin()`, `registerPreviewComponent()`, `registerCodeBlockRenderer()`
- **Plugin error isolation**: try-catch around activate/dispose/deactivate lifecycle, React `PluginErrorBoundary` wrapping plugin UI in LayoutZone, error state tracking with counts
- **Plugin config enum/range controls**: extended `PluginConfigSchemaField` to support `enum` (dropdown Select) and `range` (slider RangeInput) field types with full settings UI
- **Read-only data API**: plugins can call `listNotes()`, `listNotebooks()`, `listTags()` via `context.app` for data access without mutation capability
- **CSS variable injection (theme system)**: plugins can register custom CSS properties via `registerCssVariables()` to override theme tokens or add custom variables, applied to `document.documentElement` via `useCssVariables()` hook
- **Plugin hot reload in dev mode**: `fs.watch` on plugins directory with 300ms debounce, broadcasts reload to all windows automatically (`NODE_ENV=development` only), cleanup on app quit

## New files

| File | Purpose |
|------|---------|
| `plugin-api/src/preview/remarkPluginStore.ts` | Zustand store for remark plugin registrations |
| `plugin-api/src/preview/rehypePluginStore.ts` | Zustand store for rehype plugin registrations |
| `plugin-api/src/preview/codeBlockStore.ts` | Zustand store for custom code block renderers |
| `plugin-api/src/preview/previewComponentStore.ts` | Zustand store for preview component overrides |
| `plugin-api/src/theme/cssVariableStore.ts` | Zustand store for CSS variable injection |
| `plugin-api/src/theme/useCssVariables.ts` | React hook to apply plugin CSS variables to DOM |
| `plugin-api/src/layout/PluginErrorBoundary.tsx` | React ErrorBoundary for plugin UI isolation |
| `desktop/src/main/pluginWatcher.ts` | File watcher for plugin hot reload (dev mode) |

## Tests

- **135 plugin-api tests** across 11 test files (was 90, added 45 new)
- **25 desktop tests**
- All **13 packages** passing
- Typechecks clean (plugin-api + desktop)

## Test plan

- [ ] `pnpm test` — all 13 packages pass
- [ ] `pnpm typecheck` — plugin-api + desktop clean
- [ ] Open Settings > Plugins — built-in cards visible, enum/range controls render
- [ ] Install a community plugin with `configSchema` — Settings expand with correct controls
- [ ] Plugin with `registerRemarkPlugin()` — custom remark transforms appear in preview
- [ ] Plugin that throws in `activate()` — error caught, other plugins still load
- [ ] Plugin UI crash — ErrorBoundary shows fallback, app continues
- [ ] `pnpm dev` — plugin file changes trigger automatic reload in all windows
- [ ] Plugin calling `context.app.listNotes()` — returns note summaries
- [ ] Plugin calling `context.registerCssVariables()` — CSS variables applied to root

🤖 Generated with [Claude Code](https://claude.com/claude-code)