### PR TITLE
fix: resolve auto-update not installing on macOS

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1356,13 +1356,18 @@ function registerUpdateHandlers(): void {
     try {
       await autoUpdater.downloadUpdate();
       return { ok: true };
-    } catch {
+    } catch (err) {
+      loggers.updater().error({ error: (err as Error).message }, 'Failed to download update');
       return { ok: false };
     }
   });
 
   ipcMain.handle('updates:installNow', () => {
-    autoUpdater.quitAndInstall();
+    // Force-close all windows so macOS doesn't block the quit
+    BrowserWindow.getAllWindows().forEach(win => {
+      if (!win.isDestroyed()) win.destroy();
+    });
+    autoUpdater.quitAndInstall(false, true);
   });
 }
 


### PR DESCRIPTION
## Summary
- Force-destroy all BrowserWindows before `quitAndInstall()` so macOS doesn't block the quit signal
- Pass `isForceRunAfter = true` to ensure the app relaunches after updating
- Add error logging to `downloadUpdate()` catch block (was silently swallowed)

## Test plan
- [ ] Build production app (`pnpm build && pnpm dist:mac`)
- [ ] Check for update, download, click "Restart to Update"
- [ ] Verify app quits, installs update, and relaunches with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)