### PR TITLE
feat: surface sync conflicts in status indicator

### DIFF
--- a/apps/desktop/src/renderer/components/sync/SyncStatusIndicator.tsx
+++ b/apps/desktop/src/renderer/components/sync/SyncStatusIndicator.tsx
@@ -5,14 +5,22 @@
  */
 
 import { useState } from 'react';
-import { Cloud, CloudOff, RefreshCw, CheckCircle, AlertCircle } from 'lucide-react';
-import { useSyncStore, selectStatus, selectLastSyncAt } from '../../stores/syncStore';
+import { Cloud, CloudOff, RefreshCw, CheckCircle, AlertCircle, AlertTriangle } from 'lucide-react';
+import {
+  useSyncStore,
+  selectStatus,
+  selectLastSyncAt,
+  selectHasConflicts,
+  selectConflicts,
+} from '../../stores/syncStore';
 import { useAuthStore } from '../../stores/authStore';
 import styles from './SyncStatusIndicator.module.css';
 
 export function SyncStatusIndicator() {
   const status = useSyncStore(selectStatus);
   const lastSyncAt = useSyncStore(selectLastSyncAt);
+  const hasConflicts = useSyncStore(selectHasConflicts);
+  const conflicts = useSyncStore(selectConflicts);
   const isAuthenticated = useAuthStore(state => state.isAuthenticated);
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -22,6 +30,15 @@ export function SyncStatusIndicator() {
         icon: <CloudOff size={14} />,
         label: 'Not signed in',
         color: '#6b7280',
+      };
+    }
+
+    // Conflicts take priority over idle state
+    if (hasConflicts && status !== 'syncing') {
+      return {
+        icon: <AlertTriangle size={14} />,
+        label: `${conflicts.length} conflict${conflicts.length > 1 ? 's' : ''} — resolve in Settings`,
+        color: '#f59e0b',
       };
     }
 

--- a/apps/desktop/src/renderer/components/sync/index.ts
+++ b/apps/desktop/src/renderer/components/sync/index.ts
@@ -5,4 +5,5 @@
  */
 
 export { SyncStatusIndicator } from './SyncStatusIndicator';
+export { ConflictResolver } from './ConflictResolver';
 export { LoginModal } from './LoginModal';


### PR DESCRIPTION
## Summary
- Add conflict state to `SyncStatusIndicator` with amber warning icon and conflict count
- Conflicts take priority over idle state so users discover them without navigating to Settings
- Export `ConflictResolver` from sync components barrel (`index.ts`)

## Test plan
- [x] Lint clean
- [x] Format clean
- [ ] Manual: trigger sync conflict → verify amber triangle icon appears in status indicator
- [ ] Manual: resolve conflict in Settings → verify indicator returns to green idle state

🤖 Generated with [Claude Code](https://claude.com/claude-code)