### PR TITLE
fix: create Cloudflare Pages project before deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Ensure Cloudflare Pages project exists
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create readied-web --production-branch main
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
@@ -42,4 +50,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: pnpm
           workingDirectory: apps/web
-          command: pages deploy out --project-name=readied-web
+          command: pages deploy out --project-name=readied-web --commit-dirty=true


### PR DESCRIPTION
## Summary
- Add step to create `readied-web` project on Cloudflare Pages before deploying
- Uses `continue-on-error: true` so it doesn't fail when project already exists
- Add `--commit-dirty=true` to suppress wrangler git warning

## Context
The Deploy Web workflow has never succeeded — project `readied-web` doesn't exist on Cloudflare Pages (error code 8000007).

## Test plan
- [ ] Merge to develop → main, verify deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)