### PR TITLE
fix: Modal hook order + plugin install slug check

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -2403,7 +2403,7 @@ function registerPluginDiscoveryHandlers(): void {
   });
 
   // Install plugin from a remote URL (marketplace download)
-  ipcMain.handle('plugins:installFromUrl', async (_event, url: string, pluginSlug: string) => {
+  ipcMain.handle('plugins:installFromUrl', async (_event, url: string, _pluginSlug: string) => {
     // Safety: only allow https URLs
     if (!url.startsWith('https://')) {
       return { success: false, error: 'Only HTTPS URLs are allowed' };
@@ -2500,14 +2500,6 @@ function registerPluginDiscoveryHandlers(): void {
       }
       if (!manifest.id || !manifest.name) {
         return { success: false, error: 'Invalid manifest: missing id or name' };
-      }
-
-      // Validate manifest.id matches the expected pluginSlug if provided
-      if (pluginSlug && pluginSlug.length > 0 && manifest.id !== pluginSlug) {
-        return {
-          success: false,
-          error: `Manifest ID "${manifest.id}" does not match expected plugin "${pluginSlug}"`,
-        };
       }
 
       // Validate plugin ID - only allow alphanumeric, hyphens, underscores

--- a/apps/desktop/src/renderer/ui/patterns/Modal.tsx
+++ b/apps/desktop/src/renderer/ui/patterns/Modal.tsx
@@ -46,6 +46,7 @@ export function Modal({
   );
 
   const contentRef = useRef<HTMLDivElement | null>(null);
+  const generatedId = useId();
 
   // Focus the modal container on open
   useEffect(() => {
@@ -56,7 +57,6 @@ export function Modal({
 
   if (!open) return null;
 
-  const generatedId = useId();
   const titleId = title != null ? generatedId : undefined;
 
   return createPortal(


### PR DESCRIPTION
## Summary
Fixes two review findings from PR #198:

- **P1**: Move `useId()` above early return in Modal to prevent React hook order violation
- **P2**: Remove strict slug/id equality check in `plugins:installFromUrl` — marketplace slug and manifest id are independent identifiers

## Test plan
- [x] `pnpm typecheck` — 17/17 pass
- [x] `pnpm test` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)