### PR TITLE
fix: address all PR #202 review findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # Readied — Environment Variables
+# See CLAUDE.md for development setup instructions
 # Copy this file to .env and fill in the values.
 # The desktop app runs fully offline — these are only needed for the API and web app.
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1249,13 +1249,15 @@ function registerDataHandlers(): void {
   ipcMain.handle(
     'data:exportNote',
     async (_event: Electron.IpcMainInvokeEvent, content: string, suggestedName: string) => {
-      const safeName =
+      let safeName =
         suggestedName
           .normalize('NFC')
           // eslint-disable-next-line no-control-regex
           .replace(/[/\\:*?"<>|\x00-\x1f.]/g, '')
           .substring(0, 80)
           .trim() || 'note';
+      const WINDOWS_RESERVED = /^(con|prn|aux|nul|com\d|lpt\d)$/i;
+      if (WINDOWS_RESERVED.test(safeName)) safeName = `_${safeName}`;
       const { filePath, canceled } = await dialog.showSaveDialog({
         title: 'Export Note',
         defaultPath: join(app.getPath('documents'), `${safeName}.md`),
@@ -1437,8 +1439,9 @@ function registerUpdateHandlers(): void {
       await autoUpdater.downloadUpdate();
       return { ok: true };
     } catch (err) {
-      loggers.updater().error({ error: (err as Error).message }, 'Failed to download update');
-      return { ok: false };
+      const message = (err as Error).message;
+      loggers.updater().error({ error: message }, 'Failed to download update');
+      return { ok: false, error: message };
     }
   });
 
@@ -2535,7 +2538,12 @@ function registerPluginDiscoveryHandlers(): void {
 
       await rename(pluginSourceDir, destDir);
 
-      return { success: true, pluginId: manifest.id, pluginName: manifest.name };
+      return {
+        success: true,
+        pluginId: manifest.id,
+        pluginName: manifest.name,
+        slugMismatch: pluginSlug && manifest.id !== pluginSlug ? pluginSlug : undefined,
+      };
     } catch (error) {
       return { success: false, error: String(error) };
     } finally {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -750,7 +750,7 @@ export interface ReadiedAPI {
     /** Check for updates manually */
     checkNow: () => Promise<{ available: boolean; version?: string }>;
     /** Start downloading the available update */
-    startDownload: () => Promise<{ ok: boolean }>;
+    startDownload: () => Promise<{ ok: boolean; error?: string }>;
     /** Quit and install the downloaded update */
     installNow: () => Promise<void>;
     /** Subscribe to update-available events from background check */

--- a/apps/desktop/src/renderer/components/NoteEditor.tsx
+++ b/apps/desktop/src/renderer/components/NoteEditor.tsx
@@ -146,7 +146,7 @@ export function NoteEditor({
       savedTimerRef.current = setTimeout(() => setShowSaved(false), 1500);
     }
     prevDirtyRef.current = isDirty;
-  }, [isDirty, note?.id]);
+  }, [isDirty]);
 
   // Cleanup saved timer on unmount
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/UpdateBanner.tsx
@@ -45,7 +45,7 @@ export function UpdateBanner() {
     );
 
     cleanups.push(
-      window.readied.updates.onError((err: { message: string }) => {
+      window.readied.updates.onError((err: { message?: string }) => {
         setState(prev =>
           prev.kind === 'hidden'
             ? prev
@@ -72,7 +72,7 @@ export function UpdateBanner() {
             : {
                 kind: 'error',
                 version: (prev as { version: string }).version,
-                message: 'Download failed',
+                message: result.error ?? 'Download failed',
               }
         );
       }

--- a/apps/desktop/src/renderer/components/sidebar/SidebarFooter.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SidebarFooter.tsx
@@ -48,6 +48,14 @@ const SyncProgressIndicator = memo(function SyncProgressIndicator() {
   const syncNow = useSyncStore(state => state.syncNow);
   const refreshPendingCount = useSyncStore(state => state.refreshPendingCount);
 
+  // Force re-render every 60s so relative time text stays fresh
+  const [, forceUpdate] = useState(0);
+  useEffect(() => {
+    if (!lastSyncAt) return;
+    const timer = setInterval(() => forceUpdate((n: number) => n + 1), 60_000);
+    return () => clearInterval(timer);
+  }, [lastSyncAt]);
+
   // Track "just synced" flash state
   const [showSynced, setShowSynced] = useState(false);
   const prevStatusRef = useRef(syncStatus);

--- a/apps/desktop/src/renderer/pages/settings/sections/PluginsSection.tsx
+++ b/apps/desktop/src/renderer/pages/settings/sections/PluginsSection.tsx
@@ -224,6 +224,7 @@ function BrowseTab({ installedPluginIds }: { installedPluginIds: Set<string> }) 
           // Validate each item has required fields
           const validated = data.plugins.filter(
             (p): p is MarketplacePlugin =>
+              typeof p.slug === 'string' &&
               typeof p.name === 'string' &&
               typeof p.description === 'string' &&
               Array.isArray(p.tags)

--- a/apps/desktop/src/renderer/pages/settings/sections/Section.module.css
+++ b/apps/desktop/src/renderer/pages/settings/sections/Section.module.css
@@ -647,10 +647,10 @@
 
 /* Spinner animation for loading states */
 .pluginSpinner {
-  animation: pluginSpin 1s linear infinite;
+  animation: plugin-spin 1s linear infinite;
 }
 
-@keyframes pluginSpin {
+@keyframes plugin-spin {
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }

--- a/apps/desktop/src/renderer/ui/primitives/Toast.tsx
+++ b/apps/desktop/src/renderer/ui/primitives/Toast.tsx
@@ -58,7 +58,7 @@ export function Toaster() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className={styles.container} aria-live="polite">
+    <div className={styles.container}>
       {toasts.map(item => (
         <ToastNotification key={item.id} item={item} />
       ))}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
Fixes all 12 review comments from PR #202 (CodeRabbit + Codex).

- **NoteEditor**: Remove `note?.id` from save effect deps (P2 — prevents false "Saved" flash)
- **exportNote**: Reject Windows reserved filenames (CON, PRN, AUX, etc.)
- **installFromUrl**: Return `slugMismatch` in success response for UI awareness
- **SidebarFooter**: 60s interval refresh for "Synced Xm ago" staleness
- **UpdateBanner**: Fix optional error type + "Download failed: Download failed" duplication
- **PluginsSection**: Add `slug` to marketplace response validation
- **Section.module.css**: Keyframe `pluginSpin` → `plugin-spin` (stylelint)
- **Toast**: Remove nested `aria-live` from container (spec compliance)
- **tsconfig.json**: `jsx: "preserve"` for Next.js (was "react-jsx")
- **.env.example**: Reference to CLAUDE.md for setup docs

## Test plan
- [x] `pnpm typecheck` — 17/17 pass
- [x] `pnpm test` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of Windows reserved filenames in exports
  * Download failures now display specific error messages instead of generic text
  * Improved validation when installing marketplace plugins
  * Sync timestamp display now updates periodically
  * Enhanced accessibility for toast notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->