### PR TITLE
fix(ci): clean 7zip cache on Linux build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Clean electron-builder cache (Linux)
         if: matrix.platform == 'linux'
-        run: rm -rf ~/.cache/electron-builder/fpm
+        run: rm -rf ~/.cache/electron-builder/fpm ~/.cache/electron-builder/nsis ~/.cache/electron-builder/winCodeSign ~/.cache/electron-builder/7za*
 
       - name: Build distributables (Linux)
         if: matrix.platform == 'linux'


### PR DESCRIPTION
## Summary
Expands the Linux cache cleanup to also clear 7zip archives, fixing the
`Unknown error -2147024872` / `ERROR: No more files` failure in fpm.

Note: macOS build fails due to expired Apple Developer agreement (HTTP 403
from notarytool) — that requires manual renewal at developer.apple.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)