### PR TITLE
fix(ci): fix Linux build and Node.js 24 warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ env:
   NODE_VERSION: '22'
   ELECTRON_CACHE: ~/.cache/electron
   ELECTRON_BUILDER_CACHE: ~/.cache/electron-builder
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
@@ -55,11 +56,13 @@ jobs:
       - name: Cache Electron downloads
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ env.ELECTRON_CACHE }}
-            ${{ env.ELECTRON_BUILDER_CACHE }}
-          key: electron-v2-${{ matrix.platform }}-${{ hashFiles('apps/desktop/package.json') }}
-          restore-keys: electron-v2-${{ matrix.platform }}-
+          path: ${{ env.ELECTRON_CACHE }}
+          key: electron-v3-${{ matrix.platform }}-${{ hashFiles('apps/desktop/package.json') }}
+          restore-keys: electron-v3-${{ matrix.platform }}-
+
+      - name: Clean electron-builder cache (Linux)
+        if: matrix.platform == 'linux'
+        run: rm -rf ~/.cache/electron-builder
 
       - name: Force HTTPS for GitHub git dependencies
         shell: bash
@@ -93,10 +96,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: pnpm dist:win --publish always
-
-      - name: Clean electron-builder cache (Linux)
-        if: matrix.platform == 'linux'
-        run: rm -rf ~/.cache/electron-builder/fpm ~/.cache/electron-builder/nsis ~/.cache/electron-builder/winCodeSign ~/.cache/electron-builder/7za*
 
       - name: Build distributables (Linux)
         if: matrix.platform == 'linux'


### PR DESCRIPTION
## Summary
Fixes the persistent Linux build failure and Node.js 20 deprecation warnings.

- **Linux 7zip error**: electron-builder's fpm cache was being restored from GitHub Actions cache with a corrupted archive. Fix: remove electron-builder from the shared cache (only cache electron downloads), nuke the entire electron-builder cache dir on Linux before install, bump cache key to v3
- **Node.js 20 warnings**: Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)