### PR TITLE
fix(ci): add HTTPS git rewrite to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
+      - name: Force HTTPS for GitHub git dependencies
+        run: git config --global 'url.https://github.com/.insteadOf' 'git@github.com:'
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fixes release workflow failure: pnpm tries to clone `electron/node-gyp` via SSH which fails in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)