### PR TITLE
fix: replace removed lucide brand icons

### DIFF
--- a/apps/web/components/Navbar.tsx
+++ b/apps/web/components/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
-import { Apple } from 'lucide-react';
+import { AppleIcon } from '@/components/icons/BrandIcons';
 import { Sheet, SheetTrigger, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 
 const docsItems: { label: string; href: string; external?: boolean }[] = [
@@ -178,7 +178,7 @@ export default function Navbar() {
           href="/download"
           className="hidden items-center gap-2 rounded-lg border border-white/[0.12] bg-white/[0.06] px-4 py-1.5 text-[13px] font-medium text-white transition-all hover:bg-white/[0.1] hover:border-white/[0.18] md:inline-flex"
         >
-          <Apple className="h-3.5 w-3.5" />
+          <AppleIcon className="h-3.5 w-3.5" />
           Download
         </Link>
 
@@ -222,7 +222,7 @@ export default function Navbar() {
                   onClick={closeSheet}
                   className="flex items-center justify-center gap-2 rounded-lg border border-white/[0.12] bg-white/[0.06] px-4 py-3 text-base font-medium text-white transition-colors hover:bg-white/[0.1]"
                 >
-                  <Apple className="h-4 w-4" />
+                  <AppleIcon className="h-4 w-4" />
                   Download for Mac
                 </Link>
                 <Link

--- a/apps/web/components/icons/BrandIcons.tsx
+++ b/apps/web/components/icons/BrandIcons.tsx
@@ -1,0 +1,58 @@
+export function GithubIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={props.width || 24}
+      height={props.height || 24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4" />
+      <path d="M9 18c-4.51 2-5-2-7-2" />
+    </svg>
+  );
+}
+
+export function TwitterIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={props.width || 24}
+      height={props.height || 24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+    </svg>
+  );
+}
+
+export function AppleIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={props.width || 24}
+      height={props.height || 24}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="M12 20.94c1.5 0 2.75 1.06 4 1.06 3 0 6-8 6-12.22A4.91 4.91 0 0 0 17 5c-2.22 0-4 1.44-5 2-1-.56-2.78-2-5-2a4.9 4.9 0 0 0-5 4.78C2 14 5 22 8 22c1.25 0 2.5-1.06 4-1.06Z" />
+      <path d="M10 2c1 .5 2 2 2 5" />
+    </svg>
+  );
+}

--- a/apps/web/components/landing/CreatorStory.tsx
+++ b/apps/web/components/landing/CreatorStory.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { Github, Twitter, Globe } from 'lucide-react';
+import { Globe } from 'lucide-react';
+import { GithubIcon, TwitterIcon } from '@/components/icons/BrandIcons';
 
 export default function CreatorStory() {
   return (
@@ -42,7 +43,7 @@ export default function CreatorStory() {
             className="flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-surface text-text-muted transition-colors hover:bg-white/5 hover:text-text-primary"
             aria-label="GitHub"
           >
-            <Github className="h-4.5 w-4.5" />
+            <GithubIcon className="h-4.5 w-4.5" />
           </Link>
           <Link
             href="https://x.com/tomymaritano"
@@ -51,7 +52,7 @@ export default function CreatorStory() {
             className="flex h-10 w-10 items-center justify-center rounded-lg border border-border bg-surface text-text-muted transition-colors hover:bg-white/5 hover:text-text-primary"
             aria-label="X (Twitter)"
           >
-            <Twitter className="h-4.5 w-4.5" />
+            <TwitterIcon className="h-4.5 w-4.5" />
           </Link>
           <Link
             href="https://medium.com/@tomymaritano"

--- a/apps/web/components/landing/Hero.tsx
+++ b/apps/web/components/landing/Hero.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { Apple, Github, Play, XIcon } from 'lucide-react';
+import { Play, XIcon } from 'lucide-react';
+import { AppleIcon, GithubIcon } from '@/components/icons/BrandIcons';
 import { AnimatePresence, motion } from 'framer-motion';
 import { getProductConfig } from '@readied/product-config';
 import { AnimatedShinyText } from '@/components/magicui/animated-shiny-text';
@@ -258,7 +259,7 @@ export default function Hero() {
             href="/download"
             className="inline-flex items-center gap-2.5 rounded-xl border border-white/[0.12] bg-white/[0.06] px-6 py-3 text-sm font-medium text-white backdrop-blur-sm transition-all hover:bg-white/[0.1] hover:border-white/[0.2]"
           >
-            <Apple className="h-4 w-4" />
+            <AppleIcon className="h-4 w-4" />
             Download for Mac
           </Link>
           <Link
@@ -267,7 +268,7 @@ export default function Hero() {
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2.5 rounded-xl border border-white/[0.08] bg-white/[0.03] px-6 py-3 text-sm font-medium text-text-secondary backdrop-blur-sm transition-all hover:bg-white/[0.06] hover:text-white"
           >
-            <Github className="h-4 w-4" />
+            <GithubIcon className="h-4 w-4" />
             View on GitHub
           </Link>
         </div>

--- a/apps/web/components/landing/SocialProof.tsx
+++ b/apps/web/components/landing/SocialProof.tsx
@@ -1,11 +1,12 @@
-import { WifiOff, HardDrive, Github, Puzzle, Monitor } from 'lucide-react';
+import { WifiOff, HardDrive, Puzzle, Monitor } from 'lucide-react';
+import { GithubIcon } from '@/components/icons/BrandIcons';
 
 import { Marquee } from '@/components/magicui/marquee';
 
 const badges = [
   { icon: WifiOff, label: 'Offline First' },
   { icon: HardDrive, label: 'Local Storage' },
-  { icon: Github, label: 'Open Source' },
+  { icon: GithubIcon, label: 'Open Source' },
   { icon: Puzzle, label: 'Plugin System' },
   { icon: Monitor, label: 'Cross-platform' },
 ];


### PR DESCRIPTION
lucide-react v1.0 removed brand icons. Local SVG replacements.