### PR TITLE
feat: local HTTP API, quick capture, mermaid/math plugins + ASAR fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -81,7 +81,11 @@
       "Bash(ls /Users/tomasmaritano/Documents/Github/readied/readide/apps/desktop/src/renderer/components/NoteListFilterBar*)",
       "Bash(ls /Users/tomasmaritano/Documents/Github/readied/readide/apps/desktop/src/renderer/components/*.module.css)",
       "Bash(npm view:*)",
-      "Bash(git log:*)"
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(npx vercel:*)",
+      "Bash(gh workflow:*)",
+      "Bash(ls:*)"
     ]
   }
 }

--- a/apps/desktop/electron-vite.config.ts
+++ b/apps/desktop/electron-vite.config.ts
@@ -4,7 +4,18 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   main: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: [
+          '@readied/core',
+          '@readied/storage-core',
+          '@readied/storage-sqlite',
+          '@readied/sync-core',
+          '@readied/licensing',
+          '@readied/ai-core',
+        ],
+      }),
+    ],
     build: {
       outDir: 'out/main',
       rollupOptions: {
@@ -18,7 +29,11 @@ export default defineConfig({
     },
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [
+      externalizeDepsPlugin({
+        exclude: ['@readied/core', '@readied/storage-core', '@readied/licensing'],
+      }),
+    ],
     build: {
       outDir: 'out/preload',
       rollupOptions: {

--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -166,10 +166,14 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
 
   // IPC: Get the bearer token (for displaying in settings)
   ipcMain.handle('localServer:getToken', async () => {
-    if (!apiToken) {
-      apiToken = await getOrCreateApiToken(dataPaths.root);
+    try {
+      if (!apiToken) {
+        apiToken = await getOrCreateApiToken(dataPaths.root);
+      }
+      return { ok: true, value: apiToken };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
-    return apiToken;
   });
 }
 

--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -1,0 +1,184 @@
+/**
+ * Local HTTP API Server IPC Handlers
+ *
+ * Manages the local API server lifecycle and exposes status/token info
+ * to the renderer (settings UI).
+ */
+
+import { ipcMain, app } from 'electron';
+import { createNoteId, createNoteOperation, updateNoteOperation } from '@readied/core';
+import {
+  LocalServer,
+  getOrCreateApiToken,
+  type LocalServerHandlers,
+} from '../services/localServer.js';
+import type { SQLiteNoteRepository, DataPaths } from './types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LocalServerHandlerDeps {
+  noteRepository: SQLiteNoteRepository;
+  dataPaths: DataPaths;
+  noteToSnapshot: (note: {
+    id: string;
+    notebookId: string;
+    content: string;
+    title: string;
+    isPinned: boolean;
+    isDeleted: boolean;
+    status: import('@readied/core').NoteStatus;
+    metadata: {
+      createdAt: string;
+      updatedAt: string;
+      tags: readonly string[];
+      wordCount: number;
+      archivedAt: string | null;
+    };
+  }) => {
+    id: string;
+    notebookId: string;
+    content: string;
+    title: string;
+    createdAt: string;
+    updatedAt: string;
+    tags: string[];
+    wordCount: number;
+    archivedAt: string | null;
+    isArchived: boolean;
+    isPinned: boolean;
+    isDeleted: boolean;
+    status: import('@readied/core').NoteStatus;
+  };
+}
+
+// ============================================================================
+// Module State
+// ============================================================================
+
+const server = new LocalServer();
+let apiToken: string | null = null;
+
+// ============================================================================
+// Registration
+// ============================================================================
+
+export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void {
+  const { noteRepository: repo, dataPaths, noteToSnapshot } = deps;
+
+  // Build handler callbacks that bridge HTTP requests to the note repository
+  const handlers: LocalServerHandlers = {
+    async listNotes() {
+      const notes = await repo.list();
+      return notes
+        .filter(n => !n.isDeleted)
+        .map(n => ({
+          id: n.id,
+          title: n.title,
+          excerpt: n.content.slice(0, 200).replace(/\n/g, ' '),
+          updatedAt: n.metadata.updatedAt,
+        }));
+    },
+
+    async getNote(id) {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return null;
+      const snap = noteToSnapshot(note);
+      return {
+        id: snap.id,
+        title: snap.title,
+        content: snap.content,
+        notebookId: snap.notebookId,
+        createdAt: snap.createdAt,
+        updatedAt: snap.updatedAt,
+        tags: snap.tags,
+        wordCount: snap.wordCount,
+        isPinned: snap.isPinned,
+      };
+    },
+
+    async createNote(input) {
+      const result = await createNoteOperation(input, repo);
+      if (result.ok) {
+        return { ok: true, data: { id: result.data.id } };
+      }
+      return { ok: false, error: result.error };
+    },
+
+    async updateNote(id, content) {
+      const noteId = createNoteId(id);
+      const result = await updateNoteOperation({ id: noteId, content }, repo);
+      return { ok: result.ok, error: result.ok ? undefined : result.error };
+    },
+
+    async searchNotes(query) {
+      const notes = await repo.search(query, 50);
+      return notes.map(n => ({
+        id: n.id,
+        title: n.title,
+        excerpt: n.content.slice(0, 200).replace(/\n/g, ' '),
+        updatedAt: n.metadata.updatedAt,
+      }));
+    },
+
+    async getNoteCount() {
+      const notes = await repo.list();
+      return notes.filter(n => !n.isDeleted).length;
+    },
+
+    getAppVersion() {
+      return app.getVersion();
+    },
+  };
+
+  // IPC: Start the local server
+  ipcMain.handle('localServer:start', async (_event, port?: number) => {
+    try {
+      if (server.isRunning()) return { ok: true, port: server.getPort() };
+      apiToken = await getOrCreateApiToken(dataPaths.root);
+      await server.start(port, apiToken, handlers);
+      return { ok: true, port: server.getPort() };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  // IPC: Stop the local server
+  ipcMain.handle('localServer:stop', async () => {
+    await server.stop();
+    return { ok: true };
+  });
+
+  // IPC: Get server status
+  ipcMain.handle('localServer:status', () => {
+    return {
+      running: server.isRunning(),
+      port: server.getPort(),
+    };
+  });
+
+  // IPC: Get the bearer token (for displaying in settings)
+  ipcMain.handle('localServer:getToken', async () => {
+    if (!apiToken) {
+      apiToken = await getOrCreateApiToken(dataPaths.root);
+    }
+    return apiToken;
+  });
+}
+
+/**
+ * Auto-start the server if desired (called from main index).
+ * Returns the server instance for lifecycle management.
+ */
+export async function autoStartLocalServer(deps: LocalServerHandlerDeps): Promise<void> {
+  const { dataPaths } = deps;
+  apiToken = await getOrCreateApiToken(dataPaths.root);
+  // The actual start is controlled by settings — this just prepares the token.
+  // The renderer will call localServer:start if the setting is enabled.
+}
+
+/** Stop the server on app quit */
+export async function stopLocalServer(): Promise<void> {
+  await server.stop();
+}

--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -123,8 +123,7 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
     },
 
     async getNoteCount() {
-      const notes = await repo.list();
-      return notes.filter(n => !n.isDeleted).length;
+      return repo.count();
     },
 
     getAppVersion() {
@@ -135,6 +134,9 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
   // IPC: Start the local server
   ipcMain.handle('localServer:start', async (_event, port?: number) => {
     try {
+      if (port !== undefined && (typeof port !== 'number' || port < 1 || port > 65535)) {
+        return { ok: false, error: 'Invalid port' };
+      }
       if (server.isRunning()) return { ok: true, port: server.getPort() };
       apiToken = await getOrCreateApiToken(dataPaths.root);
       await server.start(port, apiToken, handlers);
@@ -146,8 +148,12 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
 
   // IPC: Stop the local server
   ipcMain.handle('localServer:stop', async () => {
-    await server.stop();
-    return { ok: true };
+    try {
+      await server.stop();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
   });
 
   // IPC: Get server status
@@ -168,14 +174,12 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
 }
 
 /**
- * Auto-start the server if desired (called from main index).
- * Returns the server instance for lifecycle management.
+ * Pre-initialise the API bearer token (called from main index).
+ * The actual server start is controlled by settings — the renderer
+ * will call localServer:start if the setting is enabled.
  */
-export async function autoStartLocalServer(deps: LocalServerHandlerDeps): Promise<void> {
-  const { dataPaths } = deps;
+export async function initApiToken(dataPaths: DataPaths): Promise<void> {
   apiToken = await getOrCreateApiToken(dataPaths.root);
-  // The actual start is controlled by settings — this just prepares the token.
-  // The renderer will call localServer:start if the setting is enabled.
 }
 
 /** Stop the server on app quit */

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -83,6 +83,8 @@ let aiKeyStorage: AiKeyStorage | null = null;
 
 // Pending deep link token — stored if the deep link arrives before the window is ready
 let pendingAuthToken: string | null = null;
+// Set of webContents IDs allowed to close themselves via window:closeSelf
+const closableWindowIds = new Set<number>();
 // Git service (initialized on app ready)
 let gitService: GitService | null = null;
 
@@ -451,6 +453,8 @@ function createQuickCaptureWindow(): void {
     },
   });
 
+  closableWindowIds.add(quickCaptureWindow.webContents.id);
+
   quickCaptureWindow.on('ready-to-show', () => {
     quickCaptureWindow?.show();
   });
@@ -459,6 +463,9 @@ function createQuickCaptureWindow(): void {
   // The window is closed via Escape key or explicit close/save actions.
 
   quickCaptureWindow.on('closed', () => {
+    if (quickCaptureWindow) {
+      closableWindowIds.delete(quickCaptureWindow.webContents.id);
+    }
     quickCaptureWindow = null;
   });
 
@@ -501,6 +508,8 @@ function createSettingsWindow(): void {
     },
   });
 
+  closableWindowIds.add(settingsWindow.webContents.id);
+
   settingsWindow.on('ready-to-show', () => {
     settingsWindow?.show();
     if (process.env.NODE_ENV === 'development') {
@@ -509,6 +518,9 @@ function createSettingsWindow(): void {
   });
 
   settingsWindow.on('closed', () => {
+    if (settingsWindow) {
+      closableWindowIds.delete(settingsWindow.webContents.id);
+    }
     settingsWindow = null;
   });
 
@@ -890,16 +902,12 @@ app
 
     // IPC: close the calling window (only allowed for quick-capture and settings windows)
     ipcMain.handle('window:closeSelf', async event => {
+      const senderId = event.sender.id;
+      if (!closableWindowIds.has(senderId)) {
+        return { ok: false, error: 'This window is not allowed to close itself' };
+      }
       const win = BrowserWindow.fromWebContents(event.sender);
       if (win && !win.isDestroyed()) {
-        // Prevent the main window from being closed via this handler
-        const allWindows = BrowserWindow.getAllWindows();
-        const mainWin = allWindows.find(
-          w => !w.isDestroyed() && w !== quickCaptureWindow && w !== settingsWindow
-        );
-        if (win === mainWin) {
-          return { ok: false, error: 'Cannot close main window via closeSelf' };
-        }
         win.close();
       }
       return { ok: true };
@@ -926,14 +934,30 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('before-quit', () => {
+let isQuitting = false;
+app.on('before-quit', async event => {
+  if (isQuitting) return; // Guard against re-entry
+  isQuitting = true;
+  event.preventDefault();
+
   globalShortcut.unregisterAll();
   stopPluginWatcher();
-  void stopLocalServer();
+
+  try {
+    await stopLocalServer();
+  } catch (err) {
+    getLogger().error(
+      { error: err instanceof Error ? err.message : String(err) },
+      'Error stopping local server during shutdown'
+    );
+  }
+
   if (db) {
     db.close();
     getLogger().info('Database closed');
   }
+
+  app.quit();
 });
 
 // Deep link handler for readied:// protocol (macOS)

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -13,7 +13,16 @@ initSentry();
 import { join, normalize } from 'path';
 import { readFile, writeFile, unlink } from 'fs/promises';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { app, BrowserWindow, ipcMain, protocol, net, nativeTheme } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  protocol,
+  net,
+  nativeTheme,
+  globalShortcut,
+  screen,
+} from 'electron';
 import { runMigrations, createDataPaths, type DataPaths } from '@readied/storage-core';
 import {
   createDatabase,
@@ -52,6 +61,7 @@ import { startPluginWatcher, stopPluginWatcher } from './pluginWatcher.js';
 import { createAIService, getToolRegistry } from './ai/setup.js';
 import { registerBuiltInTools } from './ai/built-in-tools.js';
 import { registerAIHandlers as registerAIHandlersNew } from './ai/ipc-ai.js';
+import { registerLocalServerHandlers, stopLocalServer } from './handlers/localServerHandlers.js';
 
 // ============================================================================
 // Global State
@@ -399,6 +409,72 @@ function createNoteWindow(noteId: string, noteTitle: string): void {
   }
 }
 
+// ============================================================================
+// Quick Capture Window
+// ============================================================================
+
+/** Quick capture window singleton */
+let quickCaptureWindow: BrowserWindow | null = null;
+
+/** Create or focus the quick capture floating window */
+function createQuickCaptureWindow(): void {
+  // If window exists, focus it
+  if (quickCaptureWindow && !quickCaptureWindow.isDestroyed()) {
+    quickCaptureWindow.focus();
+    return;
+  }
+
+  // Center on the current cursor screen
+  const cursorPoint = screen.getCursorScreenPoint();
+  const display = screen.getDisplayNearestPoint(cursorPoint);
+  const { x, y, width, height } = display.workArea;
+  const winWidth = 480;
+  const winHeight = 340;
+
+  quickCaptureWindow = new BrowserWindow({
+    x: Math.round(x + (width - winWidth) / 2),
+    y: Math.round(y + (height - winHeight) / 2),
+    width: winWidth,
+    height: winHeight,
+    resizable: false,
+    frame: false,
+    alwaysOnTop: true,
+    skipTaskbar: true,
+    show: false,
+    backgroundColor: '#0a0b0d',
+    webPreferences: {
+      preload: join(__dirname, '../preload/index.js'),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+
+  quickCaptureWindow.on('ready-to-show', () => {
+    quickCaptureWindow?.show();
+  });
+
+  // Close on blur (optional UX: dismiss when clicking away)
+  quickCaptureWindow.on('blur', () => {
+    if (quickCaptureWindow && !quickCaptureWindow.isDestroyed()) {
+      quickCaptureWindow.close();
+    }
+  });
+
+  quickCaptureWindow.on('closed', () => {
+    quickCaptureWindow = null;
+  });
+
+  // Load quick capture view via query param
+  if (process.env.NODE_ENV === 'development' && process.env.ELECTRON_RENDERER_URL) {
+    void quickCaptureWindow.loadURL(`${process.env.ELECTRON_RENDERER_URL}?view=quick-capture`);
+  } else {
+    void quickCaptureWindow.loadFile(join(__dirname, '../renderer/index.html'), {
+      query: { view: 'quick-capture' },
+    });
+  }
+}
+
 /** Settings window singleton */
 let settingsWindow: BrowserWindow | null = null;
 
@@ -583,6 +659,11 @@ app
       db: db!,
     });
     registerWindowHandlers();
+    registerLocalServerHandlers({
+      noteRepository: noteRepository!,
+      dataPaths,
+      noteToSnapshot,
+    });
     registerAIHandlersNew(createAIService(), getToolRegistry());
 
     // Register built-in AI tools with database access
@@ -796,6 +877,26 @@ app
         });
     }
 
+    // Register global quick capture shortcut
+    globalShortcut.register('CommandOrControl+Shift+N', () => {
+      createQuickCaptureWindow();
+    });
+
+    // IPC: open quick capture from renderer
+    ipcMain.handle('window:openQuickCapture', async () => {
+      createQuickCaptureWindow();
+      return { ok: true };
+    });
+
+    // IPC: close the calling window (used by quick capture to close itself)
+    ipcMain.handle('window:closeSelf', async event => {
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (win && !win.isDestroyed()) {
+        win.close();
+      }
+      return { ok: true };
+    });
+
     // Create window and start auto-updater
     createWindow();
     initAutoUpdater({ broadcastToWindows });
@@ -818,7 +919,9 @@ app.on('window-all-closed', () => {
 });
 
 app.on('before-quit', () => {
+  globalShortcut.unregisterAll();
   stopPluginWatcher();
+  void stopLocalServer();
   if (db) {
     db.close();
     getLogger().info('Database closed');

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -420,6 +420,7 @@ let quickCaptureWindow: BrowserWindow | null = null;
 function createQuickCaptureWindow(): void {
   // If window exists, focus it
   if (quickCaptureWindow && !quickCaptureWindow.isDestroyed()) {
+    quickCaptureWindow.show();
     quickCaptureWindow.focus();
     return;
   }
@@ -454,12 +455,8 @@ function createQuickCaptureWindow(): void {
     quickCaptureWindow?.show();
   });
 
-  // Close on blur (optional UX: dismiss when clicking away)
-  quickCaptureWindow.on('blur', () => {
-    if (quickCaptureWindow && !quickCaptureWindow.isDestroyed()) {
-      quickCaptureWindow.close();
-    }
-  });
+  // Blur listener intentionally removed — closing on blur drops user input.
+  // The window is closed via Escape key or explicit close/save actions.
 
   quickCaptureWindow.on('closed', () => {
     quickCaptureWindow = null;
@@ -878,9 +875,12 @@ app
     }
 
     // Register global quick capture shortcut
-    globalShortcut.register('CommandOrControl+Shift+N', () => {
+    const registered = globalShortcut.register('CommandOrControl+Shift+N', () => {
       createQuickCaptureWindow();
     });
+    if (!registered) {
+      log.warn('Failed to register global shortcut CommandOrControl+Shift+N — already in use?');
+    }
 
     // IPC: open quick capture from renderer
     ipcMain.handle('window:openQuickCapture', async () => {
@@ -888,10 +888,18 @@ app
       return { ok: true };
     });
 
-    // IPC: close the calling window (used by quick capture to close itself)
+    // IPC: close the calling window (only allowed for quick-capture and settings windows)
     ipcMain.handle('window:closeSelf', async event => {
       const win = BrowserWindow.fromWebContents(event.sender);
       if (win && !win.isDestroyed()) {
+        // Prevent the main window from being closed via this handler
+        const allWindows = BrowserWindow.getAllWindows();
+        const mainWin = allWindows.find(
+          w => !w.isDestroyed() && w !== quickCaptureWindow && w !== settingsWindow
+        );
+        if (win === mainWin) {
+          return { ok: false, error: 'Cannot close main window via closeSelf' };
+        }
         win.close();
       }
       return { ok: true };

--- a/apps/desktop/src/main/services/localServer.ts
+++ b/apps/desktop/src/main/services/localServer.ts
@@ -1,0 +1,283 @@
+/**
+ * Local HTTP API Server
+ *
+ * Runs inside the Electron main process, allowing external tools
+ * (Alfred, Raycast, Shortcuts, curl) to interact with notes via HTTP.
+ *
+ * Uses Node.js built-in `http` module — no additional dependencies.
+ */
+
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { randomBytes } from 'crypto';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface LocalServerHandlers {
+  listNotes: () => Promise<
+    Array<{ id: string; title: string; excerpt: string; updatedAt: string }>
+  >;
+  getNote: (id: string) => Promise<{
+    id: string;
+    title: string;
+    content: string;
+    notebookId: string;
+    createdAt: string;
+    updatedAt: string;
+    tags: string[];
+    wordCount: number;
+    isPinned: boolean;
+  } | null>;
+  createNote: (input: {
+    content: string;
+    notebookId?: string;
+  }) => Promise<{ ok: boolean; data?: { id: string }; error?: unknown }>;
+  updateNote: (id: string, content: string) => Promise<{ ok: boolean; error?: unknown }>;
+  searchNotes: (
+    query: string
+  ) => Promise<Array<{ id: string; title: string; excerpt: string; updatedAt: string }>>;
+  getNoteCount: () => Promise<number>;
+  getAppVersion: () => string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_PORT = 29168; // "readied" in phone keypad
+const TOKEN_FILE = 'api-token.txt';
+
+// ============================================================================
+// Token Management
+// ============================================================================
+
+/**
+ * Get or create an API bearer token. Stored as plaintext in the app's
+ * data directory (not user-facing secrets — local-only convenience token).
+ */
+export async function getOrCreateApiToken(dataDir: string): Promise<string> {
+  const tokenPath = join(dataDir, TOKEN_FILE);
+  try {
+    const existing = await fs.readFile(tokenPath, 'utf-8');
+    const trimmed = existing.trim();
+    if (trimmed.length >= 32) return trimmed;
+  } catch {
+    // File doesn't exist — generate a new token
+  }
+  const token = randomBytes(32).toString('hex');
+  await fs.writeFile(tokenPath, token, 'utf-8');
+  return token;
+}
+
+// ============================================================================
+// LocalServer Class
+// ============================================================================
+
+export class LocalServer {
+  private server: ReturnType<typeof createServer> | null = null;
+  private port = DEFAULT_PORT;
+  private token = '';
+
+  /**
+   * Start the HTTP API server.
+   */
+  async start(
+    port: number = DEFAULT_PORT,
+    token: string,
+    handlers: LocalServerHandlers
+  ): Promise<void> {
+    if (this.server) return; // Already running
+
+    this.port = port;
+    this.token = token;
+
+    this.server = createServer((req, res) => {
+      void this.handleRequest(req, res, handlers);
+    });
+
+    return new Promise((resolve, reject) => {
+      this.server!.on('error', reject);
+      this.server!.listen(port, '127.0.0.1', () => {
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Stop the HTTP API server.
+   */
+  stop(): Promise<void> {
+    return new Promise(resolve => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(() => {
+        this.server = null;
+        resolve();
+      });
+    });
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  getPort(): number {
+    return this.port;
+  }
+
+  // --------------------------------------------------------------------------
+  // Request Handling
+  // --------------------------------------------------------------------------
+
+  private async handleRequest(
+    req: IncomingMessage,
+    res: ServerResponse,
+    handlers: LocalServerHandlers
+  ): Promise<void> {
+    // Auth check
+    const authHeader = req.headers.authorization;
+    if (!authHeader || authHeader !== `Bearer ${this.token}`) {
+      this.sendJson(res, 401, { error: 'Unauthorized' });
+      return;
+    }
+
+    const url = new URL(req.url || '/', `http://127.0.0.1:${this.port}`);
+    const method = req.method?.toUpperCase() || 'GET';
+    const pathname = url.pathname;
+
+    try {
+      // GET /api/status
+      if (method === 'GET' && pathname === '/api/status') {
+        const noteCount = await handlers.getNoteCount();
+        this.sendJson(res, 200, {
+          status: 'ok',
+          version: handlers.getAppVersion(),
+          noteCount,
+        });
+        return;
+      }
+
+      // GET /api/notes/search?q=query
+      if (method === 'GET' && pathname === '/api/notes/search') {
+        const query = url.searchParams.get('q') || '';
+        if (!query) {
+          this.sendJson(res, 400, { error: 'Missing ?q= parameter' });
+          return;
+        }
+        const results = await handlers.searchNotes(query);
+        this.sendJson(res, 200, results);
+        return;
+      }
+
+      // POST /api/notes/quick
+      if (method === 'POST' && pathname === '/api/notes/quick') {
+        const body = await this.readBody(req);
+        const { content } = body as { content?: string };
+        if (!content) {
+          this.sendJson(res, 400, { error: 'Missing content' });
+          return;
+        }
+        const result = await handlers.createNote({ content, notebookId: 'inbox' });
+        if (result.ok && result.data) {
+          this.sendJson(res, 201, { id: result.data.id });
+        } else {
+          this.sendJson(res, 500, { error: 'Failed to create note' });
+        }
+        return;
+      }
+
+      // GET /api/notes/:id
+      if (method === 'GET' && pathname.match(/^\/api\/notes\/[^/]+$/)) {
+        const noteId = pathname.split('/').pop()!;
+        const note = await handlers.getNote(noteId);
+        if (!note) {
+          this.sendJson(res, 404, { error: 'Note not found' });
+          return;
+        }
+        this.sendJson(res, 200, note);
+        return;
+      }
+
+      // PUT /api/notes/:id
+      if (method === 'PUT' && pathname.match(/^\/api\/notes\/[^/]+$/)) {
+        const noteId = pathname.split('/').pop()!;
+        const body = await this.readBody(req);
+        const { content } = body as { content?: string };
+        if (!content) {
+          this.sendJson(res, 400, { error: 'Missing content' });
+          return;
+        }
+        const result = await handlers.updateNote(noteId, content);
+        if (result.ok) {
+          this.sendJson(res, 200, { ok: true });
+        } else {
+          this.sendJson(res, 500, { error: 'Failed to update note' });
+        }
+        return;
+      }
+
+      // POST /api/notes
+      if (method === 'POST' && pathname === '/api/notes') {
+        const body = await this.readBody(req);
+        const { content, notebookId } = body as {
+          content?: string;
+          notebookId?: string;
+        };
+        if (!content) {
+          this.sendJson(res, 400, { error: 'Missing content' });
+          return;
+        }
+        const result = await handlers.createNote({ content, notebookId });
+        if (result.ok && result.data) {
+          this.sendJson(res, 201, { id: result.data.id });
+        } else {
+          this.sendJson(res, 500, { error: 'Failed to create note' });
+        }
+        return;
+      }
+
+      // GET /api/notes
+      if (method === 'GET' && pathname === '/api/notes') {
+        const notes = await handlers.listNotes();
+        this.sendJson(res, 200, notes);
+        return;
+      }
+
+      // 404 for everything else
+      this.sendJson(res, 404, { error: 'Not found' });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Internal server error';
+      this.sendJson(res, 500, { error: message });
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private sendJson(res: ServerResponse, status: number, data: unknown): void {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  }
+
+  private readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        try {
+          const raw = Buffer.concat(chunks).toString('utf-8');
+          resolve(raw ? (JSON.parse(raw) as Record<string, unknown>) : {});
+        } catch {
+          reject(new Error('Invalid JSON body'));
+        }
+      });
+      req.on('error', reject);
+    });
+  }
+}

--- a/apps/desktop/src/main/services/localServer.ts
+++ b/apps/desktop/src/main/services/localServer.ts
@@ -8,7 +8,7 @@
  */
 
 import { createServer, IncomingMessage, ServerResponse } from 'http';
-import { randomBytes } from 'crypto';
+import { randomBytes, timingSafeEqual } from 'crypto';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
@@ -68,7 +68,7 @@ export async function getOrCreateApiToken(dataDir: string): Promise<string> {
     // File doesn't exist — generate a new token
   }
   const token = randomBytes(32).toString('hex');
-  await fs.writeFile(tokenPath, token, 'utf-8');
+  await fs.writeFile(tokenPath, token, { encoding: 'utf-8', mode: 0o600 });
   return token;
 }
 
@@ -99,7 +99,10 @@ export class LocalServer {
     });
 
     return new Promise((resolve, reject) => {
-      this.server!.on('error', reject);
+      this.server!.on('error', err => {
+        this.server = null;
+        reject(err);
+      });
       this.server!.listen(port, '127.0.0.1', () => {
         resolve();
       });
@@ -139,9 +142,14 @@ export class LocalServer {
     res: ServerResponse,
     handlers: LocalServerHandlers
   ): Promise<void> {
-    // Auth check
+    // Auth check (constant-time comparison to prevent timing attacks)
     const authHeader = req.headers.authorization;
-    if (!authHeader || authHeader !== `Bearer ${this.token}`) {
+    const expected = `Bearer ${this.token}`;
+    if (
+      !authHeader ||
+      authHeader.length !== expected.length ||
+      !timingSafeEqual(Buffer.from(authHeader), Buffer.from(expected))
+    ) {
       this.sendJson(res, 401, { error: 'Unauthorized' });
       return;
     }
@@ -174,11 +182,11 @@ export class LocalServer {
         return;
       }
 
-      // POST /api/notes/quick
+      // POST /api/notes/quick (must be checked before :id route)
       if (method === 'POST' && pathname === '/api/notes/quick') {
         const body = await this.readBody(req);
         const { content } = body as { content?: string };
-        if (!content) {
+        if (typeof content !== 'string') {
           this.sendJson(res, 400, { error: 'Missing content' });
           return;
         }
@@ -208,7 +216,7 @@ export class LocalServer {
         const noteId = pathname.split('/').pop()!;
         const body = await this.readBody(req);
         const { content } = body as { content?: string };
-        if (!content) {
+        if (typeof content !== 'string') {
           this.sendJson(res, 400, { error: 'Missing content' });
           return;
         }
@@ -228,7 +236,7 @@ export class LocalServer {
           content?: string;
           notebookId?: string;
         };
-        if (!content) {
+        if (typeof content !== 'string') {
           this.sendJson(res, 400, { error: 'Missing content' });
           return;
         }
@@ -266,9 +274,20 @@ export class LocalServer {
   }
 
   private readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+    const MAX_BODY_SIZE = 5 * 1024 * 1024; // 5 MB
+
     return new Promise((resolve, reject) => {
       const chunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      let totalSize = 0;
+      req.on('data', (chunk: Buffer) => {
+        totalSize += chunk.length;
+        if (totalSize > MAX_BODY_SIZE) {
+          req.destroy();
+          reject(new Error('Request body too large (max 5MB)'));
+          return;
+        }
+        chunks.push(chunk);
+      });
       req.on('end', () => {
         try {
           const raw = Buffer.concat(chunks).toString('utf-8');

--- a/apps/desktop/src/main/services/localServer.ts
+++ b/apps/desktop/src/main/services/localServer.ts
@@ -292,8 +292,8 @@ export class LocalServer {
         try {
           const raw = Buffer.concat(chunks).toString('utf-8');
           resolve(raw ? (JSON.parse(raw) as Record<string, unknown>) : {});
-        } catch {
-          reject(new Error('Invalid JSON body'));
+        } catch (err) {
+          reject(new Error('Invalid JSON body', { cause: err }));
         }
       });
       req.on('error', reject);

--- a/apps/desktop/src/preload/api/app.ts
+++ b/apps/desktop/src/preload/api/app.ts
@@ -38,6 +38,8 @@ export interface EmbedsAPI {
 export interface WindowsAPI {
   openNote: (noteId: string, noteTitle: string) => Promise<{ ok: boolean }>;
   openSettings: () => Promise<{ ok: boolean }>;
+  openQuickCapture: () => Promise<{ ok: boolean }>;
+  closeSelf: () => Promise<{ ok: boolean }>;
 }
 
 export interface ShareAPI {
@@ -103,6 +105,8 @@ export function createWindowsApi(): WindowsAPI {
   return {
     openNote: (noteId, noteTitle) => ipcRenderer.invoke('window:openNote', noteId, noteTitle),
     openSettings: () => ipcRenderer.invoke('window:openSettings'),
+    openQuickCapture: () => ipcRenderer.invoke('window:openQuickCapture'),
+    closeSelf: () => ipcRenderer.invoke('window:closeSelf'),
   };
 }
 

--- a/apps/desktop/src/preload/api/index.ts
+++ b/apps/desktop/src/preload/api/index.ts
@@ -56,3 +56,6 @@ export type {
   ShareAPI,
   EditorAPI,
 } from './app';
+
+export { createLocalServerApi } from './localServer';
+export type { LocalServerAPI } from './localServer';

--- a/apps/desktop/src/preload/api/localServer.ts
+++ b/apps/desktop/src/preload/api/localServer.ts
@@ -1,0 +1,23 @@
+/**
+ * Local Server Preload API
+ *
+ * Exposes local HTTP API server controls to the renderer.
+ */
+
+import { ipcRenderer } from 'electron';
+
+export interface LocalServerAPI {
+  start: (port?: number) => Promise<{ ok: boolean; port?: number; error?: string }>;
+  stop: () => Promise<{ ok: boolean }>;
+  status: () => Promise<{ running: boolean; port: number }>;
+  getToken: () => Promise<string>;
+}
+
+export function createLocalServerApi(): LocalServerAPI {
+  return {
+    start: (port?: number) => ipcRenderer.invoke('localServer:start', port),
+    stop: () => ipcRenderer.invoke('localServer:stop'),
+    status: () => ipcRenderer.invoke('localServer:status'),
+    getToken: () => ipcRenderer.invoke('localServer:getToken'),
+  };
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -32,6 +32,7 @@ import {
   createWindowsApi,
   createShareApi,
   createEditorApi,
+  createLocalServerApi,
 } from './api';
 
 import type {
@@ -59,6 +60,7 @@ import type {
   WindowsAPI,
   ShareAPI,
   EditorAPI,
+  LocalServerAPI,
 } from './api';
 
 // Re-export all types so the renderer can still import from '../preload/index'
@@ -125,6 +127,7 @@ export interface ReadiedAPI {
   theme: ThemeAPI;
   plugins: PluginsAPI;
   editor: EditorAPI;
+  localServer: LocalServerAPI;
 }
 
 // Compose and expose the API
@@ -153,6 +156,7 @@ const api: ReadiedAPI = {
   theme: createThemeApi(),
   plugins: createPluginsApi(),
   editor: createEditorApi(),
+  localServer: createLocalServerApi(),
 };
 
 contextBridge.exposeInMainWorld('readied', api);

--- a/apps/desktop/src/renderer/components/QuickCapture.module.css
+++ b/apps/desktop/src/renderer/components/QuickCapture.module.css
@@ -1,0 +1,181 @@
+/* Quick Capture — compact floating window */
+
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--bg-base, #0a0b0d);
+  color: var(--text-primary, #e4e4e7);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  padding: 0;
+  overflow: hidden;
+  border-radius: 12px;
+  -webkit-app-region: drag;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px 0;
+  -webkit-app-region: drag;
+}
+
+.title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary, #a1a1aa);
+  letter-spacing: 0.02em;
+}
+
+.closeButton {
+  -webkit-app-region: no-drag;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: var(--text-tertiary, #71717a);
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 16px;
+  line-height: 1;
+  transition: color 0.15s, background 0.15s;
+}
+
+.closeButton:hover {
+  color: var(--text-primary, #e4e4e7);
+  background: var(--bg-hover, #27272a);
+}
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 16px;
+  gap: 10px;
+  overflow: hidden;
+  -webkit-app-region: no-drag;
+}
+
+.titleInput {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle, #27272a);
+  border-radius: 8px;
+  background: var(--bg-tertiary, #18181b);
+  color: var(--text-primary, #e4e4e7);
+  font-size: 14px;
+  font-weight: 500;
+  outline: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.titleInput::placeholder {
+  color: var(--text-tertiary, #71717a);
+}
+
+.titleInput:focus {
+  border-color: var(--accent-primary, #5eead4);
+}
+
+.contentArea {
+  flex: 1;
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle, #27272a);
+  border-radius: 8px;
+  background: var(--bg-tertiary, #18181b);
+  color: var(--text-primary, #e4e4e7);
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  line-height: 1.6;
+  outline: none;
+  resize: none;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.contentArea::placeholder {
+  color: var(--text-tertiary, #71717a);
+}
+
+.contentArea:focus {
+  border-color: var(--accent-primary, #5eead4);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px 12px;
+  -webkit-app-region: no-drag;
+}
+
+.notebookSelect {
+  padding: 6px 8px;
+  border: 1px solid var(--border-subtle, #27272a);
+  border-radius: 6px;
+  background: var(--bg-tertiary, #18181b);
+  color: var(--text-secondary, #a1a1aa);
+  font-size: 12px;
+  outline: none;
+  cursor: pointer;
+  max-width: 160px;
+}
+
+.notebookSelect:focus {
+  border-color: var(--accent-primary, #5eead4);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+.cancelButton {
+  padding: 6px 14px;
+  border: 1px solid var(--border-subtle, #27272a);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary, #a1a1aa);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.cancelButton:hover {
+  background: var(--bg-hover, #27272a);
+  color: var(--text-primary, #e4e4e7);
+}
+
+.saveButton {
+  padding: 6px 16px;
+  border: none;
+  border-radius: 6px;
+  background: var(--accent-primary, #5eead4);
+  color: var(--bg-base, #0a0b0d);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.saveButton:hover:not(:disabled) {
+  background: var(--accent-hover, #99f6e4);
+}
+
+.saveButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.shortcutHint {
+  font-size: 10px;
+  color: var(--text-tertiary, #71717a);
+  margin-left: 4px;
+}

--- a/apps/desktop/src/renderer/components/QuickCapture.module.css
+++ b/apps/desktop/src/renderer/components/QuickCapture.module.css
@@ -9,7 +9,7 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   padding: 0;
   overflow: hidden;
-  border-radius: 12px;
+  /* border-radius removed: frameless windows can't have rounded corners without transparent:true */
   -webkit-app-region: drag;
 }
 

--- a/apps/desktop/src/renderer/components/QuickCapture.tsx
+++ b/apps/desktop/src/renderer/components/QuickCapture.tsx
@@ -1,0 +1,144 @@
+/**
+ * Quick Capture Component
+ *
+ * Rendered in a small floating window for rapid note creation.
+ * Opened via Cmd+Shift+N global shortcut or from the app.
+ */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import styles from './QuickCapture.module.css';
+
+export function QuickCapture() {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [notebookId, setNotebookId] = useState('inbox');
+  const [notebooks, setNotebooks] = useState<Array<{ id: string; name: string }>>([]);
+  const [saving, setSaving] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  // Load notebooks on mount
+  useEffect(() => {
+    void window.readied.notebooks.list().then(nbs => {
+      setNotebooks(nbs.map(nb => ({ id: nb.id, name: nb.name })));
+    });
+  }, []);
+
+  // Auto-focus the title input
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const handleClose = useCallback(() => {
+    void window.readied.windows.closeSelf();
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const trimmedContent = content.trim();
+    if (!trimmedContent && !title.trim()) return;
+
+    setSaving(true);
+    try {
+      // Build markdown content with title as H1 if provided
+      const markdown = title.trim() ? `# ${title.trim()}\n\n${trimmedContent}` : trimmedContent;
+
+      await window.readied.notes.create({
+        content: markdown,
+        notebookId: notebookId || undefined,
+      });
+
+      handleClose();
+    } catch {
+      // If save fails, keep the window open so user doesn't lose text
+      setSaving(false);
+    }
+  }, [content, title, notebookId, handleClose]);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Escape: close
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleClose();
+        return;
+      }
+      // Cmd+Enter or Ctrl+Enter: save
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        void handleSave();
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleClose, handleSave]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.title}>Quick Capture</span>
+        <button
+          className={styles.closeButton}
+          onClick={handleClose}
+          aria-label="Close"
+          type="button"
+        >
+          &times;
+        </button>
+      </div>
+
+      <div className={styles.body}>
+        <input
+          ref={titleRef}
+          className={styles.titleInput}
+          type="text"
+          placeholder="Title (optional)"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+        />
+        <textarea
+          className={styles.contentArea}
+          placeholder="Write your note..."
+          value={content}
+          onChange={e => setContent(e.target.value)}
+        />
+      </div>
+
+      <div className={styles.footer}>
+        <select
+          className={styles.notebookSelect}
+          value={notebookId}
+          onChange={e => setNotebookId(e.target.value)}
+        >
+          <option value="inbox">Inbox</option>
+          {notebooks
+            .filter(nb => nb.id !== 'inbox')
+            .map(nb => (
+              <option key={nb.id} value={nb.id}>
+                {nb.name}
+              </option>
+            ))}
+        </select>
+
+        <div className={styles.actions}>
+          <button className={styles.cancelButton} onClick={handleClose} type="button">
+            Cancel
+            <span className={styles.shortcutHint}>Esc</span>
+          </button>
+          <button
+            className={styles.saveButton}
+            onClick={() => void handleSave()}
+            disabled={saving || (!content.trim() && !title.trim())}
+            type="button"
+          >
+            {saving ? 'Saving...' : 'Save'}
+            <span className={styles.shortcutHint}>
+              {navigator.platform.includes('Mac') ? '\u2318' : 'Ctrl'}+\u23CE
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/QuickCapture.tsx
+++ b/apps/desktop/src/renderer/components/QuickCapture.tsx
@@ -54,10 +54,20 @@ export function QuickCapture() {
       // Build markdown content with title as H1 if provided
       const markdown = title.trim() ? `# ${title.trim()}\n\n${trimmedContent}` : trimmedContent;
 
-      await window.readied.notes.create({
+      const result = await window.readied.notes.create({
         content: markdown,
         notebookId: notebookId || undefined,
       });
+
+      if (result && typeof result === 'object' && 'ok' in result && !result.ok) {
+        const errMsg =
+          'error' in result && typeof result.error === 'string'
+            ? result.error
+            : 'Failed to save note';
+        setError(errMsg);
+        setSaving(false);
+        return;
+      }
 
       handleClose();
     } catch (err) {

--- a/apps/desktop/src/renderer/components/QuickCapture.tsx
+++ b/apps/desktop/src/renderer/components/QuickCapture.tsx
@@ -14,13 +14,25 @@ export function QuickCapture() {
   const [notebookId, setNotebookId] = useState('inbox');
   const [notebooks, setNotebooks] = useState<Array<{ id: string; name: string }>>([]);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const titleRef = useRef<HTMLInputElement>(null);
 
   // Load notebooks on mount
   useEffect(() => {
-    void window.readied.notebooks.list().then(nbs => {
-      setNotebooks(nbs.map(nb => ({ id: nb.id, name: nb.name })));
-    });
+    let cancelled = false;
+    window.readied.notebooks
+      .list()
+      .then(nbs => {
+        if (!cancelled) {
+          setNotebooks(nbs.map(nb => ({ id: nb.id, name: nb.name })));
+        }
+      })
+      .catch(err => {
+        console.error('Failed to load notebooks:', err);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Auto-focus the title input
@@ -37,6 +49,7 @@ export function QuickCapture() {
     if (!trimmedContent && !title.trim()) return;
 
     setSaving(true);
+    setError(null);
     try {
       // Build markdown content with title as H1 if provided
       const markdown = title.trim() ? `# ${title.trim()}\n\n${trimmedContent}` : trimmedContent;
@@ -47,8 +60,9 @@ export function QuickCapture() {
       });
 
       handleClose();
-    } catch {
+    } catch (err) {
       // If save fails, keep the window open so user doesn't lose text
+      setError(err instanceof Error ? err.message : 'Failed to save note');
       setSaving(false);
     }
   }, [content, title, notebookId, handleClose]);
@@ -56,6 +70,8 @@ export function QuickCapture() {
   // Keyboard shortcuts
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
+      // Ignore IME composition events
+      if (e.isComposing || e.keyCode === 229) return;
       // Escape: close
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -104,6 +120,18 @@ export function QuickCapture() {
           onChange={e => setContent(e.target.value)}
         />
       </div>
+
+      {error && (
+        <div
+          style={{
+            padding: '6px 16px',
+            color: '#f87171',
+            fontSize: 12,
+          }}
+        >
+          {error}
+        </div>
+      )}
 
       <div className={styles.footer}>
         <select

--- a/apps/desktop/src/renderer/main.tsx
+++ b/apps/desktop/src/renderer/main.tsx
@@ -17,6 +17,9 @@ const App = lazy(() => import('./App').then(m => ({ default: m.App })));
 const SettingsApp = lazy(() =>
   import('./pages/settings/SettingsApp').then(m => ({ default: m.SettingsApp }))
 );
+const QuickCapture = lazy(() =>
+  import('./components/QuickCapture').then(m => ({ default: m.QuickCapture }))
+);
 
 // Settings view needs LicenseProvider (used by AccountSection)
 const SettingsView = () => (
@@ -57,7 +60,8 @@ const LoadingFallback = () => (
 );
 
 // Render the appropriate view
-const RootComponent = view === 'settings' ? SettingsView : App;
+const RootComponent =
+  view === 'settings' ? SettingsView : view === 'quick-capture' ? QuickCapture : App;
 
 createRoot(container).render(
   <React.StrictMode>

--- a/apps/desktop/src/renderer/plugins/index.ts
+++ b/apps/desktop/src/renderer/plugins/index.ts
@@ -14,6 +14,9 @@ import { tablesPlugin } from './tables';
 import { focusModePlugin } from './focusMode';
 import { readingTimePlugin } from './readingTime';
 import { exportMarkdownPlugin } from './exportMarkdown';
+import { mermaidPlugin } from './mermaid';
+import { mathPlugin } from './math';
+import { vimModePlugin } from './vimMode';
 
 export {
   wordCountPlugin,
@@ -24,6 +27,9 @@ export {
   focusModePlugin,
   readingTimePlugin,
   exportMarkdownPlugin,
+  mermaidPlugin,
+  mathPlugin,
+  vimModePlugin,
 };
 
 /** All built-in plugin manifests. */
@@ -36,4 +42,7 @@ export const builtInPlugins: PluginManifest[] = [
   focusModePlugin,
   readingTimePlugin,
   exportMarkdownPlugin,
+  mermaidPlugin,
+  mathPlugin,
+  vimModePlugin,
 ];

--- a/apps/desktop/src/renderer/plugins/math.tsx
+++ b/apps/desktop/src/renderer/plugins/math.tsx
@@ -12,16 +12,18 @@
  * No external dependencies — lightweight placeholder approach.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { PluginManifest } from '@readied/plugin-api';
 import type { CodeBlockRendererProps } from '@readied/plugin-api';
 
-// Inject styles once
+// Inject styles once; keep a ref to remove on dispose
 let styleInjected = false;
+let styleElement: HTMLStyleElement | null = null;
 function injectMathStyles() {
   if (styleInjected) return;
   styleInjected = true;
   const style = document.createElement('style');
+  styleElement = style;
   style.textContent = `
     .math-block {
       position: relative;
@@ -88,29 +90,26 @@ function injectMathStyles() {
       70% { opacity: 1; }
       100% { opacity: 0; }
     }
-
-    /* Inline math styling in preview */
-    .markdown-preview code.language-math-inline {
-      background: var(--bg-surface, var(--bg-base));
-      border: 1px solid var(--border);
-      border-radius: 3px;
-      padding: 1px 4px;
-      font-style: italic;
-      font-family: var(--font-mono, monospace);
-      font-size: 0.9em;
-    }
   `;
   document.head.appendChild(style);
 }
 
 function MathRenderer({ code }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const copySource = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
     } catch {
       // silently fail
     }
@@ -156,6 +155,11 @@ export const mathPlugin: PluginManifest = {
       dispose() {
         unregisterMath();
         unregisterLatex();
+        if (styleElement && styleElement.parentNode) {
+          styleElement.parentNode.removeChild(styleElement);
+          styleElement = null;
+          styleInjected = false;
+        }
       },
     };
   },

--- a/apps/desktop/src/renderer/plugins/math.tsx
+++ b/apps/desktop/src/renderer/plugins/math.tsx
@@ -1,0 +1,159 @@
+/**
+ * Math / LaTeX Plugin
+ *
+ * Registers a code block renderer for "math" and "latex" language blocks.
+ * Displays LaTeX source in a styled container with a copy button.
+ * Inline math ($...$) and display math ($$...$$) are styled via a
+ * remark plugin that wraps them in recognizable spans.
+ *
+ * No external dependencies — lightweight placeholder approach.
+ */
+
+import { useState, useCallback } from 'react';
+import type { PluginManifest } from '@readied/plugin-api';
+import type { CodeBlockRendererProps } from '@readied/plugin-api';
+
+// Inject styles once
+let styleInjected = false;
+function injectMathStyles() {
+  if (styleInjected) return;
+  styleInjected = true;
+  const style = document.createElement('style');
+  style.textContent = `
+    .math-block {
+      position: relative;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      margin: 8px 0;
+      background: var(--bg-surface, var(--bg-base));
+    }
+    .math-block__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 12px;
+      background: var(--bg-elevated, var(--bg-surface));
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+    .math-block__label {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .math-block__actions {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .math-block__btn {
+      padding: 3px 10px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg-base);
+      color: var(--text-secondary);
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 150ms, color 150ms;
+    }
+    .math-block__btn:hover {
+      background: var(--accent);
+      color: var(--text-on-accent, #fff);
+      border-color: var(--accent);
+    }
+    .math-block__code {
+      padding: 12px 16px;
+      font-family: var(--font-mono, monospace);
+      font-size: 14px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: var(--text-primary);
+      text-align: center;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .math-block__copied {
+      color: var(--accent);
+      font-size: 11px;
+      animation: math-fade 1.5s ease-out forwards;
+    }
+    @keyframes math-fade {
+      0% { opacity: 1; }
+      70% { opacity: 1; }
+      100% { opacity: 0; }
+    }
+
+    /* Inline math styling in preview */
+    .markdown-preview code.language-math-inline {
+      background: var(--bg-surface, var(--bg-base));
+      border: 1px solid var(--border);
+      border-radius: 3px;
+      padding: 1px 4px;
+      font-style: italic;
+      font-family: var(--font-mono, monospace);
+      font-size: 0.9em;
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function MathRenderer({ code }: CodeBlockRendererProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copySource = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // silently fail
+    }
+  }, [code]);
+
+  return (
+    <div className="math-block">
+      <div className="math-block__header">
+        <span className="math-block__label">LaTeX Math</span>
+        <div className="math-block__actions">
+          {copied && <span className="math-block__copied">Copied!</span>}
+          <button className="math-block__btn" onClick={copySource} type="button">
+            Copy LaTeX
+          </button>
+        </div>
+      </div>
+      <div className="math-block__code">{code}</div>
+    </div>
+  );
+}
+
+export const mathPlugin: PluginManifest = {
+  id: 'readied-math',
+  name: 'Math / LaTeX',
+  version: '1.0.0',
+  description:
+    'Renders math and latex code blocks with styled containers and copy-to-clipboard support',
+
+  activate(context) {
+    injectMathStyles();
+
+    // Register for both "math" and "latex" fenced code blocks
+    const unregisterMath = context.registerCodeBlockRenderer('math-renderer', 'math', MathRenderer);
+    const unregisterLatex = context.registerCodeBlockRenderer(
+      'latex-renderer',
+      'latex',
+      MathRenderer
+    );
+
+    context.log.info('Math/LaTeX plugin activated');
+
+    return {
+      dispose() {
+        unregisterMath();
+        unregisterLatex();
+      },
+    };
+  },
+};

--- a/apps/desktop/src/renderer/plugins/math.tsx
+++ b/apps/desktop/src/renderer/plugins/math.tsx
@@ -3,8 +3,11 @@
  *
  * Registers a code block renderer for "math" and "latex" language blocks.
  * Displays LaTeX source in a styled container with a copy button.
- * Inline math ($...$) and display math ($$...$$) are styled via a
- * remark plugin that wraps them in recognizable spans.
+ *
+ * Limitation: This plugin only handles fenced code blocks (```math / ```latex).
+ * Inline math ($...$) and display math ($$...$$) require remark-math which is
+ * not currently installed. The inline CSS styles below are included for future
+ * compatibility but have no effect until remark-math is added.
  *
  * No external dependencies — lightweight placeholder approach.
  */

--- a/apps/desktop/src/renderer/plugins/mermaid.tsx
+++ b/apps/desktop/src/renderer/plugins/mermaid.tsx
@@ -10,12 +10,14 @@ import { useState, useCallback } from 'react';
 import type { PluginManifest } from '@readied/plugin-api';
 import type { CodeBlockRendererProps } from '@readied/plugin-api';
 
-// Inject styles once
+// Inject styles once; keep a ref to remove on dispose
 let styleInjected = false;
+let styleElement: HTMLStyleElement | null = null;
 function injectMermaidStyles() {
   if (styleInjected) return;
   styleInjected = true;
   const style = document.createElement('style');
+  styleElement = style;
   style.textContent = `
     .mermaid-block {
       position: relative;
@@ -86,18 +88,7 @@ function injectMermaidStyles() {
 
 function MermaidRenderer({ code }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false);
-
-  const openInLive = useCallback(() => {
-    // mermaid.live accepts base64-encoded JSON state
-    const state = JSON.stringify({
-      code,
-      mermaid: { theme: 'default' },
-      autoSync: true,
-      updateDiagram: true,
-    });
-    const encoded = btoa(state);
-    window.open(`https://mermaid.live/edit#base64:${encoded}`, '_blank');
-  }, [code]);
+  const [liveHint, setLiveHint] = useState(false);
 
   const copySource = useCallback(async () => {
     try {
@@ -109,17 +100,30 @@ function MermaidRenderer({ code }: CodeBlockRendererProps) {
     }
   }, [code]);
 
+  const copyForLive = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setLiveHint(true);
+      setTimeout(() => setLiveHint(false), 3000);
+    } catch {
+      // silently fail
+    }
+  }, [code]);
+
   return (
     <div className="mermaid-block">
       <div className="mermaid-block__header">
         <span className="mermaid-block__label">Mermaid Diagram</span>
         <div className="mermaid-block__actions">
           {copied && <span className="mermaid-block__copied">Copied!</span>}
+          {liveHint && (
+            <span className="mermaid-block__copied">Copied! Paste at mermaid.live/edit</span>
+          )}
           <button className="mermaid-block__btn" onClick={copySource} type="button">
             Copy
           </button>
-          <button className="mermaid-block__btn" onClick={openInLive} type="button">
-            Open in Mermaid Live
+          <button className="mermaid-block__btn" onClick={copyForLive} type="button">
+            Copy for Mermaid Live
           </button>
         </div>
       </div>
@@ -149,6 +153,11 @@ export const mermaidPlugin: PluginManifest = {
     return {
       dispose() {
         unregisterRenderer();
+        if (styleElement && styleElement.parentNode) {
+          styleElement.parentNode.removeChild(styleElement);
+          styleElement = null;
+          styleInjected = false;
+        }
       },
     };
   },

--- a/apps/desktop/src/renderer/plugins/mermaid.tsx
+++ b/apps/desktop/src/renderer/plugins/mermaid.tsx
@@ -3,10 +3,10 @@
  *
  * Registers a code block renderer for "mermaid" language blocks.
  * Displays the mermaid source in a styled container with a
- * "Open in Mermaid Live" button (avoids bundling the 2MB+ mermaid lib).
+ * "Copy for Mermaid Live" button (avoids bundling the 2MB+ mermaid lib).
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { PluginManifest } from '@readied/plugin-api';
 import type { CodeBlockRendererProps } from '@readied/plugin-api';
 
@@ -89,12 +89,22 @@ function injectMermaidStyles() {
 function MermaidRenderer({ code }: CodeBlockRendererProps) {
   const [copied, setCopied] = useState(false);
   const [liveHint, setLiveHint] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const liveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      if (liveTimeoutRef.current) clearTimeout(liveTimeoutRef.current);
+    };
+  }, []);
 
   const copySource = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 1500);
     } catch {
       // silently fail
     }
@@ -104,7 +114,8 @@ function MermaidRenderer({ code }: CodeBlockRendererProps) {
     try {
       await navigator.clipboard.writeText(code);
       setLiveHint(true);
-      setTimeout(() => setLiveHint(false), 3000);
+      if (liveTimeoutRef.current) clearTimeout(liveTimeoutRef.current);
+      liveTimeoutRef.current = setTimeout(() => setLiveHint(false), 3000);
     } catch {
       // silently fail
     }
@@ -137,7 +148,7 @@ export const mermaidPlugin: PluginManifest = {
   name: 'Mermaid Diagrams',
   version: '1.0.0',
   description:
-    'Renders mermaid code blocks with a styled preview container and one-click link to Mermaid Live editor',
+    'Renders mermaid code blocks with a styled preview container and copy for Mermaid Live editor',
 
   activate(context) {
     injectMermaidStyles();

--- a/apps/desktop/src/renderer/plugins/mermaid.tsx
+++ b/apps/desktop/src/renderer/plugins/mermaid.tsx
@@ -1,0 +1,155 @@
+/**
+ * Mermaid Diagram Plugin
+ *
+ * Registers a code block renderer for "mermaid" language blocks.
+ * Displays the mermaid source in a styled container with a
+ * "Open in Mermaid Live" button (avoids bundling the 2MB+ mermaid lib).
+ */
+
+import { useState, useCallback } from 'react';
+import type { PluginManifest } from '@readied/plugin-api';
+import type { CodeBlockRendererProps } from '@readied/plugin-api';
+
+// Inject styles once
+let styleInjected = false;
+function injectMermaidStyles() {
+  if (styleInjected) return;
+  styleInjected = true;
+  const style = document.createElement('style');
+  style.textContent = `
+    .mermaid-block {
+      position: relative;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      margin: 8px 0;
+      background: var(--bg-surface, var(--bg-base));
+    }
+    .mermaid-block__header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 6px 12px;
+      background: var(--bg-elevated, var(--bg-surface));
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+    .mermaid-block__label {
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .mermaid-block__actions {
+      display: flex;
+      gap: 6px;
+    }
+    .mermaid-block__btn {
+      padding: 3px 10px;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg-base);
+      color: var(--text-secondary);
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 150ms, color 150ms;
+    }
+    .mermaid-block__btn:hover {
+      background: var(--accent);
+      color: var(--text-on-accent, #fff);
+      border-color: var(--accent);
+    }
+    .mermaid-block__code {
+      padding: 12px;
+      font-family: var(--font-mono, monospace);
+      font-size: 13px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+      color: var(--text-primary);
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .mermaid-block__copied {
+      color: var(--accent);
+      font-size: 11px;
+      animation: mermaid-fade 1.5s ease-out forwards;
+    }
+    @keyframes mermaid-fade {
+      0% { opacity: 1; }
+      70% { opacity: 1; }
+      100% { opacity: 0; }
+    }
+  `;
+  document.head.appendChild(style);
+}
+
+function MermaidRenderer({ code }: CodeBlockRendererProps) {
+  const [copied, setCopied] = useState(false);
+
+  const openInLive = useCallback(() => {
+    // mermaid.live accepts base64-encoded JSON state
+    const state = JSON.stringify({
+      code,
+      mermaid: { theme: 'default' },
+      autoSync: true,
+      updateDiagram: true,
+    });
+    const encoded = btoa(state);
+    window.open(`https://mermaid.live/edit#base64:${encoded}`, '_blank');
+  }, [code]);
+
+  const copySource = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // silently fail
+    }
+  }, [code]);
+
+  return (
+    <div className="mermaid-block">
+      <div className="mermaid-block__header">
+        <span className="mermaid-block__label">Mermaid Diagram</span>
+        <div className="mermaid-block__actions">
+          {copied && <span className="mermaid-block__copied">Copied!</span>}
+          <button className="mermaid-block__btn" onClick={copySource} type="button">
+            Copy
+          </button>
+          <button className="mermaid-block__btn" onClick={openInLive} type="button">
+            Open in Mermaid Live
+          </button>
+        </div>
+      </div>
+      <div className="mermaid-block__code">{code}</div>
+    </div>
+  );
+}
+
+export const mermaidPlugin: PluginManifest = {
+  id: 'readied-mermaid',
+  name: 'Mermaid Diagrams',
+  version: '1.0.0',
+  description:
+    'Renders mermaid code blocks with a styled preview container and one-click link to Mermaid Live editor',
+
+  activate(context) {
+    injectMermaidStyles();
+
+    const unregisterRenderer = context.registerCodeBlockRenderer(
+      'mermaid-renderer',
+      'mermaid',
+      MermaidRenderer
+    );
+
+    context.log.info('Mermaid diagram plugin activated');
+
+    return {
+      dispose() {
+        unregisterRenderer();
+      },
+    };
+  },
+};

--- a/apps/desktop/src/renderer/plugins/tables.tsx
+++ b/apps/desktop/src/renderer/plugins/tables.tsx
@@ -327,7 +327,7 @@ function extractText(node: React.ReactNode): string {
   if (!node) return '';
   if (Array.isArray(node)) return node.map(extractText).join('');
   if (React.isValidElement(node)) {
-    const el = node as ReactElement<{ children?: React.ReactNode }>;
+    const el = node as ReactElement<{ children?: React.ReactNode; style?: React.CSSProperties }>;
     return extractText(el.props.children);
   }
   return '';
@@ -364,17 +364,26 @@ function SortableTable(
   const sortedTbodyChildren = useMemo(() => {
     if (!tbody) return null;
     const rows: ReactElement[] = [];
-    React.Children.forEach((tbody as ReactElement).props.children, child => {
-      if (React.isValidElement(child)) rows.push(child as ReactElement);
-    });
+    React.Children.forEach(
+      (tbody as ReactElement<{ children?: React.ReactNode }>).props.children,
+      child => {
+        if (React.isValidElement(child)) rows.push(child as ReactElement);
+      }
+    );
 
     if (sortCol === null) return rows;
 
     const sorted = [...rows].sort((a, b) => {
       const aCells: React.ReactNode[] = [];
       const bCells: React.ReactNode[] = [];
-      React.Children.forEach(a.props.children, c => aCells.push(c));
-      React.Children.forEach(b.props.children, c => bCells.push(c));
+      React.Children.forEach(
+        (a as ReactElement<{ children?: React.ReactNode }>).props.children,
+        c => aCells.push(c)
+      );
+      React.Children.forEach(
+        (b as ReactElement<{ children?: React.ReactNode }>).props.children,
+        c => bCells.push(c)
+      );
 
       const aText = extractText(aCells[sortCol] ?? '');
       const bText = extractText(bCells[sortCol] ?? '');
@@ -411,23 +420,31 @@ function SortableTable(
     <table {...rest} className="sortable-table">
       {thead && (
         <thead>
-          {React.Children.map((thead as ReactElement).props.children, trChild => {
-            if (!React.isValidElement(trChild)) return trChild;
-            return React.cloneElement(
-              trChild as ReactElement,
-              {
+          {React.Children.map(
+            (thead as ReactElement<{ children?: React.ReactNode }>).props.children,
+            trChild => {
+              if (!React.isValidElement(trChild)) return trChild;
+              const trEl = trChild as ReactElement<{
+                children?: React.ReactNode;
+                style?: React.CSSProperties;
+              }>;
+              return React.cloneElement(trEl, {
                 children: React.Children.map(
-                  (trChild as ReactElement).props.children,
+                  (trChild as ReactElement<{ children?: React.ReactNode }>).props.children,
                   (thChild, colIdx) => {
                     if (!React.isValidElement(thChild)) return thChild;
-                    const el = thChild as ReactElement;
+                    const el = thChild as ReactElement<{
+                      children?: React.ReactNode;
+                      style?: React.CSSProperties;
+                      className?: string;
+                    }>;
                     const isSorted = sortCol === colIdx;
                     const arrow = isSorted ? (sortDir === 'asc' ? ' \u25B2' : ' \u25BC') : '';
                     return React.cloneElement(el, {
                       className: `sortable-th${isSorted ? ' sorted' : ''}`,
                       onClick: () => handleHeaderClick(colIdx),
                       style: {
-                        ...(((el.props as Record<string, unknown>).style as object) ?? {}),
+                        ...(el.props.style ?? {}),
                         cursor: 'pointer',
                         userSelect: 'none' as const,
                       },
@@ -440,9 +457,9 @@ function SortableTable(
                     } as Record<string, unknown>);
                   }
                 ),
-              } as Record<string, unknown>
-            );
-          })}
+              } as Record<string, unknown>);
+            }
+          )}
         </thead>
       )}
       {tbody && sortedTbodyChildren && <tbody>{sortedTbodyChildren}</tbody>}

--- a/apps/desktop/src/renderer/plugins/vimMode.tsx
+++ b/apps/desktop/src/renderer/plugins/vimMode.tsx
@@ -1,0 +1,98 @@
+/**
+ * Vim Mode Plugin (Stub)
+ *
+ * Registers a toggle command for Vim keybindings in the CodeMirror editor.
+ * Currently a stub — @replit/codemirror-vim or @codemirror/vim is not installed.
+ * When the dependency is added in the future, this plugin will register
+ * the vim extension via context.registerExtensions().
+ *
+ * For now it shows a status indicator and logs a message directing the user
+ * to install the dependency.
+ */
+
+import type { PluginManifest } from '@readied/plugin-api';
+
+function VimStatusIndicator() {
+  return <span style={{ fontWeight: 600, fontSize: 11, letterSpacing: '0.05em' }}>VIM</span>;
+}
+
+export const vimModePlugin: PluginManifest = {
+  id: 'readied-vim-mode',
+  name: 'Vim Mode',
+  version: '1.0.0',
+  description:
+    'Optional Vim keybindings for the CodeMirror editor (stub — dependency not yet installed)',
+
+  configSchema: {
+    enabled: {
+      type: 'boolean',
+      default: false,
+      description: 'Enable Vim keybindings in the editor',
+    },
+  },
+
+  activate(context) {
+    let enabled = context.config.get<boolean>('enabled') ?? false;
+
+    const showStatus = () => {
+      context.layout.addComponent('editor-status-bar', {
+        id: 'vim-mode:status',
+        component: VimStatusIndicator,
+        order: 5,
+        meta: {},
+      });
+    };
+
+    const hideStatus = () => {
+      context.layout.removeComponent('vim-mode:status');
+    };
+
+    const enable = () => {
+      enabled = true;
+      context.config.set('enabled', true);
+      // TODO: When @codemirror/vim is installed, register the extension here:
+      // unregisterExt = context.registerExtensions('vim-keymap', [vim()]);
+      context.log.warn(
+        'Vim mode enabled but @codemirror/vim is not installed. ' +
+          'Add it to apps/desktop/package.json to activate Vim keybindings.'
+      );
+      showStatus();
+    };
+
+    const disable = () => {
+      enabled = false;
+      context.config.set('enabled', false);
+      hideStatus();
+      context.log.info('Vim mode disabled');
+    };
+
+    if (enabled) {
+      enable();
+    }
+
+    const unregisterCommand = context.registerCommand(
+      {
+        id: 'toggle',
+        name: 'Toggle Vim Mode',
+        icon: 'Terminal',
+      },
+      () => {
+        if (enabled) {
+          disable();
+        } else {
+          enable();
+        }
+        return true;
+      }
+    );
+
+    context.log.info('Vim mode plugin activated (stub)');
+
+    return {
+      dispose() {
+        hideStatus();
+        unregisterCommand();
+      },
+    };
+  },
+};

--- a/apps/desktop/src/renderer/plugins/vimMode.tsx
+++ b/apps/desktop/src/renderer/plugins/vimMode.tsx
@@ -12,9 +12,10 @@
 
 import type { PluginManifest } from '@readied/plugin-api';
 
-function VimStatusIndicator() {
-  return <span style={{ fontWeight: 600, fontSize: 11, letterSpacing: '0.05em' }}>VIM</span>;
-}
+// TODO: Uncomment when @codemirror/vim is installed
+// function VimStatusIndicator() {
+//   return <span style={{ fontWeight: 600, fontSize: 11, letterSpacing: '0.05em' }}>VIM</span>;
+// }
 
 export const vimModePlugin: PluginManifest = {
   id: 'readied-vim-mode',
@@ -34,14 +35,12 @@ export const vimModePlugin: PluginManifest = {
   activate(context) {
     let enabled = context.config.get<boolean>('enabled') ?? false;
 
-    const showStatus = () => {
-      context.layout.addComponent('editor-status-bar', {
-        id: 'vim-mode:status',
-        component: VimStatusIndicator,
-        order: 5,
-        meta: {},
-      });
-    };
+    // TODO: When @codemirror/vim is installed, call showStatus() in enable():
+    // const showStatus = () => {
+    //   context.layout.addComponent('editor-status-bar', {
+    //     id: 'vim-mode:status', component: VimStatusIndicator, order: 5, meta: {},
+    //   });
+    // };
 
     const hideStatus = () => {
       context.layout.removeComponent('vim-mode:status');
@@ -52,11 +51,12 @@ export const vimModePlugin: PluginManifest = {
       context.config.set('enabled', true);
       // TODO: When @codemirror/vim is installed, register the extension here:
       // unregisterExt = context.registerExtensions('vim-keymap', [vim()]);
+      // Don't show VIM indicator when the dependency is missing —
+      // it would mislead the user into thinking vim mode is active.
       context.log.warn(
         'Vim mode enabled but @codemirror/vim is not installed. ' +
           'Add it to apps/desktop/package.json to activate Vim keybindings.'
       );
-      showStatus();
     };
 
     const disable = () => {
@@ -66,18 +66,10 @@ export const vimModePlugin: PluginManifest = {
       context.log.info('Vim mode disabled');
     };
 
-    // Only call enable() if the config says enabled but the runtime state
-    // is currently disabled — avoids re-persisting config on every activation.
-    // Note: The VIM status indicator is intentionally not shown when the
-    // dependency is missing, since vim keybindings don't actually work yet.
+    // If the user previously enabled vim mode, silently note it in debug log.
+    // Don't warn on startup — only warn when the user explicitly toggles it on.
     if (enabled) {
-      // Don't re-persist: just show the warning and status
-      context.log.warn(
-        'Vim mode enabled but @codemirror/vim is not installed. ' +
-          'Add it to apps/desktop/package.json to activate Vim keybindings.'
-      );
-      // Don't show VIM indicator when the dependency is missing —
-      // it would mislead the user into thinking vim mode is active.
+      context.log.info('Vim mode config is enabled but @codemirror/vim is not installed');
     }
 
     const unregisterCommand = context.registerCommand(

--- a/apps/desktop/src/renderer/plugins/vimMode.tsx
+++ b/apps/desktop/src/renderer/plugins/vimMode.tsx
@@ -66,8 +66,18 @@ export const vimModePlugin: PluginManifest = {
       context.log.info('Vim mode disabled');
     };
 
+    // Only call enable() if the config says enabled but the runtime state
+    // is currently disabled — avoids re-persisting config on every activation.
+    // Note: The VIM status indicator is intentionally not shown when the
+    // dependency is missing, since vim keybindings don't actually work yet.
     if (enabled) {
-      enable();
+      // Don't re-persist: just show the warning and status
+      context.log.warn(
+        'Vim mode enabled but @codemirror/vim is not installed. ' +
+          'Add it to apps/desktop/package.json to activate Vim keybindings.'
+      );
+      // Don't show VIM indicator when the dependency is missing —
+      // it would mislead the user into thinking vim mode is active.
     }
 
     const unregisterCommand = context.registerCommand(

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm --filter @readied/web build",
   "outputDirectory": "apps/web/out",
-  "installCommand": "pnpm install",
+  "installCommand": "git config --global 'url.https://github.com/.insteadOf' 'git@github.com:' && pnpm install",
   "framework": null,
   "cleanUrls": true
 }


### PR DESCRIPTION
## Summary

### New Features
- **Local HTTP API** (port 29168): REST API with bearer auth for Alfred/Raycast/curl integration
- **Quick Capture** (Cmd+Shift+N): frameless floating window, always-on-top, auto-focus
- **Mermaid diagrams**: code block renderer with "Open in Mermaid Live" button
- **Math/LaTeX**: styled code block renderer with copy button
- **Vim mode**: plugin stub with toggle command (ready for @codemirror/vim)

### Bug Fix
- **ASAR crash fix**: `ERR_PACKAGE_PATH_NOT_EXPORTED` — workspace packages now bundled by electron-vite instead of externalized to node_modules

### Verified
- Note window already shows only editor (no sidebar) — confirmed correct

## Test plan
- [x] `pnpm typecheck` — 17/17 pass
- [x] `pnpm build` (desktop) — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quick Capture window with Cmd/Ctrl+Shift+N for rapid note entry (floating, frameless).
  * Local HTTP server controls (start/stop/status/get token) accessible from the app.
  * Math & LaTeX plugin: render math blocks and copy LaTeX.
  * Mermaid plugin: render Mermaid blocks and copy source.
  * Vim Mode plugin: toggleable Vim Mode command and status indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->