### PR TITLE
fix: exclude @readied/* from ASAR to fix startup crash

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -97,7 +97,8 @@
     },
     "files": [
       "out/**/*",
-      "!out/**/*.map"
+      "!out/**/*.map",
+      "!node_modules/@readied/**"
     ],
     "mac": {
       "category": "public.app-category.productivity",


### PR DESCRIPTION
Fixes ERR_PACKAGE_PATH_NOT_EXPORTED crash. Workspace packages already bundled by electron-vite.