### PR TITLE
fix: move @readied/* to devDependencies — fixes ASAR startup crash

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,18 +36,6 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.1",
     "@lezer/highlight": "^1.2.3",
-    "@readied/ai-core": "workspace:*",
-    "@readied/command-registry": "workspace:*",
-    "@readied/commands": "workspace:*",
-    "@readied/core": "workspace:*",
-    "@readied/embeds": "workspace:*",
-    "@readied/licensing": "workspace:*",
-    "@readied/plugin-api": "workspace:*",
-    "@readied/product-config": "workspace:*",
-    "@readied/storage-core": "workspace:*",
-    "@readied/storage-sqlite": "workspace:*",
-    "@readied/tasks": "workspace:*",
-    "@readied/wikilinks": "workspace:*",
     "@sentry/electron": "^7.11.0",
     "@tanstack/react-query": "^5.100.1",
     "better-sqlite3": "^12.9.0",
@@ -69,6 +57,18 @@
     "zustand": "^5.0.12"
   },
   "devDependencies": {
+    "@readied/ai-core": "workspace:*",
+    "@readied/command-registry": "workspace:*",
+    "@readied/commands": "workspace:*",
+    "@readied/core": "workspace:*",
+    "@readied/embeds": "workspace:*",
+    "@readied/licensing": "workspace:*",
+    "@readied/plugin-api": "workspace:*",
+    "@readied/product-config": "workspace:*",
+    "@readied/storage-core": "workspace:*",
+    "@readied/storage-sqlite": "workspace:*",
+    "@readied/tasks": "workspace:*",
+    "@readied/wikilinks": "workspace:*",
     "@types/better-sqlite3": "^7.6.12",
     "@types/mdast": "^4.0.4",
     "@types/react": "^19.2.14",
@@ -97,8 +97,7 @@
     },
     "files": [
       "out/**/*",
-      "!out/**/*.map",
-      "!node_modules/@readied/**"
+      "!out/**/*.map"
     ],
     "mac": {
       "category": "public.app-category.productivity",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,42 +95,6 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
-      '@readied/ai-core':
-        specifier: workspace:*
-        version: link:../../packages/ai-core
-      '@readied/command-registry':
-        specifier: workspace:*
-        version: link:../../packages/command-registry
-      '@readied/commands':
-        specifier: workspace:*
-        version: link:../../packages/commands
-      '@readied/core':
-        specifier: workspace:*
-        version: link:../../packages/core
-      '@readied/embeds':
-        specifier: workspace:*
-        version: link:../../packages/embeds
-      '@readied/licensing':
-        specifier: workspace:*
-        version: link:../../packages/licensing
-      '@readied/plugin-api':
-        specifier: workspace:*
-        version: link:../../packages/plugin-api
-      '@readied/product-config':
-        specifier: workspace:*
-        version: link:../../packages/product-config
-      '@readied/storage-core':
-        specifier: workspace:*
-        version: link:../../packages/storage-core
-      '@readied/storage-sqlite':
-        specifier: workspace:*
-        version: link:../../packages/storage-sqlite
-      '@readied/tasks':
-        specifier: workspace:*
-        version: link:../../packages/tasks
-      '@readied/wikilinks':
-        specifier: workspace:*
-        version: link:../../packages/wikilinks
       '@sentry/electron':
         specifier: ^7.11.0
         version: 7.11.0
@@ -189,6 +153,42 @@ importers:
         specifier: ^5.0.12
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
+      '@readied/ai-core':
+        specifier: workspace:*
+        version: link:../../packages/ai-core
+      '@readied/command-registry':
+        specifier: workspace:*
+        version: link:../../packages/command-registry
+      '@readied/commands':
+        specifier: workspace:*
+        version: link:../../packages/commands
+      '@readied/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@readied/embeds':
+        specifier: workspace:*
+        version: link:../../packages/embeds
+      '@readied/licensing':
+        specifier: workspace:*
+        version: link:../../packages/licensing
+      '@readied/plugin-api':
+        specifier: workspace:*
+        version: link:../../packages/plugin-api
+      '@readied/product-config':
+        specifier: workspace:*
+        version: link:../../packages/product-config
+      '@readied/storage-core':
+        specifier: workspace:*
+        version: link:../../packages/storage-core
+      '@readied/storage-sqlite':
+        specifier: workspace:*
+        version: link:../../packages/storage-sqlite
+      '@readied/tasks':
+        specifier: workspace:*
+        version: link:../../packages/tasks
+      '@readied/wikilinks':
+        specifier: workspace:*
+        version: link:../../packages/wikilinks
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
@@ -1032,8 +1032,8 @@ packages:
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
 
-  '@electron/node-gyp@git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {commit: 06b29aafb7708acef8b3669835c8a7857ebc92d2, repo: git@github.com:electron/node-gyp.git, type: git}
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
+    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -6023,7 +6023,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lie@3.3.0:
@@ -9228,7 +9227,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/node-gyp@git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2':
+  '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.3
@@ -9276,7 +9275,7 @@ snapshots:
 
   '@electron/rebuild@3.7.0':
     dependencies:
-      '@electron/node-gyp': git+https://git@github.com:electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2
+      '@electron/node-gyp': https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2
       '@malept/cross-spawn-promise': 2.0.0
       chalk: 4.1.2
       debug: 4.4.3
@@ -11813,22 +11812,6 @@ snapshots:
       '@vitest/utils': 2.1.9
       chai: 5.3.3
       tinyrainbow: 1.2.0
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.27)(lightningcss@1.32.0))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@20.19.27)(lightningcss@1.32.0)
-
-  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.3)(lightningcss@1.32.0))':
-    dependencies:
-      '@vitest/spy': 2.1.9
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.3)(lightningcss@1.32.0)
 
   '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))':
     dependencies:
@@ -17052,7 +17035,7 @@ snapshots:
   vitest@2.1.9(@types/node@20.19.27)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.27)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -17087,7 +17070,7 @@ snapshots:
   vitest@2.1.9(@types/node@22.19.3)(lightningcss@1.32.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.3)(lightningcss@1.32.0))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.6.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9


### PR DESCRIPTION
Moves workspace packages to devDependencies so electron-builder won't copy them into the ASAR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and reorganized dependencies for the desktop application to optimize the packaging process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->