### PR TITLE
fix: gate built-in plugins until enabled state loads + fix IPC listener cleanup

### DIFF
--- a/apps/desktop/src/preload/api/settings.ts
+++ b/apps/desktop/src/preload/api/settings.ts
@@ -36,9 +36,10 @@ export function createSettingsApi(): SettingsAPI {
 export function createIpcApi(): IpcAPI {
   return {
     on: (channel: string, listener: (...args: unknown[]) => void) => {
-      ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+      const handler = (_event: Electron.IpcRendererEvent, ...args: unknown[]) => listener(...args);
+      ipcRenderer.on(channel, handler);
       return () => {
-        ipcRenderer.removeAllListeners(channel);
+        ipcRenderer.removeListener(channel, handler);
       };
     },
   };

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -438,7 +438,7 @@ function NotesApp() {
   // Plugin runtime: init once, React observes
   const discoveredPlugins = useStore(pluginRuntimeStore, s => s.plugins);
   const pluginErrors = useStore(pluginRuntimeStore, s => s.errors);
-  const [builtInEnabledMap, setBuiltInEnabledMap] = useState<Record<string, boolean>>({});
+  const [builtInEnabledMap, setBuiltInEnabledMap] = useState<Record<string, boolean> | null>(null);
 
   useEffect(() => {
     void pluginRuntimeStore.getState().init();
@@ -469,7 +469,11 @@ function NotesApp() {
   }, []);
 
   const allPlugins = useMemo(() => {
-    const enabledBuiltIn = builtInPlugins.filter(p => builtInEnabledMap[p.id] !== false);
+    // Don't mount built-in plugins until the enabled state is loaded
+    // to avoid activating disabled plugins on the initial render
+    const enabledBuiltIn = builtInEnabledMap
+      ? builtInPlugins.filter(p => builtInEnabledMap[p.id] !== false)
+      : [];
     return [...enabledBuiltIn, ...discoveredPlugins];
   }, [discoveredPlugins, builtInEnabledMap]);
 


### PR DESCRIPTION
## Summary

This commit was pushed to #237 after the squash-merge, so it didn't make it into develop. Cherry-picked here.

- **P1: gate built-in plugins until enabled state loads** — `builtInEnabledMap` started as `{}` so `!== false` passed for every plugin, briefly activating disabled plugins on launch. Now starts as `null` and built-in plugins are excluded from `PluginHost` until `listState()` resolves
- **P2: fix IPC listener cleanup** — `ipc.on()` cleanup used `removeAllListeners(channel)` which nuked other listeners on the same channel (e.g. `pluginRuntimeStore`). Changed to `removeListener` with the specific handler reference

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)