### PR TITLE
fix: unwrap getToken IPC result + use exact range for auto-link paste

### DIFF
--- a/apps/desktop/src/preload/api/localServer.ts
+++ b/apps/desktop/src/preload/api/localServer.ts
@@ -18,6 +18,10 @@ export function createLocalServerApi(): LocalServerAPI {
     start: (port?: number) => ipcRenderer.invoke('localServer:start', port),
     stop: () => ipcRenderer.invoke('localServer:stop'),
     status: () => ipcRenderer.invoke('localServer:status'),
-    getToken: () => ipcRenderer.invoke('localServer:getToken'),
+    getToken: async () => {
+      const result = await ipcRenderer.invoke('localServer:getToken');
+      if (!result.ok) throw new Error(result.error ?? 'Failed to get token');
+      return result.value as string;
+    },
   };
 }

--- a/apps/desktop/src/renderer/components/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor.tsx
@@ -575,22 +575,26 @@ export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorPro
             userEvent: 'input.paste',
           });
 
-          // Fetch title in background and replace with markdown link
+          // Fetch title in background and replace with markdown link.
+          // Track the exact range where we inserted the URL so later
+          // edits don't cause us to rewrite the wrong occurrence.
+          const insertedFrom = from;
+          const insertedTo = from + plainText.length;
           window.readied.editor
             .fetchUrlTitle(plainText)
             .then(({ title }) => {
               if (!title) return;
-              // Find the URL in the document — it may have moved due to edits
+              // Verify the URL still sits at the expected position
               const currentDoc = view.state.doc.toString();
-              const urlIndex = currentDoc.indexOf(plainText, from > 20 ? from - 20 : 0);
-              if (urlIndex === -1) return;
+              const textAtRange = currentDoc.slice(insertedFrom, insertedTo);
+              if (textAtRange !== plainText) return;
               // Verify it's still a bare URL (not already wrapped in markdown link)
-              const charBefore = urlIndex > 0 ? currentDoc[urlIndex - 1] : '';
+              const charBefore = insertedFrom > 0 ? currentDoc[insertedFrom - 1] : '';
               if (charBefore === '(' || charBefore === '<') return;
               const mdLink = `[${title}](${plainText})`;
               view.dispatch({
-                changes: { from: urlIndex, to: urlIndex + plainText.length, insert: mdLink },
-                selection: EditorSelection.cursor(urlIndex + mdLink.length),
+                changes: { from: insertedFrom, to: insertedTo, insert: mdLink },
+                selection: EditorSelection.cursor(insertedFrom + mdLink.length),
                 userEvent: 'input.paste',
               });
             })


### PR DESCRIPTION
## Summary

Fixes two P2 findings from Codex review on PR #238.

- **`localServer.getToken()` type mismatch** — IPC handler returns `{ ok, value }` but preload declared `Promise<string>` and passed the raw object through. Any caller would send `Bearer [object Object]`. Now unwraps `value` in preload and throws on error.
- **Auto-link paste rewrites wrong URL** — `indexOf()` could match an earlier duplicate URL in the document. Now tracks the exact insert position (`from`/`to`) and verifies the text at that range still matches before replacing with the markdown link.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all pass
- [ ] Manual: paste a URL in the editor, verify auto-link replaces the correct occurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)