### PR TITLE
fix(mcp-server): non-destructive FTS5 check + FTS5 search

### DIFF
--- a/packages/mcp-server/src/__tests__/fts5-triggers.test.ts
+++ b/packages/mcp-server/src/__tests__/fts5-triggers.test.ts
@@ -152,6 +152,9 @@ describe('FTS5 runtime check', () => {
   it('openDb succeeds with an in-memory database (FTS5 available)', () => {
     const db = openDb(':memory:');
     expect(db).toBeTruthy();
+    // Verify FTS5 actually works on the returned connection
+    db.prepare('CREATE VIRTUAL TABLE _test_fts USING fts5(x)').run();
+    db.prepare('DROP TABLE _test_fts').run();
     db.close();
   });
 });

--- a/packages/mcp-server/src/db.ts
+++ b/packages/mcp-server/src/db.ts
@@ -52,20 +52,18 @@ function getDbPath(): string {
 
 /**
  * Verify that the SQLite build includes FTS5.
- * Fails loudly at startup so the error is obvious, rather than
- * surfacing later as a cryptic trigger failure on write operations.
+ * Uses sqlite_compileoption_used() to check without touching the schema,
+ * avoiding the risk of a stale temp table if the process crashes mid-check.
  */
 function assertFts5Available(db: Database.Database): void {
-  try {
-    db.prepare('CREATE VIRTUAL TABLE _fts5_check USING fts5(x)').run();
-    db.prepare('DROP TABLE _fts5_check').run();
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
+  const row = db.prepare("SELECT sqlite_compileoption_used('ENABLE_FTS5') AS v").get() as
+    | { v: number }
+    | undefined;
+  if (!row || row.v !== 1) {
     throw new Error(
       `FTS5 module is not available in this SQLite build.\n` +
         `The Readied database uses FTS5 for full-text search triggers.\n` +
-        `Without FTS5, write operations (create/update/delete notes) will fail.\n` +
-        `Original error: ${message}`
+        `Without FTS5, write operations (create/update/delete notes) will fail.`
     );
   }
 }
@@ -73,7 +71,9 @@ function assertFts5Available(db: Database.Database): void {
 export function openDb(dbPath?: string): Database.Database {
   const resolvedPath = dbPath ?? getDbPath();
   const db = new Database(resolvedPath);
-  db.pragma('journal_mode = WAL');
+  if (resolvedPath !== ':memory:') {
+    db.pragma('journal_mode = WAL');
+  }
   assertFts5Available(db);
   return db;
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -45,6 +45,14 @@ function execute(db: Database.Database, sql: string, params: unknown[] = []): nu
   return db.prepare(sql).run(...params).changes;
 }
 
+/** Escape and prepare a query string for FTS5 MATCH syntax */
+function prepareFtsQuery(input: string): string {
+  const escaped = input.replace(/["*^()]/g, ' ').trim();
+  const terms = escaped.split(/\s+/).filter(t => t.length > 0);
+  if (terms.length === 0) return '""';
+  return terms.map(t => `"${t}"*`).join(' OR ');
+}
+
 function createServer(db: Database.Database) {
   const server = new McpServer({
     name: 'readied',
@@ -202,23 +210,30 @@ function createServer(db: Database.Database) {
     }
   );
 
-  // ── Search notes ────────────────────────────────────────────────────────
+  // ── Search notes (FTS5) ──────────────────────────────────────────────────
 
   server.tool(
     'readied_search_notes',
-    'Search across all notes by content or title. Returns matching notes with snippets.',
+    'Full-text search across all notes using FTS5 with relevance ranking. Returns matching notes with snippets.',
     {
       query: z.string().describe('Search query'),
       limit: z.number().default(10),
     },
     async ({ query: q, limit }) => {
+      const trimmed = q.trim();
+      if (!trimmed) {
+        return { content: [{ type: 'text' as const, text: 'No results found.' }] };
+      }
+
+      const ftsQuery = prepareFtsQuery(trimmed);
       const results = query(
         db,
-        `SELECT id, title, substr(content, 1, 300) as snippet
-         FROM notes
-         WHERE (content LIKE ? OR title LIKE ?) AND is_deleted = 0
-         ORDER BY updated_at DESC LIMIT ?`,
-        [`%${q}%`, `%${q}%`, limit]
+        `SELECT n.id, n.title, snippet(notes_fts, 2, '**', '**', '…', 32) as snippet
+         FROM notes_fts
+         JOIN notes n ON n.id = notes_fts.id
+         WHERE notes_fts MATCH ? AND n.is_deleted = 0
+         ORDER BY bm25(notes_fts) LIMIT ?`,
+        [ftsQuery, limit]
       );
 
       if (results.length === 0) {


### PR DESCRIPTION
## Summary

Addresses two major CodeRabbit findings on PR #238.

### 1. Non-destructive FTS5 check (was Major)
`assertFts5Available` used `CREATE VIRTUAL TABLE` + `DROP TABLE` to probe FTS5. If the process crashed between those two statements, a stale `_fts5_check` table would persist and block all future startups with a false "FTS5 not available" error.

**Fix**: Use `sqlite_compileoption_used('ENABLE_FTS5')` — a read-only query that never touches the schema.

### 2. Search now actually uses FTS5 (was Major)
The docstring and PR description said search used FTS5, but the query was still `LIKE '%term%'`. The FTS5 triggers were maintaining the `notes_fts` index on every write, but no reader ever queried it.

**Fix**: `readied_search_notes` now uses `notes_fts MATCH` with `bm25()` ranking and `snippet()` highlights.

### Also
- Skip WAL pragma for `:memory:` databases (no-op but avoids confusion in tests/health checks)

## Test plan

- [x] `pnpm --filter @readied/mcp-server build` — clean
- [x] `pnpm --filter @readied/mcp-server test` — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)