### PR TITLE
fix(typecheck): unblock pnpm -r typecheck after TS 6.x bump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Build packages first
         run: pnpm build
 
+      - name: Typecheck all packages
+        run: pnpm -r typecheck
+
       - name: Typecheck desktop
         working-directory: apps/desktop
         run: pnpm typecheck

--- a/apps/desktop/src/renderer/tsconfig.json
+++ b/apps/desktop/src/renderer/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "../../out/renderer",
+    "rootDir": "..",
     "jsx": "react-jsx",
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "noEmit": true,
@@ -11,5 +12,5 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts", "../preload/index.ts"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.d.ts", "../preload/index.ts", "../preload/api/**/*.ts"]
 }

--- a/packages/licensing/tsconfig.json
+++ b/packages/licensing/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "noEmit": false,
-    "declaration": true
+    "declaration": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "__tests__"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,6 +18,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "ignoreDeprecations": "6.0"
   }
 }


### PR DESCRIPTION
## Summary

Unblocks `pnpm -r typecheck` on `develop`. After the recent TypeScript 6.x dependency bump, three preexisting failures broke the pre-push hook for everyone:

- `TS5101` baseUrl deprecation across `packages/{core,plugin-api,sync-core,wikilinks}`
- Missing `types: ["node"]` in `packages/licensing` → `Buffer` not found in `validator.ts`
- `apps/desktop/src/renderer` `rootDir` misconfiguration → `TS6059` on every cross-import from `../preload/api/*`

No runtime code changes — only tsconfig edits.

## Why this is PR-B (first in the audit stack)

Part of the full tech debt audit stack. This must land first because every subsequent stacked PR would otherwise need `--no-verify` to push. Plan reference: `/Users/tomasmaritano/.claude/plans/ultracode-quiero-correr-un-enchanted-platypus.md`.

## Changes

| File | Change |
|---|---|
| `tsconfig.base.json` | Add `"ignoreDeprecations": "6.0"` (covers 4 packages in one shot) |
| `packages/licensing/tsconfig.json` | Add `"types": ["node"]` |
| `apps/desktop/src/renderer/tsconfig.json` | Explicit `"rootDir": ".."` and include `../preload/api/**/*.ts` |
| `.github/workflows/ci.yml` | Add `pnpm -r typecheck` step to the existing typecheck job |

The new CI step ensures this regression class never sneaks in silently again — previously only `apps/desktop` was typechecked in CI, full monorepo was only checked at pre-push.

## Test plan

- [x] `pnpm -r typecheck` exits 0
- [x] Pre-push hook passes without `--no-verify`
- [ ] CI typecheck job runs both `pnpm -r typecheck` and `apps/desktop typecheck`

## Follow-ups (not in this PR)

- The `baseUrl` option will be removed in TS 7.x. Migrating away from `baseUrl` + `paths` to relative imports (or proper project references) is a separate effort.
- `rootDir = ".."` is a workaround; a cleaner solution is project references between preload and renderer, also a separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)