### PR TITLE
fix(editor): stop runtime crashes in MarkdownEditor

### DIFF
--- a/apps/desktop/src/renderer/components/MarkdownEditor.tsx
+++ b/apps/desktop/src/renderer/components/MarkdownEditor.tsx
@@ -360,6 +360,19 @@ export const MarkdownEditor = forwardRef<MarkdownEditorHandle, MarkdownEditorPro
       } = editorSettings;
 
       return [
+        // Global plugin error sink — catches exceptions thrown by view plugins
+        // (instead of crashing the EditorView). Logs to console + Sentry if wired.
+        EditorView.exceptionSink.of(err => {
+          // eslint-disable-next-line no-console
+          console.error('[CodeMirror] plugin error:', err);
+          const sentry = (
+            globalThis as unknown as {
+              Sentry?: { captureException: (e: unknown, ctx?: unknown) => void };
+            }
+          ).Sentry;
+          sentry?.captureException(err, { tags: { source: 'codemirror' } });
+        }),
+
         // Configurable: Line numbers
         lineNumbersCompartment.of(showLineNumbers ? lineNumbers() : []),
 

--- a/apps/desktop/src/renderer/plugins/tables.tsx
+++ b/apps/desktop/src/renderer/plugins/tables.tsx
@@ -1,13 +1,6 @@
 import { useState, useCallback, useMemo, type ReactElement } from 'react';
-import {
-  ViewPlugin,
-  WidgetType,
-  Decoration,
-  type ViewUpdate,
-  type DecorationSet,
-  type EditorView,
-} from '@codemirror/view';
-import { RangeSetBuilder } from '@codemirror/state';
+import { WidgetType, Decoration, EditorView, type DecorationSet } from '@codemirror/view';
+import { RangeSetBuilder, StateField, type EditorState } from '@codemirror/state';
 import type { PluginManifest, ZoneComponentProps } from '@readied/plugin-api';
 import React from 'react';
 
@@ -266,27 +259,22 @@ class TableWidget extends WidgetType {
   }
 }
 
-function buildTableDecorations(view: EditorView): DecorationSet {
+// Build table decorations from EditorState (StateField-compatible).
+// We MUST use StateField, not ViewPlugin: tables span multiple lines, and
+// CodeMirror forbids Decoration.replace() ranges that include line breaks
+// when provided by a ViewPlugin. See dev.to/marijn — "Decorations that
+// replace line breaks may not be specified via plugins".
+function buildTableDecorations(state: EditorState): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>();
-  const doc = view.state.doc;
+  const doc = state.doc;
   const docText = doc.toString();
   const ranges = findTableRanges(docText);
-  const sel = view.state.selection.main;
+  const sel = state.selection.main;
 
   for (const range of ranges) {
     // Skip if cursor is inside this table range (show raw markdown for editing)
     if (sel.from >= range.from && sel.from <= range.to) continue;
     if (sel.to >= range.from && sel.to <= range.to) continue;
-
-    // Only process tables in visible ranges
-    let visible = false;
-    for (const vr of view.visibleRanges) {
-      if (range.from <= vr.to && range.to >= vr.from) {
-        visible = true;
-        break;
-      }
-    }
-    if (!visible) continue;
 
     const parsed = parseGfmTable(range.text, range.from);
     if (!parsed) continue;
@@ -298,24 +286,18 @@ function buildTableDecorations(view: EditorView): DecorationSet {
   return builder.finish();
 }
 
-const tableViewPlugin = ViewPlugin.fromClass(
-  class {
-    decorations: DecorationSet;
-
-    constructor(view: EditorView) {
-      this.decorations = buildTableDecorations(view);
-    }
-
-    update(update: ViewUpdate) {
-      if (update.docChanged || update.selectionSet || update.viewportChanged) {
-        this.decorations = buildTableDecorations(update.view);
-      }
-    }
+const tableDecorationsField = StateField.define<DecorationSet>({
+  create(state) {
+    return buildTableDecorations(state);
   },
-  {
-    decorations: v => v.decorations,
-  }
-);
+  update(decorations, tr) {
+    if (tr.docChanged || tr.selection) {
+      return buildTableDecorations(tr.state);
+    }
+    return decorations.map(tr.changes);
+  },
+  provide: f => EditorView.decorations.from(f),
+});
 
 // ============================================================
 // Feature 3: Sortable Preview Table (React component)
@@ -493,7 +475,7 @@ export const tablesPlugin: PluginManifest = {
     // --- Feature 2: WYSIWYG toggle ---
     const enableWysiwyg = () => {
       if (unregisterWysiwyg) return;
-      unregisterWysiwyg = context.registerExtensions('table-wysiwyg', [tableViewPlugin]);
+      unregisterWysiwyg = context.registerExtensions('table-wysiwyg', [tableDecorationsField]);
       context.log.info('Table WYSIWYG enabled');
     };
 


### PR DESCRIPTION
## Summary

Two production crashes were silently breaking the markdown editor on mount. Console showed both, side-by-side, on every note open:

```
CodeMirror plugin crashed: TypeError: tags is not iterable
RangeError: Decorations that replace line breaks may not be specified via plugins
```

This PR addresses both.

## Fix 1 — Tables plugin: ViewPlugin → StateField

`apps/desktop/src/renderer/plugins/tables.tsx` registered table WYSIWYG widgets via `ViewPlugin.fromClass(...)` and called `Decoration.replace({ widget })` over multi-line table ranges. CodeMirror 6 forbids this — `Decoration.replace()` ranges that include line breaks **must** come from a `StateField`, not from a `ViewPlugin`. The runtime error is thrown inside `RangeSet.spans` during `dispatchTransactions` and the plugin self-disables (see "Table WYSIWYG disabled" in console).

Migration:
- `buildTableDecorations(view)` → `buildTableDecorations(state: EditorState)`.
- Replaced `tableViewPlugin` with `tableDecorationsField = StateField.define<DecorationSet>(...)` that:
  - `create(state)` builds the initial set.
  - `update(decos, tr)` rebuilds on `tr.docChanged || tr.selection`, otherwise maps existing decorations through `tr.changes`.
  - `provide: f => EditorView.decorations.from(f)` wires them to the view.
- Dropped the `view.visibleRanges` optimization — StateField has no viewport context. Most documents have ≤ a few tables; cost is negligible. If profiling shows hot spots later, we can dispatch viewport `StateEffect`s from a thin ViewPlugin.

The `Decoration.replace({widget})` call is unchanged — only the *registration shape* moved from ViewPlugin to StateField, which is the API contract CodeMirror enforces.

## Fix 2 — Editor exception sink (catch \"tags is not iterable\")

`TypeError: tags is not iterable` throws **inside** `HighlightStyle.style` during syntax-tree highlight — *not* at \`HighlightStyle.define\` time. Each \`tag: tags.headingN\` is fine; the iteration failure happens when a parser extension emits malformed tag metadata for a syntax tree node (likely a custom parser, candidates: wikilinks / embed inline preview / a future markdown extension).

Without root-cause repro (needs runtime reproduction in dev), we add `EditorView.exceptionSink.of(...)` at the head of the extension list in `MarkdownEditor.tsx`. This catches the throw at the plugin boundary, logs it to console + Sentry (if a global Sentry is attached), and lets the editor continue mounting. No more white-screen on open.

Root-cause fix for the offending parser will land in a follow-up PR once we repro and isolate which extension is at fault.

## Files

- `apps/desktop/src/renderer/plugins/tables.tsx` — ViewPlugin → StateField migration.
- `apps/desktop/src/renderer/components/MarkdownEditor.tsx` — add `EditorView.exceptionSink`.

## Test plan

- [x] `pnpm -r typecheck` — green.
- [x] `pnpm test` — 17/17 packages, 51 desktop tests pass.
- [ ] Manual: launch desktop, open a note containing a markdown table, confirm:
  - No \`RangeError\` in console.
  - WYSIWYG table renders when cursor is outside.
  - Raw markdown shows when cursor enters the table range.
- [ ] Manual: open a note that previously triggered \`tags is not iterable\`, confirm editor mounts (the error may still log via the new exception sink — that's expected, this PR only stops the crash).

## Stack context

This is **PR-A** in the tech-debt audit stack. Stacked on top of #265 (PR-B). When #265 merges, this PR's base will automatically retarget to \`develop\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)