### PR TITLE
refactor(stores): use named selectors instead of destructuring full state

### DIFF
--- a/apps/desktop/src/renderer/components/auth/MagicLinkFlow.tsx
+++ b/apps/desktop/src/renderer/components/auth/MagicLinkFlow.tsx
@@ -6,7 +6,7 @@
 
 import { useState, useCallback, useEffect, useRef, FormEvent } from 'react';
 import { Mail, CheckCircle, AlertCircle, X, RefreshCw } from 'lucide-react';
-import { useAuthStore } from '../../stores/authStore';
+import { useAuthStore, selectIsAuthenticated, selectError } from '../../stores/authStore';
 import styles from './MagicLinkFlow.module.css';
 
 export interface MagicLinkFlowProps {
@@ -17,7 +17,9 @@ export interface MagicLinkFlowProps {
 type Step = 'email' | 'sent' | 'verifying' | 'success' | 'error';
 
 export function MagicLinkFlow({ onSuccess, onCancel }: MagicLinkFlowProps) {
-  const { requestMagicLink, isAuthenticated, error: authError } = useAuthStore();
+  const requestMagicLink = useAuthStore(state => state.requestMagicLink);
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const authError = useAuthStore(selectError);
   const [step, setStep] = useState<Step>('email');
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);

--- a/apps/desktop/src/renderer/components/sync/EnableSyncModal.tsx
+++ b/apps/desktop/src/renderer/components/sync/EnableSyncModal.tsx
@@ -11,9 +11,9 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Cloud, Mail, CheckCircle, X, RefreshCw, Sparkles } from 'lucide-react';
-import { useAuthStore } from '../../stores/authStore';
-import { useLicense } from '../../contexts/LicenseContext';
 import { getProductConfig } from '@readied/product-config';
+import { useAuthStore, selectIsAuthenticated, selectError } from '../../stores/authStore';
+import { useLicense } from '../../contexts/LicenseContext';
 import styles from './LoginModal.module.css';
 
 interface EnableSyncModalProps {
@@ -46,7 +46,9 @@ export function EnableSyncModal({ isOpen, onClose }: EnableSyncModalProps) {
   const [isResending, setIsResending] = useState(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const { requestMagicLink, isAuthenticated, error: authError } = useAuthStore();
+  const requestMagicLink = useAuthStore(state => state.requestMagicLink);
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const authError = useAuthStore(selectError);
   const { state: licenseState, openSubscribe } = useLicense();
   const config = useMemo(() => getProductConfig(), []);
   const proPricing = config.plans.pro.pricing!;

--- a/apps/desktop/src/renderer/pages/settings/sections/AccountSection.tsx
+++ b/apps/desktop/src/renderer/pages/settings/sections/AccountSection.tsx
@@ -17,8 +17,18 @@ import {
   ChevronRight,
 } from 'lucide-react';
 import { getProductConfig } from '@readied/product-config';
-import { useAuthStore } from '../../../stores/authStore';
-import { useSyncStore } from '../../../stores/syncStore';
+import {
+  useAuthStore,
+  selectUser,
+  selectIsAuthenticated,
+  selectIsLoading,
+} from '../../../stores/authStore';
+import {
+  useSyncStore,
+  selectStatus,
+  selectLastSyncAt,
+  selectConflicts,
+} from '../../../stores/syncStore';
 import { useLicense } from '../../../contexts/LicenseContext';
 import { SettingGroup } from '../components/SettingGroup';
 import { SettingRow } from '../components/SettingRow';
@@ -39,8 +49,15 @@ function formatBytes(bytes: number): string {
 }
 
 export function AccountSection() {
-  const { user, isAuthenticated, isLoading, logout, loadSession } = useAuthStore();
-  const { syncNow, status: syncStatus, lastSyncAt, conflicts } = useSyncStore();
+  const user = useAuthStore(selectUser);
+  const isAuthenticated = useAuthStore(selectIsAuthenticated);
+  const isLoading = useAuthStore(selectIsLoading);
+  const logout = useAuthStore(state => state.logout);
+  const loadSession = useAuthStore(state => state.loadSession);
+  const syncNow = useSyncStore(state => state.syncNow);
+  const syncStatus = useSyncStore(selectStatus);
+  const lastSyncAt = useSyncStore(selectLastSyncAt);
+  const conflicts = useSyncStore(selectConflicts);
   const { state: licenseState, openSubscribe } = useLicense();
   const [showMagicLinkFlow, setShowMagicLinkFlow] = useState(false);
   const [message, setMessage] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Three components destructured the full auth/sync store, causing them to re-render on **every** state change in that store — even fields they never read. Migrated each to per-field selector calls. All three stores already exported named selectors; consumers just weren't using them.

## Audit finding vs reality

The audit flagged \`syncStore\`, \`authStore\`, and \`settingsStore\` as having NO selectors and tagged it severity-High. Checking the source, all three already export named selectors at the bottom of each file (e.g. \`selectStatus\`, \`selectUser\`, \`selectAi\`). The real bug was much smaller: **three consumer files** still destructured the full state hook. This PR fixes those three files.

## Files

| File | Before | After |
|---|---|---|
| \`components/auth/MagicLinkFlow.tsx\` | \`const { requestMagicLink, isAuthenticated, error: authError } = useAuthStore()\` | 3 individual selector calls |
| \`components/sync/EnableSyncModal.tsx\` | same trio | 3 individual selector calls |
| \`pages/settings/sections/AccountSection.tsx\` | 5 auth fields + 4 sync fields destructured at once | 9 individual selector calls |

No behavior change; just selector subscription tightening.

## Why this matters

With \`const { user } = useAuthStore()\`, React+Zustand subscribes the component to the entire store. If \`isLoading\` flips somewhere else, this component re-renders, even though it never reads \`isLoading\`. With \`useAuthStore(selectUser)\`, the component only re-renders when \`user\` itself changes by reference.

Profile with React DevTools to confirm reduced render counts on auth/sync state churn (e.g. during a sync cycle, the magic-link modal should no longer flicker).

## Test plan

- [x] \`pnpm -r typecheck\` — green.
- [x] \`pnpm test\` — 17/17 packages.
- [ ] Manual: open the magic-link flow while a sync cycle runs. Confirm no visible flicker on the modal.

## Stack context

**PR-H** in the audit stack. Stacked on top of #267 (PR-C). Retargets to \`develop\` automatically as predecessors merge.

## Note

The audit's \"god stores\" finding (300+ lines on sync, 270+ on settings) is real but the *selector* claim was overstated. If perceived churn remains a problem, the next iteration could:
- Add \`useShallow\` for grouped multi-field selectors where atomic re-render is needed.
- Or split very wide stores into sub-stores.

Neither is in scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)