### PR TITLE
chore(mcp-server): migrate to registerTool API + FTS5 for read_note

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -54,14 +54,16 @@ function createServer(db: Database) {
 
   // ── List notes ──────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_list_notes',
-    'List notes in Readied. Returns titles, IDs, and metadata.',
     {
-      notebook: z.string().optional().describe('Filter by notebook name'),
-      limit: z.number().default(20).describe('Max notes to return'),
-      includeTrash: z.boolean().default(false).describe('Include trashed notes'),
-      status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
+      description: 'List notes in Readied. Returns titles, IDs, and metadata.',
+      inputSchema: {
+        notebook: z.string().optional().describe('Filter by notebook name'),
+        limit: z.number().default(20).describe('Max notes to return'),
+        includeTrash: z.boolean().default(false).describe('Include trashed notes'),
+        status: z.enum(['active', 'on_hold', 'completed', 'dropped']).optional(),
+      },
     },
     async ({ notebook, limit, includeTrash, status }) => {
       let sql = `
@@ -104,12 +106,14 @@ function createServer(db: Database) {
 
   // ── Read note ───────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_read_note',
-    'Read the full content of a note by ID or title search.',
     {
-      id: z.string().optional().describe('Note ID (exact match)'),
-      title: z.string().optional().describe('Title to search for (partial match)'),
+      description: 'Read the full content of a note by ID or title search.',
+      inputSchema: {
+        id: z.string().optional().describe('Note ID (exact match)'),
+        title: z.string().optional().describe('Title to search for (FTS5)'),
+      },
     },
     async ({ id, title }) => {
       let note: Record<string, unknown> | null = null;
@@ -117,11 +121,29 @@ function createServer(db: Database) {
       if (id) {
         note = queryOne(db, 'SELECT id, title, content, notebook_id FROM notes WHERE id = ?', [id]);
       } else if (title) {
+        // Use FTS5 to find the best-matching live note by title.
+        // Falls back to a parameterized LIKE if FTS produced no hit, so this
+        // tool still works on freshly-restored DBs where the FTS index is empty.
+        const ftsQuery = prepareFtsQuery(title);
         note = queryOne(
           db,
-          'SELECT id, title, content, notebook_id FROM notes WHERE title LIKE ? AND is_deleted = 0 ORDER BY updated_at DESC LIMIT 1',
-          [`%${title}%`]
+          `SELECT n.id, n.title, n.content, n.notebook_id
+             FROM notes_fts
+             JOIN notes n ON n.id = notes_fts.id
+             WHERE notes_fts MATCH ? AND n.is_deleted = 0
+             ORDER BY bm25(notes_fts) LIMIT 1`,
+          [ftsQuery]
         );
+        if (!note) {
+          note = queryOne(
+            db,
+            `SELECT id, title, content, notebook_id
+               FROM notes
+              WHERE title LIKE '%' || ? || '%' AND is_deleted = 0
+              ORDER BY updated_at DESC LIMIT 1`,
+            [title]
+          );
+        }
       }
 
       if (!note) {
@@ -136,12 +158,14 @@ function createServer(db: Database) {
 
   // ── Create note ─────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_create_note',
-    'Create a new note in Readied. Content should be markdown.',
     {
-      content: z.string().describe('Markdown content for the note'),
-      notebook: z.string().optional().describe('Notebook name (defaults to Inbox)'),
+      description: 'Create a new note in Readied. Content should be markdown.',
+      inputSchema: {
+        content: z.string().describe('Markdown content for the note'),
+        notebook: z.string().optional().describe('Notebook name (defaults to Inbox)'),
+      },
     },
     async ({ content, notebook }) => {
       const id = crypto.randomUUID();
@@ -174,12 +198,14 @@ function createServer(db: Database) {
 
   // ── Update note ─────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_update_note',
-    'Update an existing note. Replaces the full content.',
     {
-      id: z.string().describe('Note ID'),
-      content: z.string().describe('New markdown content'),
+      description: 'Update an existing note. Replaces the full content.',
+      inputSchema: {
+        id: z.string().describe('Note ID'),
+        content: z.string().describe('New markdown content'),
+      },
     },
     async ({ id, content }) => {
       const now = new Date().toISOString();
@@ -205,12 +231,15 @@ function createServer(db: Database) {
 
   // ── Search notes (FTS5) ──────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_search_notes',
-    'Full-text search across all notes using FTS5 with relevance ranking. Returns matching notes with snippets.',
     {
-      query: z.string().describe('Search query'),
-      limit: z.number().default(10),
+      description:
+        'Full-text search across all notes using FTS5 with relevance ranking. Returns matching notes with snippets.',
+      inputSchema: {
+        query: z.string().describe('Search query'),
+        limit: z.number().default(10),
+      },
     },
     async ({ query: q, limit }) => {
       const trimmed = q.trim();
@@ -246,30 +275,39 @@ function createServer(db: Database) {
 
   // ── List notebooks ──────────────────────────────────────────────────────
 
-  server.tool('readied_list_notebooks', 'List all notebooks in Readied.', {}, async () => {
-    const notebooks = query(
-      db,
-      `SELECT nb.id, nb.name, nb.parent_id, COUNT(n.id) as note_count
+  server.registerTool(
+    'readied_list_notebooks',
+    {
+      description: 'List all notebooks in Readied.',
+      inputSchema: {},
+    },
+    async () => {
+      const notebooks = query(
+        db,
+        `SELECT nb.id, nb.name, nb.parent_id, COUNT(n.id) as note_count
          FROM notebooks nb
          LEFT JOIN notes n ON n.notebook_id = nb.id AND n.is_deleted = 0
          GROUP BY nb.id
          ORDER BY nb.name`
-    );
+      );
 
-    const text = notebooks
-      .map(nb => `- **${nb.name}** (${nb.note_count} notes) — ID: ${nb.id}`)
-      .join('\n');
+      const text = notebooks
+        .map(nb => `- **${nb.name}** (${nb.note_count} notes) — ID: ${nb.id}`)
+        .join('\n');
 
-    return { content: [{ type: 'text' as const, text: text || 'No notebooks found.' }] };
-  });
+      return { content: [{ type: 'text' as const, text: text || 'No notebooks found.' }] };
+    }
+  );
 
   // ── Trash note ──────────────────────────────────────────────────────────
 
-  server.tool(
+  server.registerTool(
     'readied_trash_note',
-    'Move a note to trash (soft delete).',
     {
-      id: z.string().describe('Note ID'),
+      description: 'Move a note to trash (soft delete).',
+      inputSchema: {
+        id: z.string().describe('Note ID'),
+      },
     },
     async ({ id }) => {
       const changes = execute(


### PR DESCRIPTION
## Summary

Two changes in \`packages/mcp-server/src/index.ts\`:

### 1. \`server.tool()\` → \`server.registerTool()\` (MCP SDK 1.29)

All 7 call sites migrated:

| Tool | |
|---|---|
| \`readied_list_notes\` | ✅ |
| \`readied_read_note\` | ✅ |
| \`readied_create_note\` | ✅ |
| \`readied_update_note\` | ✅ |
| \`readied_search_notes\` | ✅ |
| \`readied_list_notebooks\` | ✅ |
| \`readied_trash_note\` | ✅ |

The old \`tool()\` overload is deprecated in \`@modelcontextprotocol/sdk\` (TS6387 in the IDE). \`registerTool\` takes a config object \`{description?, inputSchema?, outputSchema?, annotations?, _meta?}\` instead of positional args, so future evolution (output schemas, annotations) is additive without breaking changes.

### 2. \`readied_read_note\`: FTS5 title search, LIKE as fallback

The previous title search did \`title LIKE '%' || ? || '%'\` which:
- can't use any index (wildcard-prefix LIKE),
- has no relevance ranking.

New flow: build the FTS5 query via the existing \`prepareFtsQuery()\` (same path as \`readied_search_notes\`), bm25-rank, take the top hit. If FTS returns nothing (index rebuild in progress, freshly restored DB, etc.), fall back to the parameterized LIKE on the live table so the tool still works in degraded states.

\`\`\`ts
const ftsQuery = prepareFtsQuery(title);
note = queryOne(db,
  \`SELECT n.id, n.title, n.content, n.notebook_id
     FROM notes_fts JOIN notes n ON n.id = notes_fts.id
     WHERE notes_fts MATCH ? AND n.is_deleted = 0
     ORDER BY bm25(notes_fts) LIMIT 1\`,
  [ftsQuery]
);
if (!note) {
  // FTS index might not have caught up — fall back
  note = queryOne(db, \`SELECT ... WHERE title LIKE '%' || ? || '%' ...\`, [title]);
}
\`\`\`

## Test plan

- [x] \`pnpm --filter @readied/mcp-server build\` — clean.
- [x] \`pnpm --filter @readied/mcp-server test\` — 5/5 (the FTS5 trigger test from #264 still passes).
- [ ] Manual: \`node packages/mcp-server/dist/index.js\` against a Readied DB, then via Claude Code exercise each of the 7 tools.

## Stack context

**PR-J** in the audit stack. Stacked on top of #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B). Retargets to \`develop\` automatically as predecessors merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)