### PR TITLE
fix(backup): integrity-check restored db and roll back on failure

### DIFF
--- a/apps/desktop/src/main/handlers/dataHandlers.ts
+++ b/apps/desktop/src/main/handlers/dataHandlers.ts
@@ -6,6 +6,7 @@
 
 import { join } from 'path';
 import { writeFile } from 'fs/promises';
+import { copyFileSync, existsSync, unlinkSync } from 'fs';
 import { ipcMain, dialog, shell, app } from 'electron';
 import {
   createBackup,
@@ -48,18 +49,76 @@ export function registerDataHandlers(deps: DataHandlerDeps): void {
 
   // Restore from backup
   ipcMain.handle('data:backup:restore', async (_event, backupPath: string) => {
-    // Close current database connection
     const currentDb = getDb();
     if (currentDb) {
       currentDb.close();
     }
 
+    // Copies backup over the live db file and writes a `.pre-restore` safety
+    // copy of the previous live db (used by the rollback path below).
     const result = restoreBackup(backupPath, paths.database);
+    if (!result.success) {
+      // restoreBackup never touched the live db, just reopen it.
+      setDb(createDatabase(paths.database));
+      return result;
+    }
 
-    // Reconnect to database
-    const newDb = createDatabase(paths.database);
-    runMigrations(newDb, allMigrations);
+    const safetyPath = paths.database + '.pre-restore';
+    const rollback = (reason: string): typeof result => {
+      if (existsSync(safetyPath)) {
+        copyFileSync(safetyPath, paths.database);
+      }
+      setDb(createDatabase(paths.database));
+      return { success: false, error: reason };
+    };
+
+    let newDb: ReturnType<typeof createDatabase>;
+    try {
+      newDb = createDatabase(paths.database);
+    } catch (err) {
+      return rollback(
+        `Could not open restored database: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    // PRAGMA integrity_check returns a single row `{ integrity_check: 'ok' }`
+    // on a healthy database, or one or more rows describing the corruption.
+    // We refuse to swap to a corrupt restore and roll back to the safety copy.
+    try {
+      const row = newDb.prepare<{ integrity_check: string }>('PRAGMA integrity_check').get();
+      if (row?.integrity_check !== 'ok') {
+        newDb.close();
+        return rollback(
+          `Backup failed integrity check (${row?.integrity_check ?? 'unknown error'}). Previous database has been restored.`
+        );
+      }
+    } catch (err) {
+      newDb.close();
+      return rollback(
+        `Backup integrity check threw: ${err instanceof Error ? err.message : String(err)}. Previous database has been restored.`
+      );
+    }
+
+    // Backup is intact — apply migrations to bring older schemas current.
+    try {
+      runMigrations(newDb, allMigrations);
+    } catch (err) {
+      newDb.close();
+      return rollback(
+        `Migrations failed on restored database: ${err instanceof Error ? err.message : String(err)}. Previous database has been restored.`
+      );
+    }
+
     setDb(newDb);
+
+    // Restore succeeded — discard the safety copy.
+    if (existsSync(safetyPath)) {
+      try {
+        unlinkSync(safetyPath);
+      } catch {
+        // best-effort cleanup; not fatal
+      }
+    }
 
     return result;
   });


### PR DESCRIPTION
## Summary

Hardens the restore-from-backup flow in \`apps/desktop/src/main/handlers/dataHandlers.ts\` so a corrupt backup can't quietly leave the user with a broken live database.

## Old flow (problem)

1. Close current db.
2. \`copyFileSync(backup, live)\`.
3. Open the new db, run migrations, swap reference.

Trusts the backup file. If it was corrupt (interrupted write, bit rot, hostile file), the user loses the working db and gets cryptic SQLite errors on the next read.

## New flow

1. Close current db.
2. \`restoreBackup()\` copies backup over live and writes a \`.pre-restore\` safety copy of the previous db.
3. **Open the restored db.**
4. **\`PRAGMA integrity_check\`** — must return \`'ok'\`.
5. \`runMigrations()\` to bring older backups current.
6. Swap the db reference and delete the safety copy.

Any failure at steps 3-5 rolls back to the safety copy and returns a clear, user-readable error describing which step failed. The user is never left with a corrupt or partially-migrated live database.

## Audit refinements (relative to the original plan)

The B10 / B11 items in the audit turned out to already be addressed or factually incorrect:

| Audit ID | Claim | Reality |
|---|---|---|
| **B10** | Missing index on \`notes.needs_sync\` → full table scan on sync | **Already fixed** — migration \`011_sync_tracking\` declares \`CREATE INDEX IF NOT EXISTS idx_notes_needs_sync ON notes(needs_sync) WHERE needs_sync = 1\` (partial index, exactly what the audit recommended). |
| **B11** | FTS5 triggers don't share an explicit txn → drift risk | **False positive** — SQLite triggers run within the same implicit transaction as the parent statement. If the trigger throws, the parent INSERT/UPDATE rolls back. The FTS index can't drift from the notes table this way. |
| **B12** | Backup restore has no integrity check / no schema version replay | **Partially valid** — migrations were already replayed, but integrity check was missing. This PR adds it. |

So PR-I's actual scope is much narrower than the audit suggested. That's fine — the goal is to address real issues, not invent them.

## Test plan

- [x] \`pnpm --filter @readied/desktop typecheck:main\` — green.
- [ ] Manual: restore a corrupt backup file → expect error message + previous db intact.
- [ ] Manual: restore a valid old backup → migrations bring it current; safety copy deleted.

## Stack context

**PR-I** in the audit stack. Stacked on top of #270 (PR-J) → #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B). Retargets to \`develop\` automatically as predecessors merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)