### PR TITLE
refactor(ipc): add typed IPC registry, migrate aiKeyHandlers as proof

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -54,6 +54,7 @@
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",
     "unist-util-visit": "^5.1.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.13"
   },
   "devDependencies": {

--- a/apps/desktop/src/main/handlers/aiKeyHandlers.ts
+++ b/apps/desktop/src/main/handlers/aiKeyHandlers.ts
@@ -2,35 +2,62 @@
  * AI Key Storage IPC Handlers
  *
  * Handles saving, retrieving, and managing AI provider API keys.
+ *
+ * Inputs are validated at the IPC boundary via Zod. Renderer-supplied
+ * provider names and keys are bounded in length and shape — a malformed
+ * payload throws an IpcValidationError before ever reaching aiKeyStorage.
  */
 
-import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { AiKeyStorage } from './types.js';
 
 export interface AiKeyHandlerDeps {
   aiKeyStorage: AiKeyStorage;
 }
 
+// A provider name is short, kebab-case-ish, and ASCII. Cap at 64 to defend
+// against accidental large inputs.
+const ProviderSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Provider name must be alphanumeric (with _ or -)');
+
+// Keys can be long (sk-... up to a few hundred chars on some providers);
+// 4096 is well above anything real and well below "this is junk".
+const ApiKeySchema = z.string().min(1).max(4096);
+
 export function registerAiKeyHandlers(deps: AiKeyHandlerDeps): void {
   const { aiKeyStorage } = deps;
 
-  ipcMain.handle('ai:saveKey', async (_event, provider: string, apiKey: string) => {
-    await aiKeyStorage.saveKey(provider, apiKey);
+  defineIpcHandler({
+    channel: 'ai:saveKey',
+    args: z.tuple([ProviderSchema, ApiKeySchema]),
+    handler: (provider, apiKey) => aiKeyStorage.saveKey(provider, apiKey),
   });
 
-  ipcMain.handle('ai:getKey', async (_event, provider: string) => {
-    return aiKeyStorage.getKey(provider);
+  defineIpcHandler({
+    channel: 'ai:getKey',
+    args: z.tuple([ProviderSchema]),
+    handler: provider => aiKeyStorage.getKey(provider),
   });
 
-  ipcMain.handle('ai:removeKey', async (_event, provider: string) => {
-    await aiKeyStorage.removeKey(provider);
+  defineIpcHandler({
+    channel: 'ai:removeKey',
+    args: z.tuple([ProviderSchema]),
+    handler: provider => aiKeyStorage.removeKey(provider),
   });
 
-  ipcMain.handle('ai:hasKey', async (_event, provider: string) => {
-    return aiKeyStorage.hasKey(provider);
+  defineIpcHandler({
+    channel: 'ai:hasKey',
+    args: z.tuple([ProviderSchema]),
+    handler: provider => aiKeyStorage.hasKey(provider),
   });
 
-  ipcMain.handle('ai:listConnectedProviders', async () => {
-    return aiKeyStorage.listProviders();
+  defineIpcHandler({
+    channel: 'ai:listConnectedProviders',
+    args: z.tuple([]),
+    handler: () => aiKeyStorage.listProviders(),
   });
 }

--- a/apps/desktop/src/main/ipc/registry.ts
+++ b/apps/desktop/src/main/ipc/registry.ts
@@ -1,0 +1,59 @@
+/**
+ * Typed IPC handler registry.
+ *
+ * Wraps `ipcMain.handle()` with Zod validation at the boundary. Renderer
+ * input is treated as untrusted: if the schema doesn't accept the args,
+ * the handler throws BEFORE the business logic runs, and the renderer
+ * sees a structured "invalid args" error instead of a downstream crash.
+ *
+ * Pattern:
+ *
+ *   defineIpcHandler({
+ *     channel: 'ai:saveKey',
+ *     args: z.tuple([z.string().min(1), z.string().min(1)]),
+ *     handler: (provider, apiKey) => aiKeyStorage.saveKey(provider, apiKey),
+ *   });
+ *
+ * Notes:
+ * - `args` is a Zod tuple matching the positional renderer arguments.
+ *   Use `z.tuple([])` for no-arg handlers.
+ * - The schema runs on every invocation. Keep it tight (length caps,
+ *   enums) — schemas are the contract.
+ */
+
+import { ipcMain } from 'electron';
+import { z } from 'zod';
+
+export interface DefineIpcHandlerConfig<
+  Schema extends z.ZodTuple<z.ZodTypeAny[], z.ZodTypeAny | null>,
+  Return,
+> {
+  /** IPC channel name (e.g. 'ai:saveKey'). Must be unique. */
+  channel: string;
+  /** Zod tuple describing the positional args sent by the renderer. */
+  args: Schema;
+  /** Business logic. Receives validated args, never raw input. */
+  handler: (...args: z.infer<Schema>) => Promise<Return> | Return;
+}
+
+export class IpcValidationError extends Error {
+  readonly channel: string;
+  constructor(channel: string, message: string) {
+    super(`Invalid IPC args for "${channel}": ${message}`);
+    this.name = 'IpcValidationError';
+    this.channel = channel;
+  }
+}
+
+export function defineIpcHandler<
+  Schema extends z.ZodTuple<z.ZodTypeAny[], z.ZodTypeAny | null>,
+  Return,
+>(config: DefineIpcHandlerConfig<Schema, Return>): void {
+  ipcMain.handle(config.channel, async (_event, ...rawArgs: unknown[]) => {
+    const parsed = config.args.safeParse(rawArgs);
+    if (!parsed.success) {
+      throw new IpcValidationError(config.channel, parsed.error.message);
+    }
+    return config.handler(...(parsed.data as z.infer<Schema>));
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
       zustand:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.15)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))


### PR DESCRIPTION
## Summary

Scoped first slice of **PR-F**. The audit's PR-F bundled IPC validation + keychain (keytar) + HMAC license files into one PR — that's three independent security efforts, each with their own review surface. This PR ships just the **typed IPC registry** plus a single handler migration to prove the pattern.

The other two slices (keychain credential storage, HMAC license signing) will land as their own PRs.

## What this PR introduces

### 1. \`apps/desktop/src/main/ipc/registry.ts\`

A small \`defineIpcHandler({channel, args, handler})\` wrapper around \`ipcMain.handle()\` with Zod tuple validation at the boundary:

\`\`\`ts
defineIpcHandler({
  channel: 'ai:saveKey',
  args: z.tuple([ProviderSchema, ApiKeySchema]),
  handler: (provider, apiKey) => aiKeyStorage.saveKey(provider, apiKey),
});
\`\`\`

Renderer-supplied args are validated **before** business logic runs. An invalid payload throws \`IpcValidationError\` at the boundary, so the renderer sees a structured error instead of a downstream crash deep inside storage code.

### 2. \`aiKeyHandlers.ts\` migrated as the proof

5 channels migrated. Schemas:

| Schema | Constraint | Why |
|---|---|---|
| \`ProviderSchema\` | string, 1–64 chars, \`[a-zA-Z0-9_-]+\` | Anti-garbage; matches real provider IDs |
| \`ApiKeySchema\` | string, 1–4096 chars | Conservative cap — well above real API key lengths, well below "this is junk" |

These are bounds-checks, not credential-at-rest hardening (that's the keychain slice).

### 3. \`apps/desktop/package.json\`

Adds \`zod ^4.4.3\` as a direct dep (it was already used in 4 workspace packages but not exposed to desktop main).

## What this PR does NOT include

- **Keychain integration** (B3 — AI keys stored unencrypted). Needs \`keytar\` + electron-builder integration + a one-time migration on first launch. Separate PR.
- **HMAC license signing** (B4). Separate PR with its own review.
- **Migration of the other 12 handler modules.** Once this pattern is reviewed, the rest can follow in focused per-module PRs (notes, notebooks, plugins, sync, etc.).

## Test plan

- [x] \`pnpm -r typecheck\` — green.
- [x] \`pnpm test\` — all packages green.
- [ ] Manual: launch desktop, save an AI key via Settings → AI, then load it back. Verify the existing flow still works (no behavior change for valid inputs).
- [ ] Manual: send a malformed payload via DevTools (\`window.readied.ai.saveKey({not: 'a string'}, 'key')\`). Expect an \`IpcValidationError\` in the renderer console.

## Audit linkage

| Audit ID | Status |
|---|---|
| **B2** — IPC handlers accept raw strings | Partially addressed for AI-key surface; pattern in place for the rest |
| **B3** — AI keys unencrypted (keychain) | Separate PR |
| **B4** — License files unsigned (HMAC) | Separate PR |

## Stack context

**PR-F1** in the audit stack. Stacked on top of #271 (PR-I) → #270 (PR-J) → #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B). Retargets to \`develop\` automatically as predecessors merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)