### PR TITLE
refactor(ipc): migrate light handlers to defineIpcHandler (PR-F4)

### DIFF
--- a/apps/desktop/src/main/handlers/licenseHandlers.ts
+++ b/apps/desktop/src/main/handlers/licenseHandlers.ts
@@ -5,7 +5,8 @@
  * Fetches subscription status from API with local caching.
  */
 
-import { ipcMain, shell } from 'electron';
+import { shell } from 'electron';
+import { z } from 'zod';
 import type {
   LicenseStorage,
   AppLicenseState,
@@ -18,6 +19,7 @@ import {
   canStartTrial,
   isCachedSubscriptionValid,
 } from '@readied/licensing';
+import { defineIpcHandler } from '../ipc/registry.js';
 import { loggers } from '../logger';
 import type { ApiClient, SubscriptionStatus } from '../services/apiClient';
 
@@ -116,62 +118,62 @@ async function getSubscriptionData(
 export function registerLicenseHandlers(deps: LicenseHandlerDependencies): void {
   const { licenseStorage, apiClient } = deps;
 
-  /**
-   * Get current license state
-   * Trial data is local, subscription data comes from server (with local cache)
-   */
-  ipcMain.handle('license:getState', async (): Promise<AppLicenseState> => {
-    let trialData = await licenseStorage.readTrialData();
-    const subscriptionData = await getSubscriptionData(licenseStorage, apiClient);
+  defineIpcHandler({
+    channel: 'license:getState',
+    args: z.tuple([]),
+    handler: async (): Promise<AppLicenseState> => {
+      let trialData = await licenseStorage.readTrialData();
+      const subscriptionData = await getSubscriptionData(licenseStorage, apiClient);
 
-    // Auto-start trial if user hasn't started one yet
-    if (canStartTrial(trialData, subscriptionData)) {
-      trialData = startTrial();
-      await licenseStorage.writeTrialData(trialData);
-      getLicenseLogger().info('Trial started automatically');
-    }
+      if (canStartTrial(trialData, subscriptionData)) {
+        trialData = startTrial();
+        await licenseStorage.writeTrialData(trialData);
+        getLicenseLogger().info('Trial started automatically');
+      }
 
-    return computeLicenseState(trialData, subscriptionData);
+      return computeLicenseState(trialData, subscriptionData);
+    },
   });
 
-  /**
-   * Force-refresh subscription status from API (ignores cache)
-   */
-  ipcMain.handle('license:refreshSubscription', async (): Promise<AppLicenseState> => {
-    const trialData = await licenseStorage.readTrialData();
-    const subscriptionData = await getSubscriptionData(licenseStorage, apiClient, true);
-    return computeLicenseState(trialData, subscriptionData);
+  defineIpcHandler({
+    channel: 'license:refreshSubscription',
+    args: z.tuple([]),
+    handler: async (): Promise<AppLicenseState> => {
+      const trialData = await licenseStorage.readTrialData();
+      const subscriptionData = await getSubscriptionData(licenseStorage, apiClient, true);
+      return computeLicenseState(trialData, subscriptionData);
+    },
   });
 
-  /**
-   * Start trial manually (if not auto-started)
-   */
-  ipcMain.handle('license:startTrial', async (): Promise<{ success: boolean; error?: string }> => {
-    const trialData = await licenseStorage.readTrialData();
-    const subscriptionData = await licenseStorage.readSubscriptionData();
+  defineIpcHandler({
+    channel: 'license:startTrial',
+    args: z.tuple([]),
+    handler: async (): Promise<{ success: boolean; error?: string }> => {
+      const trialData = await licenseStorage.readTrialData();
+      const subscriptionData = await licenseStorage.readSubscriptionData();
 
-    if (!canStartTrial(trialData, subscriptionData)) {
-      return { success: false, error: 'Trial already started or subscription active' };
-    }
+      if (!canStartTrial(trialData, subscriptionData)) {
+        return { success: false, error: 'Trial already started or subscription active' };
+      }
 
-    const newTrialData = startTrial();
-    await licenseStorage.writeTrialData(newTrialData);
-    getLicenseLogger().info('Trial started manually');
-    return { success: true };
+      const newTrialData = startTrial();
+      await licenseStorage.writeTrialData(newTrialData);
+      getLicenseLogger().info('Trial started manually');
+      return { success: true };
+    },
   });
 
-  /**
-   * Open subscription checkout page
-   * Creates a Stripe checkout session via API and opens it in the browser
-   */
-  ipcMain.handle(
-    'license:openSubscribe',
-    async (
-      _event,
-      options?: { plan?: 'monthly' | 'annual' }
-    ): Promise<{ success: boolean; error?: string }> => {
+  defineIpcHandler({
+    channel: 'license:openSubscribe',
+    args: z.tuple([
+      z
+        .object({
+          plan: z.enum(['monthly', 'annual']).optional(),
+        })
+        .optional(),
+    ]),
+    handler: async (options): Promise<{ success: boolean; error?: string }> => {
       try {
-        // Get current user to verify authentication
         const user = await apiClient.getCurrentUser();
 
         if (!user || !user.email) {
@@ -184,7 +186,6 @@ export function registerLicenseHandlers(deps: LicenseHandlerDependencies): void 
           'Creating checkout session via API'
         );
 
-        // Create checkout session via API (server handles Stripe SDK)
         const { url } = await apiClient.createCheckoutSession({
           plan: options?.plan || 'monthly',
           successUrl: 'https://readied.app/subscription/success',
@@ -195,7 +196,6 @@ export function registerLicenseHandlers(deps: LicenseHandlerDependencies): void 
           return { success: false, error: 'No checkout URL returned' };
         }
 
-        // Open checkout URL in browser
         await shell.openExternal(url);
 
         getLicenseLogger().info({ email: user.email }, 'Checkout session opened in browser');
@@ -207,6 +207,6 @@ export function registerLicenseHandlers(deps: LicenseHandlerDependencies): void 
           error: error instanceof Error ? error.message : 'Failed to create checkout session',
         };
       }
-    }
-  );
+    },
+  });
 }

--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -5,13 +5,15 @@
  * to the renderer (settings UI).
  */
 
-import { ipcMain, app } from 'electron';
+import { app } from 'electron';
+import { z } from 'zod';
 import { createNoteId, createNoteOperation, updateNoteOperation } from '@readied/core';
 import {
   LocalServer,
   getOrCreateApiToken,
   type LocalServerHandlers,
 } from '../services/localServer.js';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { SQLiteNoteRepository, DataPaths } from './types.js';
 
 // ============================================================================
@@ -131,49 +133,56 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
     },
   };
 
-  // IPC: Start the local server
-  ipcMain.handle('localServer:start', async (_event, port?: number) => {
-    try {
-      if (port !== undefined && (typeof port !== 'number' || port < 1 || port > 65535)) {
-        return { ok: false, error: 'Invalid port' };
+  defineIpcHandler({
+    channel: 'localServer:start',
+    args: z.tuple([z.number().int().min(1).max(65535).optional()]),
+    handler: async port => {
+      try {
+        if (server.isRunning()) return { ok: true, port: server.getPort() };
+        apiToken = await getOrCreateApiToken(dataPaths.root);
+        await server.start(port, apiToken, handlers);
+        return { ok: true, port: server.getPort() };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
-      if (server.isRunning()) return { ok: true, port: server.getPort() };
-      apiToken = await getOrCreateApiToken(dataPaths.root);
-      await server.start(port, apiToken, handlers);
-      return { ok: true, port: server.getPort() };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    },
   });
 
-  // IPC: Stop the local server
-  ipcMain.handle('localServer:stop', async () => {
-    try {
-      await server.stop();
-      return { ok: true };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+  defineIpcHandler({
+    channel: 'localServer:stop',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        await server.stop();
+        return { ok: true };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
   });
 
-  // IPC: Get server status
-  ipcMain.handle('localServer:status', () => {
-    return {
+  defineIpcHandler({
+    channel: 'localServer:status',
+    args: z.tuple([]),
+    handler: () => ({
       running: server.isRunning(),
       port: server.getPort(),
-    };
+    }),
   });
 
-  // IPC: Get the bearer token (for displaying in settings)
-  ipcMain.handle('localServer:getToken', async () => {
-    try {
-      if (!apiToken) {
-        apiToken = await getOrCreateApiToken(dataPaths.root);
+  defineIpcHandler({
+    channel: 'localServer:getToken',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        if (!apiToken) {
+          apiToken = await getOrCreateApiToken(dataPaths.root);
+        }
+        return { ok: true, value: apiToken };
+      } catch (err) {
+        return { ok: false, error: err instanceof Error ? err.message : String(err) };
       }
-      return { ok: true, value: apiToken };
-    } catch (err) {
-      return { ok: false, error: err instanceof Error ? err.message : String(err) };
-    }
+    },
   });
 }
 

--- a/apps/desktop/src/main/handlers/logHandlers.ts
+++ b/apps/desktop/src/main/handlers/logHandlers.ts
@@ -1,11 +1,14 @@
 /**
  * Log IPC Handlers
  *
- * Handles renderer-side logging via IPC.
+ * Handles renderer-side logging via IPC. Validated at the boundary:
+ * level must be one of the enum values; message capped at 16 KiB;
+ * context object size is left to JSON serialization limits.
  */
 
-import { ipcMain } from 'electron';
-import { createChildLogger, type LogLevel } from '../logger';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
+import { createChildLogger } from '../logger';
 import type { DataPaths } from './types.js';
 
 export interface LogHandlerDeps {
@@ -13,20 +16,18 @@ export interface LogHandlerDeps {
   getDataPaths: () => DataPaths | null;
 }
 
+const LogLevelSchema = z.enum(['debug', 'info', 'warn', 'error']);
+const LogMessageSchema = z.string().max(16384);
+const LogContextSchema = z.record(z.string(), z.unknown()).optional();
+
 export function registerLogHandlers(deps: LogHandlerDeps): void {
   const rendererLogger = createChildLogger({ component: 'renderer' });
 
-  // Log from renderer
-  ipcMain.handle(
-    'log:write',
-    async (
-      _event,
-      level: LogLevel,
-      message: string,
-      context?: Record<string, unknown>
-    ): Promise<{ success: boolean }> => {
+  defineIpcHandler({
+    channel: 'log:write',
+    args: z.tuple([LogLevelSchema, LogMessageSchema, LogContextSchema]),
+    handler: (level, message, context): { success: boolean } => {
       const childLogger = context ? rendererLogger.child(context) : rendererLogger;
-
       switch (level) {
         case 'debug':
           childLogger.debug(message);
@@ -41,13 +42,13 @@ export function registerLogHandlers(deps: LogHandlerDeps): void {
           childLogger.error(message);
           break;
       }
-
       return { success: true };
-    }
-  );
+    },
+  });
 
-  // Get log file path (for debugging/support)
-  ipcMain.handle('log:getPath', async (): Promise<string | null> => {
-    return deps.getDataPaths()?.logs ?? null;
+  defineIpcHandler({
+    channel: 'log:getPath',
+    args: z.tuple([]),
+    handler: (): string | null => deps.getDataPaths()?.logs ?? null,
   });
 }

--- a/apps/desktop/src/main/handlers/pluginHandlers.ts
+++ b/apps/desktop/src/main/handlers/pluginHandlers.ts
@@ -8,15 +8,26 @@ import { join, normalize, basename } from 'path';
 import { readFile, mkdir, rm, readdir, stat, rename } from 'fs/promises';
 import { existsSync } from 'fs';
 import { execFile } from 'child_process';
-import { ipcMain, dialog, BrowserWindow, net } from 'electron';
-import type { DataPaths, Database } from './types.js';
-import { scanPlugins } from '../pluginScanner.js';
 import { writeFile } from 'fs/promises';
+import { ipcMain, dialog, BrowserWindow, net } from 'electron';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
+import { scanPlugins } from '../pluginScanner.js';
+import type { DataPaths, Database } from './types.js';
 
 export interface PluginHandlerDeps {
   dataPaths: DataPaths;
   db: Database;
 }
+
+// Plugin IDs are constrained the same way we enforce on install (regex check
+// on manifest.id). Mirror that here so the IPC boundary catches the same shape.
+const PluginIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/);
+const ConfigKeySchema = z.string().min(1).max(256);
 
 export function registerPluginHandlers(deps: PluginHandlerDeps): void {
   const { dataPaths: paths, db: database } = deps;
@@ -25,372 +36,410 @@ export function registerPluginHandlers(deps: PluginHandlerDeps): void {
   // Plugin Config Persistence
   // ═══════════════════════════════════════════════════════════════════════════
 
-  ipcMain.handle('pluginConfig:get', (_event, pluginId: string, key: string) => {
-    const row = database
-      .prepare('SELECT value FROM plugin_config WHERE plugin_id = ? AND key = ?')
-      .get(pluginId, key) as { value: string } | undefined;
-    return row ? JSON.parse(row.value) : undefined;
+  defineIpcHandler({
+    channel: 'pluginConfig:get',
+    args: z.tuple([PluginIdSchema, ConfigKeySchema]),
+    handler: (pluginId, key) => {
+      const row = database
+        .prepare('SELECT value FROM plugin_config WHERE plugin_id = ? AND key = ?')
+        .get(pluginId, key) as { value: string } | undefined;
+      return row ? JSON.parse(row.value) : undefined;
+    },
   });
 
-  ipcMain.handle('pluginConfig:set', (_event, pluginId: string, key: string, value: unknown) => {
-    database
-      .prepare('INSERT OR REPLACE INTO plugin_config (plugin_id, key, value) VALUES (?, ?, ?)')
-      .run(pluginId, key, JSON.stringify(value));
+  defineIpcHandler({
+    channel: 'pluginConfig:set',
+    args: z.tuple([PluginIdSchema, ConfigKeySchema, z.unknown()]),
+    handler: (pluginId, key, value) => {
+      database
+        .prepare('INSERT OR REPLACE INTO plugin_config (plugin_id, key, value) VALUES (?, ?, ?)')
+        .run(pluginId, key, JSON.stringify(value));
+    },
   });
 
-  ipcMain.handle('pluginConfig:getAll', (_event, pluginId: string) => {
-    const rows = database
-      .prepare('SELECT key, value FROM plugin_config WHERE plugin_id = ?')
-      .all(pluginId) as Array<{ key: string; value: string }>;
-    const result: Record<string, unknown> = {};
-    for (const row of rows) {
-      result[row.key] = JSON.parse(row.value);
-    }
-    return result;
+  defineIpcHandler({
+    channel: 'pluginConfig:getAll',
+    args: z.tuple([PluginIdSchema]),
+    handler: pluginId => {
+      const rows = database
+        .prepare('SELECT key, value FROM plugin_config WHERE plugin_id = ?')
+        .all(pluginId) as Array<{ key: string; value: string }>;
+      const result: Record<string, unknown> = {};
+      for (const row of rows) {
+        result[row.key] = JSON.parse(row.value);
+      }
+      return result;
+    },
   });
 
-  ipcMain.handle('pluginConfig:clear', (_event, pluginId: string) => {
-    database.prepare('DELETE FROM plugin_config WHERE plugin_id = ?').run(pluginId);
+  defineIpcHandler({
+    channel: 'pluginConfig:clear',
+    args: z.tuple([PluginIdSchema]),
+    handler: pluginId => {
+      database.prepare('DELETE FROM plugin_config WHERE plugin_id = ?').run(pluginId);
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Plugin Discovery
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Scan filesystem for plugins
-  ipcMain.handle('plugins:scan', async () => {
-    return scanPlugins(paths.plugins);
+  defineIpcHandler({
+    channel: 'plugins:scan',
+    args: z.tuple([]),
+    handler: () => scanPlugins(paths.plugins),
   });
 
-  // Check if a plugin is enabled (default: true if no row exists)
-  ipcMain.handle('plugins:isEnabled', (_event, pluginId: string) => {
-    const row = database
-      .prepare('SELECT enabled FROM plugin_registry WHERE plugin_id = ?')
-      .get(pluginId) as { enabled: number } | undefined;
-    return row ? row.enabled === 1 : true;
+  defineIpcHandler({
+    channel: 'plugins:isEnabled',
+    args: z.tuple([PluginIdSchema]),
+    handler: pluginId => {
+      const row = database
+        .prepare('SELECT enabled FROM plugin_registry WHERE plugin_id = ?')
+        .get(pluginId) as { enabled: number } | undefined;
+      return row ? row.enabled === 1 : true;
+    },
   });
 
-  // Set plugin enabled/disabled state
-  ipcMain.handle('plugins:setEnabled', (_event, pluginId: string, enabled: boolean) => {
-    database
-      .prepare(
-        'INSERT INTO plugin_registry (plugin_id, enabled) VALUES (?, ?) ON CONFLICT(plugin_id) DO UPDATE SET enabled = ?'
-      )
-      .run(pluginId, enabled ? 1 : 0, enabled ? 1 : 0);
+  defineIpcHandler({
+    channel: 'plugins:setEnabled',
+    args: z.tuple([PluginIdSchema, z.boolean()]),
+    handler: (pluginId, enabled) => {
+      database
+        .prepare(
+          'INSERT INTO plugin_registry (plugin_id, enabled) VALUES (?, ?) ON CONFLICT(plugin_id) DO UPDATE SET enabled = ?'
+        )
+        .run(pluginId, enabled ? 1 : 0, enabled ? 1 : 0);
+    },
   });
 
-  // List all plugin registry state
-  ipcMain.handle('plugins:listState', () => {
-    const rows = database.prepare('SELECT plugin_id, enabled FROM plugin_registry').all() as Array<{
-      plugin_id: string;
-      enabled: number;
-    }>;
-    return rows.map(row => ({
-      pluginId: row.plugin_id,
-      enabled: row.enabled === 1,
-    }));
+  defineIpcHandler({
+    channel: 'plugins:listState',
+    args: z.tuple([]),
+    handler: () => {
+      const rows = database
+        .prepare('SELECT plugin_id, enabled FROM plugin_registry')
+        .all() as Array<{
+        plugin_id: string;
+        enabled: number;
+      }>;
+      return rows.map(row => ({
+        pluginId: row.plugin_id,
+        enabled: row.enabled === 1,
+      }));
+    },
   });
 
-  // Read init.js user script (returns null if not found)
-  ipcMain.handle('plugins:readInitScript', async () => {
-    const initPath = join(paths.root, 'init.js');
-    try {
-      const code = await readFile(initPath, 'utf-8');
-      return code;
-    } catch {
-      return null;
-    }
+  defineIpcHandler({
+    channel: 'plugins:readInitScript',
+    args: z.tuple([]),
+    handler: async () => {
+      const initPath = join(paths.root, 'init.js');
+      try {
+        return await readFile(initPath, 'utf-8');
+      } catch {
+        return null;
+      }
+    },
   });
 
-  // Install plugin from archive (.tar.gz or .zip)
-  ipcMain.handle('plugins:install', async () => {
-    const { filePaths, canceled } = await dialog.showOpenDialog({
-      title: 'Install Plugin',
-      properties: ['openFile'],
-      filters: [{ name: 'Plugin Archive', extensions: ['tar.gz', 'tgz', 'zip'] }],
-      buttonLabel: 'Install',
-    });
+  defineIpcHandler({
+    channel: 'plugins:install',
+    args: z.tuple([]),
+    handler: async () => {
+      const { filePaths, canceled } = await dialog.showOpenDialog({
+        title: 'Install Plugin',
+        properties: ['openFile'],
+        filters: [{ name: 'Plugin Archive', extensions: ['tar.gz', 'tgz', 'zip'] }],
+        buttonLabel: 'Install',
+      });
 
-    if (canceled || !filePaths[0]) {
-      return { success: false, error: 'Cancelled' };
-    }
+      if (canceled || !filePaths[0]) {
+        return { success: false, error: 'Cancelled' };
+      }
 
-    const archivePath = filePaths[0];
-    const fileName = basename(archivePath).toLowerCase();
+      const archivePath = filePaths[0];
+      const fileName = basename(archivePath).toLowerCase();
 
-    // Hoist tmpDir so it can be cleaned up in finally
-    let tmpDir: string | null = null;
+      // Hoist tmpDir so it can be cleaned up in finally
+      let tmpDir: string | null = null;
 
-    try {
+      try {
+        // Ensure plugins dir exists
+        await mkdir(paths.plugins, { recursive: true });
+
+        // Extract to a temp dir first, then move validated plugin folder
+        tmpDir = join(paths.plugins, `__installing_${Date.now()}`);
+        const extractDir = tmpDir;
+        await mkdir(extractDir, { recursive: true });
+
+        await new Promise<void>((resolve, reject) => {
+          const cb = (error: Error | null) => {
+            if (error) reject(error);
+            else resolve();
+          };
+          if (fileName.endsWith('.zip')) {
+            if (process.platform === 'win32') {
+              execFile(
+                'powershell',
+                [
+                  '-NoProfile',
+                  '-NonInteractive',
+                  '-Command',
+                  'Expand-Archive',
+                  '-Force',
+                  '-Path',
+                  archivePath,
+                  '-DestinationPath',
+                  extractDir,
+                ],
+                cb
+              );
+            } else {
+              execFile('unzip', ['-o', archivePath, '-d', extractDir], cb);
+            }
+          } else {
+            execFile('tar', ['-xzf', archivePath, '-C', extractDir], cb);
+          }
+        });
+
+        // Find the manifest.json — could be at root or one level deep
+        const entries = await readdir(extractDir);
+        let pluginSourceDir = extractDir;
+
+        // If there's a single subdirectory, use that as the plugin root
+        if (entries.length === 1 && entries[0]) {
+          const candidatePath = join(extractDir, entries[0]);
+          const candidateStat = await stat(candidatePath);
+          if (candidateStat.isDirectory()) {
+            pluginSourceDir = candidatePath;
+          }
+        }
+
+        // Validate: must have manifest.json
+        const manifestPath = join(pluginSourceDir, 'manifest.json');
+        if (!existsSync(manifestPath)) {
+          return { success: false, error: 'No manifest.json found in archive' };
+        }
+
+        const manifestRaw = await readFile(manifestPath, 'utf-8');
+        const manifest = JSON.parse(manifestRaw);
+        if (!manifest.id || !manifest.name) {
+          return { success: false, error: 'Invalid manifest: missing id or name' };
+        }
+
+        // Validate plugin ID - only allow alphanumeric, hyphens, underscores
+        if (!/^[a-zA-Z0-9_-]+$/.test(manifest.id)) {
+          return {
+            success: false,
+            error: 'Invalid plugin ID: must be alphanumeric with hyphens/underscores only',
+          };
+        }
+
+        // Verify path doesn't escape plugins directory
+        const destDir = join(paths.plugins, manifest.id);
+        if (!normalize(destDir).startsWith(normalize(paths.plugins))) {
+          return { success: false, error: 'Invalid plugin ID: path traversal detected' };
+        }
+
+        // Move to final destination
+        if (existsSync(destDir)) {
+          await rm(destDir, { recursive: true, force: true });
+        }
+
+        await rename(pluginSourceDir, destDir);
+
+        return { success: true, pluginId: manifest.id, pluginName: manifest.name };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      } finally {
+        if (tmpDir && existsSync(tmpDir)) {
+          await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        }
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'plugins:installFromUrl',
+    args: z.tuple([z.string().url().startsWith('https://').max(2048), PluginIdSchema]),
+    handler: async (url, pluginSlug) => {
+      // Safety: only allow https URLs
+      if (!url.startsWith('https://')) {
+        return { success: false, error: 'Only HTTPS URLs are allowed' };
+      }
+
       // Ensure plugins dir exists
       await mkdir(paths.plugins, { recursive: true });
 
-      // Extract to a temp dir first, then move validated plugin folder
-      tmpDir = join(paths.plugins, `__installing_${Date.now()}`);
-      const extractDir = tmpDir;
-      await mkdir(extractDir, { recursive: true });
+      // Download to a temp file inside the plugins dir
+      const tmpDir = join(paths.plugins, `__downloading_${Date.now()}`);
+      await mkdir(tmpDir, { recursive: true });
 
-      await new Promise<void>((resolve, reject) => {
-        const cb = (error: Error | null) => {
-          if (error) reject(error);
-          else resolve();
-        };
-        if (fileName.endsWith('.zip')) {
-          if (process.platform === 'win32') {
-            execFile(
-              'powershell',
-              [
-                '-NoProfile',
-                '-NonInteractive',
-                '-Command',
-                'Expand-Archive',
-                '-Force',
-                '-Path',
-                archivePath,
-                '-DestinationPath',
-                extractDir,
-              ],
-              cb
-            );
+      try {
+        const response = await net.fetch(url);
+        if (!response.ok) {
+          return { success: false, error: `Download failed: HTTP ${response.status}` };
+        }
+
+        // Limit download size to 50 MB
+        const MAX_PLUGIN_SIZE = 50 * 1024 * 1024;
+        const contentLength = response.headers.get('content-length');
+        if (contentLength && parseInt(contentLength, 10) > MAX_PLUGIN_SIZE) {
+          return { success: false, error: 'Plugin archive exceeds maximum size of 50 MB' };
+        }
+
+        const buffer = Buffer.from(await response.arrayBuffer());
+        if (buffer.byteLength > MAX_PLUGIN_SIZE) {
+          return { success: false, error: 'Plugin archive exceeds maximum size of 50 MB' };
+        }
+
+        // Determine archive type from URL pathname
+        const urlPathname = new URL(url).pathname.toLowerCase();
+        const isZip = urlPathname.endsWith('.zip');
+        const archiveExt = isZip ? '.zip' : '.tar.gz';
+        const archivePath = join(tmpDir, `plugin${archiveExt}`);
+        await writeFile(archivePath, buffer);
+
+        // Extract to a staging dir
+        const stageDir = join(tmpDir, 'extracted');
+        await mkdir(stageDir, { recursive: true });
+
+        await new Promise<void>((resolve, reject) => {
+          const cb = (error: Error | null) => {
+            if (error) reject(error);
+            else resolve();
+          };
+          if (isZip) {
+            if (process.platform === 'win32') {
+              execFile(
+                'powershell',
+                [
+                  '-NoProfile',
+                  '-NonInteractive',
+                  '-Command',
+                  'Expand-Archive',
+                  '-Force',
+                  '-Path',
+                  archivePath,
+                  '-DestinationPath',
+                  stageDir,
+                ],
+                cb
+              );
+            } else {
+              execFile('unzip', ['-o', archivePath, '-d', stageDir], cb);
+            }
           } else {
-            execFile('unzip', ['-o', archivePath, '-d', extractDir], cb);
+            execFile('tar', ['-xzf', archivePath, '-C', stageDir], cb);
           }
-        } else {
-          execFile('tar', ['-xzf', archivePath, '-C', extractDir], cb);
-        }
-      });
+        });
 
-      // Find the manifest.json — could be at root or one level deep
-      const entries = await readdir(extractDir);
-      let pluginSourceDir = extractDir;
+        // Find manifest.json — could be at root or one level deep
+        const entries = await readdir(stageDir);
+        let pluginSourceDir = stageDir;
 
-      // If there's a single subdirectory, use that as the plugin root
-      if (entries.length === 1 && entries[0]) {
-        const candidatePath = join(extractDir, entries[0]);
-        const candidateStat = await stat(candidatePath);
-        if (candidateStat.isDirectory()) {
-          pluginSourceDir = candidatePath;
-        }
-      }
-
-      // Validate: must have manifest.json
-      const manifestPath = join(pluginSourceDir, 'manifest.json');
-      if (!existsSync(manifestPath)) {
-        return { success: false, error: 'No manifest.json found in archive' };
-      }
-
-      const manifestRaw = await readFile(manifestPath, 'utf-8');
-      const manifest = JSON.parse(manifestRaw);
-      if (!manifest.id || !manifest.name) {
-        return { success: false, error: 'Invalid manifest: missing id or name' };
-      }
-
-      // Validate plugin ID - only allow alphanumeric, hyphens, underscores
-      if (!/^[a-zA-Z0-9_-]+$/.test(manifest.id)) {
-        return {
-          success: false,
-          error: 'Invalid plugin ID: must be alphanumeric with hyphens/underscores only',
-        };
-      }
-
-      // Verify path doesn't escape plugins directory
-      const destDir = join(paths.plugins, manifest.id);
-      if (!normalize(destDir).startsWith(normalize(paths.plugins))) {
-        return { success: false, error: 'Invalid plugin ID: path traversal detected' };
-      }
-
-      // Move to final destination
-      if (existsSync(destDir)) {
-        await rm(destDir, { recursive: true, force: true });
-      }
-
-      await rename(pluginSourceDir, destDir);
-
-      return { success: true, pluginId: manifest.id, pluginName: manifest.name };
-    } catch (error) {
-      return { success: false, error: String(error) };
-    } finally {
-      if (tmpDir && existsSync(tmpDir)) {
-        await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      }
-    }
-  });
-
-  // Install plugin from a remote URL (marketplace download)
-  ipcMain.handle('plugins:installFromUrl', async (_event, url: string, pluginSlug: string) => {
-    // Safety: only allow https URLs
-    if (!url.startsWith('https://')) {
-      return { success: false, error: 'Only HTTPS URLs are allowed' };
-    }
-
-    // Ensure plugins dir exists
-    await mkdir(paths.plugins, { recursive: true });
-
-    // Download to a temp file inside the plugins dir
-    const tmpDir = join(paths.plugins, `__downloading_${Date.now()}`);
-    await mkdir(tmpDir, { recursive: true });
-
-    try {
-      const response = await net.fetch(url);
-      if (!response.ok) {
-        return { success: false, error: `Download failed: HTTP ${response.status}` };
-      }
-
-      // Limit download size to 50 MB
-      const MAX_PLUGIN_SIZE = 50 * 1024 * 1024;
-      const contentLength = response.headers.get('content-length');
-      if (contentLength && parseInt(contentLength, 10) > MAX_PLUGIN_SIZE) {
-        return { success: false, error: 'Plugin archive exceeds maximum size of 50 MB' };
-      }
-
-      const buffer = Buffer.from(await response.arrayBuffer());
-      if (buffer.byteLength > MAX_PLUGIN_SIZE) {
-        return { success: false, error: 'Plugin archive exceeds maximum size of 50 MB' };
-      }
-
-      // Determine archive type from URL pathname
-      const urlPathname = new URL(url).pathname.toLowerCase();
-      const isZip = urlPathname.endsWith('.zip');
-      const archiveExt = isZip ? '.zip' : '.tar.gz';
-      const archivePath = join(tmpDir, `plugin${archiveExt}`);
-      await writeFile(archivePath, buffer);
-
-      // Extract to a staging dir
-      const stageDir = join(tmpDir, 'extracted');
-      await mkdir(stageDir, { recursive: true });
-
-      await new Promise<void>((resolve, reject) => {
-        const cb = (error: Error | null) => {
-          if (error) reject(error);
-          else resolve();
-        };
-        if (isZip) {
-          if (process.platform === 'win32') {
-            execFile(
-              'powershell',
-              [
-                '-NoProfile',
-                '-NonInteractive',
-                '-Command',
-                'Expand-Archive',
-                '-Force',
-                '-Path',
-                archivePath,
-                '-DestinationPath',
-                stageDir,
-              ],
-              cb
-            );
-          } else {
-            execFile('unzip', ['-o', archivePath, '-d', stageDir], cb);
+        if (entries.length === 1 && entries[0]) {
+          const candidatePath = join(stageDir, entries[0]);
+          const candidateStat = await stat(candidatePath);
+          if (candidateStat.isDirectory()) {
+            pluginSourceDir = candidatePath;
           }
-        } else {
-          execFile('tar', ['-xzf', archivePath, '-C', stageDir], cb);
         }
-      });
 
-      // Find manifest.json — could be at root or one level deep
-      const entries = await readdir(stageDir);
-      let pluginSourceDir = stageDir;
-
-      if (entries.length === 1 && entries[0]) {
-        const candidatePath = join(stageDir, entries[0]);
-        const candidateStat = await stat(candidatePath);
-        if (candidateStat.isDirectory()) {
-          pluginSourceDir = candidatePath;
+        // Validate: must have manifest.json
+        const manifestPath = join(pluginSourceDir, 'manifest.json');
+        if (!existsSync(manifestPath)) {
+          return { success: false, error: 'No manifest.json found in downloaded archive' };
         }
-      }
 
-      // Validate: must have manifest.json
-      const manifestPath = join(pluginSourceDir, 'manifest.json');
-      if (!existsSync(manifestPath)) {
-        return { success: false, error: 'No manifest.json found in downloaded archive' };
-      }
+        const manifestRaw = await readFile(manifestPath, 'utf-8');
+        const manifest = JSON.parse(manifestRaw);
+        if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
+          return { success: false, error: 'Invalid manifest: not a JSON object' };
+        }
+        if (!manifest.id || !manifest.name) {
+          return { success: false, error: 'Invalid manifest: missing id or name' };
+        }
 
-      const manifestRaw = await readFile(manifestPath, 'utf-8');
-      const manifest = JSON.parse(manifestRaw);
-      if (typeof manifest !== 'object' || manifest === null || Array.isArray(manifest)) {
-        return { success: false, error: 'Invalid manifest: not a JSON object' };
-      }
-      if (!manifest.id || !manifest.name) {
-        return { success: false, error: 'Invalid manifest: missing id or name' };
-      }
+        // Cross-plugin overwrite protection: if we requested plugin A but the
+        // archive contains plugin B, block when it would overwrite an existing plugin
+        if (pluginSlug && manifest.id !== pluginSlug) {
+          const wouldOverwrite = join(paths.plugins, manifest.id);
+          if (existsSync(wouldOverwrite)) {
+            return {
+              success: false,
+              error: `Archive contains "${manifest.id}" but "${pluginSlug}" was requested. Refusing to overwrite existing plugin.`,
+            };
+          }
+        }
 
-      // Cross-plugin overwrite protection: if we requested plugin A but the
-      // archive contains plugin B, block when it would overwrite an existing plugin
-      if (pluginSlug && manifest.id !== pluginSlug) {
-        const wouldOverwrite = join(paths.plugins, manifest.id);
-        if (existsSync(wouldOverwrite)) {
+        // Validate plugin ID - only allow alphanumeric, hyphens, underscores
+        if (!/^[a-zA-Z0-9_-]+$/.test(manifest.id)) {
           return {
             success: false,
-            error: `Archive contains "${manifest.id}" but "${pluginSlug}" was requested. Refusing to overwrite existing plugin.`,
+            error: 'Invalid plugin ID: must be alphanumeric with hyphens/underscores only',
           };
         }
-      }
 
-      // Validate plugin ID - only allow alphanumeric, hyphens, underscores
-      if (!/^[a-zA-Z0-9_-]+$/.test(manifest.id)) {
+        // Verify path doesn't escape plugins directory
+        const destDir = join(paths.plugins, manifest.id);
+        if (!normalize(destDir).startsWith(normalize(paths.plugins))) {
+          return { success: false, error: 'Invalid plugin ID: path traversal detected' };
+        }
+
+        // Move to final destination
+        if (existsSync(destDir)) {
+          await rm(destDir, { recursive: true, force: true });
+        }
+
+        await rename(pluginSourceDir, destDir);
+
         return {
-          success: false,
-          error: 'Invalid plugin ID: must be alphanumeric with hyphens/underscores only',
+          success: true,
+          pluginId: manifest.id,
+          pluginName: manifest.name,
+          slugMismatch: pluginSlug && manifest.id !== pluginSlug ? pluginSlug : undefined,
         };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      } finally {
+        if (existsSync(tmpDir)) {
+          await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        }
       }
-
-      // Verify path doesn't escape plugins directory
-      const destDir = join(paths.plugins, manifest.id);
-      if (!normalize(destDir).startsWith(normalize(paths.plugins))) {
-        return { success: false, error: 'Invalid plugin ID: path traversal detected' };
-      }
-
-      // Move to final destination
-      if (existsSync(destDir)) {
-        await rm(destDir, { recursive: true, force: true });
-      }
-
-      await rename(pluginSourceDir, destDir);
-
-      return {
-        success: true,
-        pluginId: manifest.id,
-        pluginName: manifest.name,
-        slugMismatch: pluginSlug && manifest.id !== pluginSlug ? pluginSlug : undefined,
-      };
-    } catch (error) {
-      return { success: false, error: String(error) };
-    } finally {
-      // Always clean up temp dir
-      if (existsSync(tmpDir)) {
-        await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      }
-    }
+    },
   });
 
-  // Uninstall plugin (remove its directory)
-  ipcMain.handle('plugins:uninstall', async (_event, pluginId: string) => {
-    // Safety: only allow removing from the plugins directory, prevent path traversal
-    const safeName = pluginId.replace(/[^a-z0-9-]/g, '');
-    const pluginDir = join(paths.plugins, safeName);
-    const normalizedDir = normalize(pluginDir);
+  defineIpcHandler({
+    channel: 'plugins:uninstall',
+    args: z.tuple([PluginIdSchema]),
+    handler: async pluginId => {
+      // Safety: only allow removing from the plugins directory, prevent path traversal
+      const safeName = pluginId.replace(/[^a-z0-9-]/g, '');
+      const pluginDir = join(paths.plugins, safeName);
+      const normalizedDir = normalize(pluginDir);
 
-    if (!normalizedDir.startsWith(normalize(paths.plugins))) {
-      return { success: false, error: 'Invalid plugin ID' };
-    }
+      if (!normalizedDir.startsWith(normalize(paths.plugins))) {
+        return { success: false, error: 'Invalid plugin ID' };
+      }
 
-    if (!existsSync(pluginDir)) {
-      return { success: false, error: 'Plugin not found' };
-    }
+      if (!existsSync(pluginDir)) {
+        return { success: false, error: 'Plugin not found' };
+      }
 
-    try {
-      await rm(pluginDir, { recursive: true, force: true });
-      // Clean up registry entry
-      database.prepare('DELETE FROM plugin_registry WHERE plugin_id = ?').run(pluginId);
-      return { success: true };
-    } catch (error) {
-      return { success: false, error: String(error) };
-    }
+      try {
+        await rm(pluginDir, { recursive: true, force: true });
+        database.prepare('DELETE FROM plugin_registry WHERE plugin_id = ?').run(pluginId);
+        return { success: true };
+      } catch (error) {
+        return { success: false, error: String(error) };
+      }
+    },
   });
 
-  // Request plugin reload: broadcast to all windows except sender
+  // plugins:requestReload uses ipcMain.on (fire-and-forget, not invoke),
+  // so defineIpcHandler doesn't apply — left raw.
   ipcMain.on('plugins:requestReload', event => {
     const senderWebContents = event.sender;
     for (const win of BrowserWindow.getAllWindows()) {

--- a/apps/desktop/src/main/handlers/shareHandlers.ts
+++ b/apps/desktop/src/main/handlers/shareHandlers.ts
@@ -5,30 +5,44 @@
  * Auto-copies the share URL to clipboard.
  */
 
-import { ipcMain, clipboard } from 'electron';
+import { clipboard } from 'electron';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { ApiClient } from '../services/apiClient.js';
 
 export interface ShareHandlerDependencies {
   apiClient: ApiClient;
 }
 
+// Note content can be quite long; cap at 1 MiB which is well above any
+// realistic note and well below "this looks like an attack payload".
+const SharePayloadSchema = z.object({
+  noteId: z.string().min(1).max(128),
+  title: z.string().max(512),
+  content: z.string().max(1024 * 1024),
+  tags: z.array(z.string().max(64)).max(64).optional(),
+  backlinks: z
+    .array(z.object({ noteId: z.string().min(1).max(128), title: z.string().max(512) }))
+    .max(256)
+    .optional(),
+  wordCount: z.number().int().nonnegative().optional(),
+  notebookName: z.string().max(256).optional(),
+});
+
+const SlugSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/);
+
 export function registerShareHandlers(deps: ShareHandlerDependencies): void {
   const { apiClient } = deps;
 
-  // Create or update a shared note
-  ipcMain.handle(
-    'share:create',
-    async (
-      _event,
-      input: {
-        noteId: string;
-        title: string;
-        content: string;
-        tags?: string[];
-        backlinks?: Array<{ noteId: string; title: string }>;
-        wordCount?: number;
-        notebookName?: string;
-      }
+  defineIpcHandler({
+    channel: 'share:create',
+    args: z.tuple([SharePayloadSchema]),
+    handler: async (
+      input
     ): Promise<{ success: boolean; url?: string; slug?: string; error?: string }> => {
       try {
         const result = await apiClient.shareNote(input);
@@ -40,13 +54,13 @@ export function registerShareHandlers(deps: ShareHandlerDependencies): void {
           error: error instanceof Error ? error.message : 'Failed to share note',
         };
       }
-    }
-  );
+    },
+  });
 
-  // Delete a shared note
-  ipcMain.handle(
-    'share:delete',
-    async (_event, slug: string): Promise<{ success: boolean; error?: string }> => {
+  defineIpcHandler({
+    channel: 'share:delete',
+    args: z.tuple([SlugSchema]),
+    handler: async (slug): Promise<{ success: boolean; error?: string }> => {
       try {
         await apiClient.unshareNote(slug);
         return { success: true };
@@ -56,6 +70,6 @@ export function registerShareHandlers(deps: ShareHandlerDependencies): void {
           error: error instanceof Error ? error.message : 'Failed to unshare note',
         };
       }
-    }
-  );
+    },
+  });
 }

--- a/apps/desktop/src/main/handlers/updateHandlers.ts
+++ b/apps/desktop/src/main/handlers/updateHandlers.ts
@@ -6,6 +6,8 @@
 
 import { BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
 import { loggers } from '../logger';
 import type { BroadcastFn } from './types.js';
 
@@ -14,11 +16,10 @@ export interface UpdateHandlerDeps {
 }
 
 export function registerUpdateHandlers(_deps: UpdateHandlerDeps): void {
-  // Manual check for updates
-  ipcMain.handle(
-    'updates:checkNow',
-    async (): Promise<{ available: boolean; version?: string }> => {
-      // In development or without proper updater config, return mock response
+  defineIpcHandler({
+    channel: 'updates:checkNow',
+    args: z.tuple([]),
+    handler: async (): Promise<{ available: boolean; version?: string }> => {
       if (process.env.NODE_ENV === 'development') {
         return { available: false };
       }
@@ -29,17 +30,14 @@ export function registerUpdateHandlers(_deps: UpdateHandlerDeps): void {
           cleanup();
           resolve({ available: true, version: info.version });
         };
-
         const onNotAvailable = () => {
           cleanup();
           resolve({ available: false });
         };
-
         const onError = () => {
           cleanup();
           resolve({ available: false });
         };
-
         const cleanup = () => {
           autoUpdater.removeListener('update-available', onAvailable);
           autoUpdater.removeListener('update-not-available', onNotAvailable);
@@ -55,23 +53,30 @@ export function registerUpdateHandlers(_deps: UpdateHandlerDeps): void {
           resolve({ available: false });
         });
       });
-    }
-  );
-
-  ipcMain.handle('updates:startDownload', async () => {
-    if (process.env.NODE_ENV === 'development') return { ok: false };
-    try {
-      await autoUpdater.downloadUpdate();
-      return { ok: true };
-    } catch (err) {
-      const message = (err as Error).message;
-      loggers.updater().error({ error: message }, 'Failed to download update');
-      return { ok: false, error: message };
-    }
+    },
   });
 
+  defineIpcHandler({
+    channel: 'updates:startDownload',
+    args: z.tuple([]),
+    handler: async () => {
+      if (process.env.NODE_ENV === 'development') return { ok: false };
+      try {
+        await autoUpdater.downloadUpdate();
+        return { ok: true };
+      } catch (err) {
+        const message = (err as Error).message;
+        loggers.updater().error({ error: message }, 'Failed to download update');
+        return { ok: false, error: message };
+      }
+    },
+  });
+
+  // installNow doesn't return a value AND triggers a quit — keeping the
+  // raw ipcMain.handle is simpler here since registry.ts always wraps in
+  // Promise<unknown> and we don't want async semantics interfering with
+  // the synchronous window-destruction path.
   ipcMain.handle('updates:installNow', () => {
-    // Force-close all windows so macOS doesn't block the quit
     BrowserWindow.getAllWindows().forEach(win => {
       if (!win.isDestroyed()) win.destroy();
     });
@@ -83,7 +88,6 @@ export function registerUpdateHandlers(_deps: UpdateHandlerDeps): void {
 export function initAutoUpdater(deps: UpdateHandlerDeps): void {
   const updateLog = loggers.updater();
 
-  // Only check for updates in production
   if (process.env.NODE_ENV === 'development') {
     updateLog.debug('Skipping auto-updater in development');
     return;
@@ -125,7 +129,6 @@ export function initAutoUpdater(deps: UpdateHandlerDeps): void {
     deps.broadcastToWindows('updates:error', { message: err.message });
   });
 
-  // Check for updates after a short delay
   setTimeout(() => {
     void autoUpdater.checkForUpdates();
   }, 3000);


### PR DESCRIPTION
## Summary

Applies the typed IPC registry pattern from #272 to six handler modules. ~30 IPC channels are now validated at the boundary with Zod tuple schemas before the business logic runs.

The remaining five "heavy" modules (\`note\`, \`notebook\`, \`data\`, \`git\`, \`authSync\` — ~96 channels) will land in **PR-F5** as a separate PR for reviewability.

## Files migrated

| Module | Channels | Notes |
|---|---|---|
| \`logHandlers.ts\` | 2 | LogLevel enum, message ≤16 KiB |
| \`shareHandlers.ts\` | 2 | Note content ≤1 MiB, tags/backlinks count-capped |
| \`updateHandlers.ts\` | 2 (+1 raw) | \`updates:installNow\` kept raw — synchronous quit path |
| \`licenseHandlers.ts\` | 4 | Optional plan enum on \`openSubscribe\` |
| \`localServerHandlers.ts\` | 4 | Port range 1–65535 (was inside-handler check) |
| \`pluginHandlers.ts\` | 11 (+1 raw) | \`PluginIdSchema\` matches install-time regex |

\`plugins:requestReload\` uses \`ipcMain.on\` (fire-and-forget, not invoke), so it's not subject to \`defineIpcHandler\` — left raw.

## Schema highlights

- \`PluginIdSchema\` is \`z.string().min(1).max(128).regex(/^[a-zA-Z0-9_-]+$/)\` — mirrors the regex enforced at install time on \`manifest.id\`. The boundary now catches the same shape that the install-time check catches.
- Where the original code had defensive in-handler validation (e.g. \`if (port < 1 || port > 65535)\`), the schema now handles it. Defensive checks that produce nicer error strings (e.g. the \"https only\" guard inside \`installFromUrl\`) are kept as belt-and-suspenders.

## Test plan

- [x] \`pnpm --filter @readied/desktop typecheck:main\` — green.
- [x] \`pnpm test\` — 17/17 packages.
- [ ] Manual: each affected setting/feature in the app continues to work for valid inputs.
- [ ] Manual: try a malformed payload via DevTools (e.g. \`window.readied.plugins.setEnabled('not-a-valid-id!@#', true)\`). Expect \`IpcValidationError\`.

## Stack context

**PR-F4** in the audit stack. Stacked on top of #272 (PR-F1) → #271 (PR-I) → #270 (PR-J) → #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B).

## Follow-ups

- **PR-F5**: heavy data modules (note, notebook, data, git, authSync) — same pattern, ~96 channels.
- **PR-F2**: keychain storage for AI keys (Electron safeStorage is the leaning choice).
- **PR-F3**: license verification (asymmetric — server signs, client verifies; **not** HMAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)