### PR TITLE
refactor(ipc): migrate heavy data handlers to defineIpcHandler (PR-F5)

### DIFF
--- a/apps/desktop/src/main/handlers/authSyncHandlers.ts
+++ b/apps/desktop/src/main/handlers/authSyncHandlers.ts
@@ -5,7 +5,9 @@
  * subscription/billing, and device management.
  */
 
-import { ipcMain, shell } from 'electron';
+import { shell } from 'electron';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type {
   ApiClient,
   EncryptionService,
@@ -22,6 +24,29 @@ export interface AuthSyncHandlerDeps {
   broadcastToWindows: BroadcastFn;
 }
 
+const EmailSchema = z.string().email().max(254);
+const TokenSchema = z.string().min(1).max(2048);
+const PassphraseSchema = z.string().min(1).max(1024);
+const RecoveryKeySchema = z.string().min(8).max(512);
+const IdSchema = z.string().min(1).max(128);
+const NameSchema = z.string().min(1).max(128);
+const KeyHexSchema = z
+  .string()
+  .min(32)
+  .max(256)
+  .regex(/^[a-f0-9]+$/i);
+const UrlSchema = z.string().url().max(2048);
+
+const SyncChangeSchema = z.object({
+  noteId: IdSchema,
+  operation: z.enum(['create', 'update', 'delete']),
+  content: z
+    .string()
+    .max(10 * 1024 * 1024)
+    .optional(),
+  localVersion: z.number().int().nonnegative().optional(),
+});
+
 export function registerAuthSyncHandlers(deps: AuthSyncHandlerDeps): void {
   const {
     apiClient: client,
@@ -30,7 +55,6 @@ export function registerAuthSyncHandlers(deps: AuthSyncHandlerDeps): void {
     encryptionService: encryption,
   } = deps;
 
-  // Broadcast sync status events to all renderer windows
   sync.onStatusChange(event => {
     deps.broadcastToWindows('sync:status-changed', event);
   });
@@ -39,556 +63,603 @@ export function registerAuthSyncHandlers(deps: AuthSyncHandlerDeps): void {
   // Authentication
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Request magic link email
-  ipcMain.handle('auth:requestMagicLink', async (_event, email: string) => {
-    try {
-      await client.requestMagicLink(email);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to request magic link',
-      };
-    }
+  defineIpcHandler({
+    channel: 'auth:requestMagicLink',
+    args: z.tuple([EmailSchema]),
+    handler: async email => {
+      try {
+        await client.requestMagicLink(email);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to request magic link',
+        };
+      }
+    },
   });
 
-  // Verify magic link token and save tokens
-  ipcMain.handle('auth:verify', async (_event, token: string) => {
-    try {
-      const result = await client.verifyMagicLink(token);
-      await storage.saveTokens(result.accessToken, result.refreshToken);
-      return { success: true, user: result.user };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to verify token',
-      };
-    }
+  defineIpcHandler({
+    channel: 'auth:verify',
+    args: z.tuple([TokenSchema]),
+    handler: async token => {
+      try {
+        const result = await client.verifyMagicLink(token);
+        await storage.saveTokens(result.accessToken, result.refreshToken);
+        return { success: true, user: result.user };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to verify token',
+        };
+      }
+    },
   });
 
-  // Get current session
-  ipcMain.handle('auth:getSession', async () => {
-    try {
-      const hasTokens = await storage.hasTokens();
-      if (!hasTokens) {
+  defineIpcHandler({
+    channel: 'auth:getSession',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const hasTokens = await storage.hasTokens();
+        if (!hasTokens) return null;
+        const user = await client.getCurrentUser();
+        return { user };
+      } catch {
+        await storage.clearTokens();
         return null;
       }
-
-      const user = await client.getCurrentUser();
-      return { user };
-    } catch (_error) {
-      // If session is invalid, clear tokens
-      await storage.clearTokens();
-      return null;
-    }
+    },
   });
 
-  // Logout and clear tokens
-  ipcMain.handle('auth:logout', async () => {
-    try {
-      // Abort any in-flight sync operations before clearing tokens
-      sync?.stopAutoSync();
-      await storage.clearTokens();
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to logout',
-      };
-    }
+  defineIpcHandler({
+    channel: 'auth:logout',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        sync?.stopAutoSync();
+        await storage.clearTokens();
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to logout',
+        };
+      }
+    },
   });
 
-  // Refresh access token
-  ipcMain.handle('auth:refreshToken', async () => {
-    try {
-      const refreshed = await client.refreshAccessToken();
-      return { success: refreshed };
-    } catch (_error) {
-      return { success: false };
-    }
+  defineIpcHandler({
+    channel: 'auth:refreshToken',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const refreshed = await client.refreshAccessToken();
+        return { success: refreshed };
+      } catch {
+        return { success: false };
+      }
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Sync
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Pull changes from server
-  ipcMain.handle('sync:pull', async () => {
-    try {
-      const result = await sync.pull();
-      return {
-        success: result.success,
-        changes: result.changes,
-        cursor: result.cursor,
-        hasMore: result.hasMore,
-        conflicts: result.conflicts,
-        error: result.error,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to pull changes',
-      };
-    }
-  });
-
-  // Push changes to server
-  ipcMain.handle(
-    'sync:push',
-    async (
-      _event,
-      changes: Array<{
-        noteId: string;
-        operation: 'create' | 'update' | 'delete';
-        content?: string;
-        localVersion?: number;
-      }>
-    ) => {
+  defineIpcHandler({
+    channel: 'sync:pull',
+    args: z.tuple([]),
+    handler: async () => {
       try {
-        const result = await sync.push(changes);
+        const result = await sync.pull();
         return {
           success: result.success,
-          results: result.results,
+          changes: result.changes,
+          cursor: result.cursor,
+          hasMore: result.hasMore,
+          conflicts: result.conflicts,
           error: result.error,
         };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to pull changes',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'sync:push',
+    args: z.tuple([z.array(SyncChangeSchema).max(100000)]),
+    handler: async changes => {
+      try {
+        const result = await sync.push(changes);
+        return { success: result.success, results: result.results, error: result.error };
       } catch (error) {
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to push changes',
         };
       }
-    }
-  );
-
-  // Perform full sync (pull + push)
-  ipcMain.handle('sync:syncNow', async () => {
-    try {
-      const result = await sync.syncNow();
-      return result;
-    } catch (error) {
-      return {
-        success: false,
-        changesApplied: 0,
-        changesPushed: 0,
-        conflicts: [],
-        error: error instanceof Error ? error.message : 'Sync failed',
-      };
-    }
+    },
   });
 
-  // Get sync status
-  ipcMain.handle('sync:status', async () => {
-    try {
-      const state = sync.getState();
-      return {
-        success: true,
-        cursor: state.cursor,
-        lastSyncAt: state.lastSyncAt,
-        isSyncing: state.isSyncing,
-        lastError: state.lastError,
-        consecutiveFailures: state.consecutiveFailures,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get sync status',
-      };
-    }
-  });
-
-  // Get pending change count (offline queue size)
-  ipcMain.handle('sync:pendingCount', async () => {
-    try {
-      return { success: true, count: sync.getPendingCount() };
-    } catch (error) {
-      return { success: false, count: 0, error: error instanceof Error ? error.message : 'Failed' };
-    }
-  });
-
-  // Resolve conflict
-  ipcMain.handle(
-    'sync:resolveConflict',
-    async (_event, noteId: string, resolution: 'local' | 'remote') => {
+  defineIpcHandler({
+    channel: 'sync:syncNow',
+    args: z.tuple([]),
+    handler: async () => {
       try {
-        await sync.resolveConflict(noteId, resolution);
+        return await sync.syncNow();
+      } catch (error) {
+        return {
+          success: false,
+          changesApplied: 0,
+          changesPushed: 0,
+          conflicts: [],
+          error: error instanceof Error ? error.message : 'Sync failed',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'sync:status',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        const state = sync.getState();
         return {
           success: true,
+          cursor: state.cursor,
+          lastSyncAt: state.lastSyncAt,
+          isSyncing: state.isSyncing,
+          lastError: state.lastError,
+          consecutiveFailures: state.consecutiveFailures,
         };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get sync status',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'sync:pendingCount',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        return { success: true, count: sync.getPendingCount() };
+      } catch (error) {
+        return {
+          success: false,
+          count: 0,
+          error: error instanceof Error ? error.message : 'Failed',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'sync:resolveConflict',
+    args: z.tuple([IdSchema, z.enum(['local', 'remote'])]),
+    handler: async (noteId, resolution) => {
+      try {
+        await sync.resolveConflict(noteId, resolution);
+        return { success: true };
       } catch (error) {
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to resolve conflict',
         };
       }
-    }
-  );
-
-  // Start auto-sync
-  ipcMain.handle('sync:startAutoSync', async (_event, intervalMs?: number) => {
-    try {
-      sync.startAutoSync(intervalMs);
-      return {
-        success: true,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to start auto-sync',
-      };
-    }
+    },
   });
 
-  // Stop auto-sync
-  ipcMain.handle('sync:stopAutoSync', async () => {
-    try {
-      sync.stopAutoSync();
-      return {
-        success: true,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to stop auto-sync',
-      };
-    }
+  defineIpcHandler({
+    channel: 'sync:startAutoSync',
+    args: z.tuple([
+      z
+        .number()
+        .int()
+        .min(1000)
+        .max(24 * 60 * 60 * 1000)
+        .optional(),
+    ]),
+    handler: intervalMs => {
+      try {
+        sync.startAutoSync(intervalMs);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to start auto-sync',
+        };
+      }
+    },
   });
 
-  // Tag sync - pull
-  ipcMain.handle('sync:pullTags', async () => {
-    try {
-      return await sync.pullTags();
-    } catch (error) {
-      return { success: false, applied: 0, error: String(error) };
-    }
+  defineIpcHandler({
+    channel: 'sync:stopAutoSync',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        sync.stopAutoSync();
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to stop auto-sync',
+        };
+      }
+    },
   });
 
-  // Tag sync - push
-  ipcMain.handle('sync:pushTags', async () => {
-    try {
-      return await sync.pushTags();
-    } catch (error) {
-      return { success: false, pushed: 0, error: String(error) };
-    }
+  defineIpcHandler({
+    channel: 'sync:pullTags',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        return await sync.pullTags();
+      } catch (error) {
+        return { success: false, applied: 0, error: String(error) };
+      }
+    },
   });
 
-  ipcMain.handle('sync:history', async (_event, limit?: number) => {
-    try {
-      const history = sync.getSyncHistory(limit);
-      return { success: true, history };
-    } catch (error) {
-      return {
-        success: false,
-        history: [],
-        error: error instanceof Error ? error.message : 'Failed to get sync history',
-      };
-    }
+  defineIpcHandler({
+    channel: 'sync:pushTags',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        return await sync.pushTags();
+      } catch (error) {
+        return { success: false, pushed: 0, error: String(error) };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'sync:history',
+    args: z.tuple([z.number().int().positive().max(10000).optional()]),
+    handler: limit => {
+      try {
+        const history = sync.getSyncHistory(limit);
+        return { success: true, history };
+      } catch (error) {
+        return {
+          success: false,
+          history: [],
+          error: error instanceof Error ? error.message : 'Failed to get sync history',
+        };
+      }
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // E2EE Key Management
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Check if encryption is ready (CEK cached locally)
-  ipcMain.handle('encryption:isReady', async () => {
-    return { ready: encryption?.isReady() ?? false };
+  defineIpcHandler({
+    channel: 'encryption:isReady',
+    args: z.tuple([]),
+    handler: () => ({ ready: encryption?.isReady() ?? false }),
   });
 
-  // Check if this is a first-time setup or existing user
-  ipcMain.handle('encryption:getKeyStatus', async () => {
-    try {
-      const serverKeys = await client.getEncryptionKeys();
-      const hasLocalKey = encryption?.isReady() ?? false;
-      const hasLegacyKey = encryption?.hasLegacyKey() ?? false;
-
-      return {
-        success: true,
-        hasServerKeys: serverKeys.exists,
-        hasLocalKey,
-        hasLegacyKey,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get key status',
-      };
-    }
-  });
-
-  // First device: set up encryption keys with passphrase
-  ipcMain.handle('encryption:setupKeys', async (_event, passphrase: string) => {
-    try {
-      if (!encryption) throw new Error('Encryption service not available');
-
-      const result = await encryption.setupKeys(passphrase);
-
-      // Upload to server
-      await client.setEncryptionKeys({
-        salt: result.salt,
-        wrappedCek: result.wrappedCek,
-        wrappedCekRecovery: result.wrappedCekRecovery,
-        kdfParams: result.kdfParams,
-      });
-
-      return {
-        success: true,
-        recoveryKey: result.recoveryKey, // Show once to user!
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to setup encryption keys',
-      };
-    }
-  });
-
-  // New device: unlock with passphrase
-  ipcMain.handle('encryption:unlockWithPassphrase', async (_event, passphrase: string) => {
-    try {
-      if (!encryption) throw new Error('Encryption service not available');
-
-      const serverKeys = await client.getEncryptionKeys();
-      if (
-        !serverKeys.exists ||
-        !serverKeys.salt ||
-        !serverKeys.wrappedCek ||
-        !serverKeys.kdfParams
-      ) {
-        return { success: false, error: 'No encryption keys found on server' };
+  defineIpcHandler({
+    channel: 'encryption:getKeyStatus',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const serverKeys = await client.getEncryptionKeys();
+        const hasLocalKey = encryption?.isReady() ?? false;
+        const hasLegacyKey = encryption?.hasLegacyKey() ?? false;
+        return {
+          success: true,
+          hasServerKeys: serverKeys.exists,
+          hasLocalKey,
+          hasLegacyKey,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get key status',
+        };
       }
-
-      await encryption.unlockWithPassphrase(
-        passphrase,
-        serverKeys.salt,
-        serverKeys.wrappedCek,
-        serverKeys.kdfParams
-      );
-
-      return { success: true };
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : 'Failed to unlock';
-      const isWrongPassphrase = msg.includes('incorrect passphrase') || msg.includes('unwrap');
-      return {
-        success: false,
-        wrongPassphrase: isWrongPassphrase,
-        error: isWrongPassphrase ? 'Incorrect passphrase' : msg,
-      };
-    }
+    },
   });
 
-  // Unlock with recovery key
-  ipcMain.handle('encryption:unlockWithRecoveryKey', async (_event, recoveryKey: string) => {
-    try {
-      if (!encryption) throw new Error('Encryption service not available');
-
-      const serverKeys = await client.getEncryptionKeys();
-      if (!serverKeys.exists || !serverKeys.wrappedCekRecovery) {
-        return { success: false, error: 'No recovery key found on server' };
+  defineIpcHandler({
+    channel: 'encryption:setupKeys',
+    args: z.tuple([PassphraseSchema]),
+    handler: async passphrase => {
+      try {
+        if (!encryption) throw new Error('Encryption service not available');
+        const result = await encryption.setupKeys(passphrase);
+        await client.setEncryptionKeys({
+          salt: result.salt,
+          wrappedCek: result.wrappedCek,
+          wrappedCekRecovery: result.wrappedCekRecovery,
+          kdfParams: result.kdfParams,
+        });
+        return { success: true, recoveryKey: result.recoveryKey };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to setup encryption keys',
+        };
       }
-
-      await encryption.unlockWithRecoveryKey(recoveryKey, serverKeys.wrappedCekRecovery);
-
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to unlock with recovery key',
-      };
-    }
+    },
   });
 
-  // Migrate legacy per-device key to key hierarchy
-  ipcMain.handle('encryption:migrateLegacyKey', async (_event, passphrase: string) => {
-    try {
-      if (!encryption) throw new Error('Encryption service not available');
-
-      const result = await encryption.migrateLegacyKey(passphrase);
-
-      // Upload to server
-      await client.setEncryptionKeys({
-        salt: result.salt,
-        wrappedCek: result.wrappedCek,
-        wrappedCekRecovery: result.wrappedCekRecovery,
-        kdfParams: result.kdfParams,
-      });
-
-      return {
-        success: true,
-        recoveryKey: result.recoveryKey,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to migrate legacy key',
-      };
-    }
+  defineIpcHandler({
+    channel: 'encryption:unlockWithPassphrase',
+    args: z.tuple([PassphraseSchema]),
+    handler: async passphrase => {
+      try {
+        if (!encryption) throw new Error('Encryption service not available');
+        const serverKeys = await client.getEncryptionKeys();
+        if (
+          !serverKeys.exists ||
+          !serverKeys.salt ||
+          !serverKeys.wrappedCek ||
+          !serverKeys.kdfParams
+        ) {
+          return { success: false, error: 'No encryption keys found on server' };
+        }
+        await encryption.unlockWithPassphrase(
+          passphrase,
+          serverKeys.salt,
+          serverKeys.wrappedCek,
+          serverKeys.kdfParams
+        );
+        return { success: true };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : 'Failed to unlock';
+        const isWrongPassphrase = msg.includes('incorrect passphrase') || msg.includes('unwrap');
+        return {
+          success: false,
+          wrongPassphrase: isWrongPassphrase,
+          error: isWrongPassphrase ? 'Incorrect passphrase' : msg,
+        };
+      }
+    },
   });
 
-  // Change passphrase (re-wrap CEK)
-  ipcMain.handle('encryption:changePassphrase', async (_event, newPassphrase: string) => {
-    try {
-      if (!encryption) throw new Error('Encryption service not available');
+  defineIpcHandler({
+    channel: 'encryption:unlockWithRecoveryKey',
+    args: z.tuple([RecoveryKeySchema]),
+    handler: async recoveryKey => {
+      try {
+        if (!encryption) throw new Error('Encryption service not available');
+        const serverKeys = await client.getEncryptionKeys();
+        if (!serverKeys.exists || !serverKeys.wrappedCekRecovery) {
+          return { success: false, error: 'No recovery key found on server' };
+        }
+        await encryption.unlockWithRecoveryKey(recoveryKey, serverKeys.wrappedCekRecovery);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to unlock with recovery key',
+        };
+      }
+    },
+  });
 
-      const result = await encryption.changePassphrase(newPassphrase);
+  defineIpcHandler({
+    channel: 'encryption:migrateLegacyKey',
+    args: z.tuple([PassphraseSchema]),
+    handler: async passphrase => {
+      try {
+        if (!encryption) throw new Error('Encryption service not available');
+        const result = await encryption.migrateLegacyKey(passphrase);
+        await client.setEncryptionKeys({
+          salt: result.salt,
+          wrappedCek: result.wrappedCek,
+          wrappedCekRecovery: result.wrappedCekRecovery,
+          kdfParams: result.kdfParams,
+        });
+        return { success: true, recoveryKey: result.recoveryKey };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to migrate legacy key',
+        };
+      }
+    },
+  });
 
-      // Upload new wrapped key to server
-      await client.setEncryptionKeys({
-        salt: result.salt,
-        wrappedCek: result.wrappedCek,
-        kdfParams: result.kdfParams,
-      });
-
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to change passphrase',
-      };
-    }
+  defineIpcHandler({
+    channel: 'encryption:changePassphrase',
+    args: z.tuple([PassphraseSchema]),
+    handler: async newPassphrase => {
+      try {
+        if (!encryption) throw new Error('Encryption service not available');
+        const result = await encryption.changePassphrase(newPassphrase);
+        await client.setEncryptionKeys({
+          salt: result.salt,
+          wrappedCek: result.wrappedCek,
+          kdfParams: result.kdfParams,
+        });
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to change passphrase',
+        };
+      }
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Subscription
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Get subscription status
-  ipcMain.handle('subscription:getStatus', async () => {
-    try {
-      const status = await client.getSubscriptionStatus();
-      return {
-        success: true,
-        status,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get subscription status',
-      };
-    }
+  defineIpcHandler({
+    channel: 'subscription:getStatus',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const status = await client.getSubscriptionStatus();
+        return { success: true, status };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get subscription status',
+        };
+      }
+    },
   });
 
-  // Open Stripe billing portal
-  ipcMain.handle('subscription:openPortal', async (_event, returnUrl: string) => {
-    try {
-      const { url } = await client.createPortalSession(returnUrl);
-      void shell.openExternal(url);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to open billing portal',
-      };
-    }
+  defineIpcHandler({
+    channel: 'subscription:openPortal',
+    args: z.tuple([UrlSchema]),
+    handler: async returnUrl => {
+      try {
+        const { url } = await client.createPortalSession(returnUrl);
+        void shell.openExternal(url);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to open billing portal',
+        };
+      }
+    },
   });
 
-  // Open checkout (placeholder - opens pricing page)
-  ipcMain.handle('subscription:openCheckout', async () => {
-    try {
-      void shell.openExternal('https://readied.app/pricing');
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to open checkout',
-      };
-    }
+  defineIpcHandler({
+    channel: 'subscription:openCheckout',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        void shell.openExternal('https://readied.app/pricing');
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to open checkout',
+        };
+      }
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Devices
   // ═══════════════════════════════════════════════════════════════════════════
 
-  ipcMain.handle('devices:list', async () => {
-    try {
-      const result = await client.listDevices();
-      return result.devices;
-    } catch (_error) {
-      return [];
-    }
+  defineIpcHandler({
+    channel: 'devices:list',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const result = await client.listDevices();
+        return result.devices;
+      } catch {
+        return [];
+      }
+    },
   });
 
-  ipcMain.handle('devices:rename', async (_event, deviceId: string, name: string) => {
-    try {
-      await client.renameDevice(deviceId, name);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to rename device',
-      };
-    }
+  defineIpcHandler({
+    channel: 'devices:rename',
+    args: z.tuple([IdSchema, NameSchema]),
+    handler: async (deviceId, name) => {
+      try {
+        await client.renameDevice(deviceId, name);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to rename device',
+        };
+      }
+    },
   });
 
-  ipcMain.handle('devices:revoke', async (_event, deviceId: string) => {
-    try {
-      await client.revokeDevice(deviceId);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to revoke device',
-      };
-    }
+  defineIpcHandler({
+    channel: 'devices:revoke',
+    args: z.tuple([IdSchema]),
+    handler: async deviceId => {
+      try {
+        await client.revokeDevice(deviceId);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to revoke device',
+        };
+      }
+    },
   });
 
-  ipcMain.handle('devices:revokeOthers', async () => {
-    try {
-      const result = await client.revokeOtherDevices();
-      return { success: true, revokedCount: result.revokedCount };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to revoke devices',
-      };
-    }
+  defineIpcHandler({
+    channel: 'devices:revokeOthers',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const result = await client.revokeOtherDevices();
+        return { success: true, revokedCount: result.revokedCount };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to revoke devices',
+        };
+      }
+    },
   });
 
-  ipcMain.handle('devices:getCurrent', async () => {
-    try {
-      const result = await client.listDevices();
-      return result.devices.find(d => d.isCurrent) ?? null;
-    } catch (_error) {
-      return null;
-    }
+  defineIpcHandler({
+    channel: 'devices:getCurrent',
+    args: z.tuple([]),
+    handler: async () => {
+      try {
+        const result = await client.listDevices();
+        return result.devices.find(d => d.isCurrent) ?? null;
+      } catch {
+        return null;
+      }
+    },
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
-  // Encryption Key Management
+  // Encryption Key Management (export/import)
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Export encryption key (for backup)
-  ipcMain.handle('encryption:exportKey', async () => {
-    try {
-      if (!encryption) {
-        throw new Error('Encryption service not initialized');
+  defineIpcHandler({
+    channel: 'encryption:exportKey',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        if (!encryption) throw new Error('Encryption service not initialized');
+        const keyHex = encryption.exportKey();
+        return { success: true, key: keyHex };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to export encryption key',
+        };
       }
-      const keyHex = encryption.exportKey();
-      return {
-        success: true,
-        key: keyHex,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to export encryption key',
-      };
-    }
+    },
   });
 
-  // Import encryption key (for restore)
-  ipcMain.handle('encryption:importKey', async (_event, keyHex: string) => {
-    try {
-      if (!encryption) {
-        throw new Error('Encryption service not initialized');
+  defineIpcHandler({
+    channel: 'encryption:importKey',
+    args: z.tuple([KeyHexSchema]),
+    handler: async keyHex => {
+      try {
+        if (!encryption) throw new Error('Encryption service not initialized');
+        await encryption.importKey(keyHex);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to import encryption key',
+        };
       }
-      await encryption.importKey(keyHex);
-      return {
-        success: true,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to import encryption key',
-      };
-    }
+    },
   });
 }

--- a/apps/desktop/src/main/handlers/dataHandlers.ts
+++ b/apps/desktop/src/main/handlers/dataHandlers.ts
@@ -8,6 +8,7 @@ import { join } from 'path';
 import { writeFile } from 'fs/promises';
 import { copyFileSync, existsSync, unlinkSync } from 'fs';
 import { ipcMain, dialog, shell, app } from 'electron';
+import { z } from 'zod';
 import {
   createBackup,
   listBackups,
@@ -20,6 +21,7 @@ import {
 import { createDatabase, allMigrations } from '@readied/storage-sqlite';
 import { runMigrations } from '@readied/storage-core';
 import { createNoteOperation } from '@readied/core';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { SQLiteNoteRepository, Database } from './types.js';
 
 export interface DataHandlerDeps {
@@ -34,20 +36,27 @@ export interface DataHandlerDeps {
 export function registerDataHandlers(deps: DataHandlerDeps): void {
   const { dataPaths: paths, noteRepository: repo, getDb, setDb } = deps;
 
-  // Create backup
-  ipcMain.handle('data:backup', async () => {
-    return createBackup({
-      backupDir: paths.backups,
-      databasePath: paths.database,
-    });
+  defineIpcHandler({
+    channel: 'data:backup',
+    args: z.tuple([]),
+    handler: () =>
+      createBackup({
+        backupDir: paths.backups,
+        databasePath: paths.database,
+      }),
   });
 
-  // List backups
-  ipcMain.handle('data:backups:list', async () => {
-    return listBackups(paths.backups);
+  defineIpcHandler({
+    channel: 'data:backups:list',
+    args: z.tuple([]),
+    handler: () => listBackups(paths.backups),
   });
 
-  // Restore from backup
+  // Restore uses ipcMain.handle raw because the integrity-check rollback
+  // path is non-trivial state management — see PR #271 for the rationale.
+  // Validation: backupPath must be a non-empty string. We don't constrain
+  // it further (it comes from a native dialog), but the rollback logic
+  // is what guarantees safety, not the schema.
   ipcMain.handle('data:backup:restore', async (_event, backupPath: string) => {
     const currentDb = getDb();
     if (currentDb) {
@@ -123,50 +132,52 @@ export function registerDataHandlers(deps: DataHandlerDeps): void {
     return result;
   });
 
-  // Export notes
-  ipcMain.handle('data:export', async () => {
-    // Show save dialog
-    const { filePath, canceled } = await dialog.showSaveDialog({
-      title: 'Export Notes',
-      defaultPath: join(app.getPath('documents'), 'readied-export'),
-      buttonLabel: 'Export',
-    });
+  defineIpcHandler({
+    channel: 'data:export',
+    args: z.tuple([]),
+    handler: async () => {
+      // Show save dialog
+      const { filePath, canceled } = await dialog.showSaveDialog({
+        title: 'Export Notes',
+        defaultPath: join(app.getPath('documents'), 'readied-export'),
+        buttonLabel: 'Export',
+      });
 
-    if (canceled || !filePath) {
-      return { success: false, error: 'Export cancelled' };
-    }
+      if (canceled || !filePath) {
+        return { success: false, error: 'Export cancelled' };
+      }
 
-    // Get all notes
-    const notes = await repo.list({ archived: 'all' });
-    const snapshots = notes.map(note => ({
-      id: note.id,
-      content: note.content,
-      title: note.title, // Use structural title
-      createdAt: note.metadata.createdAt,
-      updatedAt: note.metadata.updatedAt,
-      tags: [...note.metadata.tags],
-      wordCount: note.metadata.wordCount,
-      archivedAt: note.metadata.archivedAt,
-    }));
+      // Get all notes
+      const notes = await repo.list({ archived: 'all' });
+      const snapshots = notes.map(note => ({
+        id: note.id,
+        content: note.content,
+        title: note.title, // Use structural title
+        createdAt: note.metadata.createdAt,
+        updatedAt: note.metadata.updatedAt,
+        tags: [...note.metadata.tags],
+        wordCount: note.metadata.wordCount,
+        archivedAt: note.metadata.archivedAt,
+      }));
 
-    const result = exportNotes(snapshots, {
-      outputDir: filePath,
-      appVersion: app.getVersion(),
-      includeArchived: true,
-    });
+      const result = exportNotes(snapshots, {
+        outputDir: filePath,
+        appVersion: app.getVersion(),
+        includeArchived: true,
+      });
 
-    if (result.success) {
-      // Open the export folder
-      shell.showItemInFolder(filePath);
-    }
+      if (result.success) {
+        shell.showItemInFolder(filePath);
+      }
 
-    return result;
+      return result;
+    },
   });
 
-  // Export single note to file
-  ipcMain.handle(
-    'data:exportNote',
-    async (_event: Electron.IpcMainInvokeEvent, content: string, suggestedName: string) => {
+  defineIpcHandler({
+    channel: 'data:exportNote',
+    args: z.tuple([z.string().max(1024 * 1024), z.string().max(512)]),
+    handler: async (content, suggestedName) => {
       let safeName =
         suggestedName
           .normalize('NFC')
@@ -196,71 +207,78 @@ export function registerDataHandlers(deps: DataHandlerDeps): void {
           error: error instanceof Error ? error.message : 'Failed to write file',
         };
       }
-    }
-  );
-
-  // Import notes
-  ipcMain.handle('data:import', async () => {
-    // Show folder selection dialog
-    const { filePaths, canceled } = await dialog.showOpenDialog({
-      title: 'Import Notes',
-      properties: ['openDirectory'],
-      buttonLabel: 'Import',
-    });
-
-    const sourceDir = filePaths[0];
-    if (canceled || !sourceDir) {
-      return { success: false, error: 'Import cancelled' };
-    }
-
-    const importType = detectImportType(sourceDir);
-
-    const result = importNotes({
-      sourceDir,
-      type: importType,
-      recursive: true,
-    });
-
-    if (!result.success || !result.notes) {
-      return result;
-    }
-
-    // Import each note
-    let imported = 0;
-    for (const imported_note of result.notes) {
-      try {
-        await createNoteOperation(
-          {
-            content: imported_note.content,
-          },
-          repo
-        );
-        imported++;
-      } catch {
-        // Skip notes that fail to import
-      }
-    }
-
-    return {
-      success: true,
-      noteCount: imported,
-      skipped: result.skipped,
-    };
+    },
   });
 
-  // Get data paths info
-  ipcMain.handle('data:paths', async () => {
-    return {
+  defineIpcHandler({
+    channel: 'data:import',
+    args: z.tuple([]),
+    handler: async () => {
+      // Show folder selection dialog
+      const { filePaths, canceled } = await dialog.showOpenDialog({
+        title: 'Import Notes',
+        properties: ['openDirectory'],
+        buttonLabel: 'Import',
+      });
+
+      const sourceDir = filePaths[0];
+      if (canceled || !sourceDir) {
+        return { success: false, error: 'Import cancelled' };
+      }
+
+      const importType = detectImportType(sourceDir);
+
+      const result = importNotes({
+        sourceDir,
+        type: importType,
+        recursive: true,
+      });
+
+      if (!result.success || !result.notes) {
+        return result;
+      }
+
+      // Import each note
+      let imported = 0;
+      for (const imported_note of result.notes) {
+        try {
+          await createNoteOperation(
+            {
+              content: imported_note.content,
+            },
+            repo
+          );
+          imported++;
+        } catch {
+          // Skip notes that fail to import
+        }
+      }
+
+      return {
+        success: true,
+        noteCount: imported,
+        skipped: result.skipped,
+      };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'data:paths',
+    args: z.tuple([]),
+    handler: () => ({
       root: paths.root,
       database: paths.database,
       backups: paths.backups,
       logs: paths.logs,
-    };
+    }),
   });
 
-  // Open data folder in system file manager
-  ipcMain.handle('data:openFolder', async () => {
-    void shell.openPath(paths.root);
-    return { success: true };
+  defineIpcHandler({
+    channel: 'data:openFolder',
+    args: z.tuple([]),
+    handler: () => {
+      void shell.openPath(paths.root);
+      return { success: true };
+    },
   });
 }

--- a/apps/desktop/src/main/handlers/gitHandlers.ts
+++ b/apps/desktop/src/main/handlers/gitHandlers.ts
@@ -4,113 +4,133 @@
  * Handles git operations for git-backed notebooks.
  */
 
-import { ipcMain } from 'electron';
+import { z } from 'zod';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { GitService } from './types.js';
 
 export interface GitHandlerDeps {
   gitService: GitService;
 }
 
+const IdSchema = z.string().min(1).max(128);
+// SHAs are hex; allow short-SHAs (≥7) up to full 40-char.
+const ShaSchema = z
+  .string()
+  .min(7)
+  .max(40)
+  .regex(/^[a-f0-9]+$/i);
+// Commit messages can be long but not absurd.
+const CommitMessageSchema = z.string().min(1).max(8192);
+// Note file content cap matches the share payload cap.
+const NoteContentSchema = z.string().max(1024 * 1024);
+
 export function registerGitHandlers(deps: GitHandlerDeps): void {
   const { gitService: git } = deps;
 
-  // Initialize git repository for a notebook
-  ipcMain.handle('git:init', async (_event, notebookId: string) => {
-    try {
-      const repoPath = await git.initRepository(notebookId);
-      return {
-        success: true,
-        repoPath,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to initialize git repository',
-      };
-    }
+  defineIpcHandler({
+    channel: 'git:init',
+    args: z.tuple([IdSchema]),
+    handler: async notebookId => {
+      try {
+        const repoPath = await git.initRepository(notebookId);
+        return { success: true, repoPath };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to initialize git repository',
+        };
+      }
+    },
   });
 
-  // Check if notebook has git repository
-  ipcMain.handle('git:isRepo', async (_event, notebookId: string) => {
-    try {
-      const isRepo = await git.isGitRepository(notebookId);
-      return { success: true, isRepo };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to check git repository',
-      };
-    }
+  defineIpcHandler({
+    channel: 'git:isRepo',
+    args: z.tuple([IdSchema]),
+    handler: async notebookId => {
+      try {
+        const isRepo = await git.isGitRepository(notebookId);
+        return { success: true, isRepo };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to check git repository',
+        };
+      }
+    },
   });
 
-  // Commit changes
-  ipcMain.handle(
-    'git:commit',
-    async (_event, notebookId: string, message: string, files?: string[]) => {
+  defineIpcHandler({
+    channel: 'git:commit',
+    args: z.tuple([
+      IdSchema,
+      CommitMessageSchema,
+      z.array(z.string().max(1024)).max(10000).optional(),
+    ]),
+    handler: async (notebookId, message, files) => {
       try {
         const sha = await git.commit(notebookId, message, files);
-        return {
-          success: true,
-          sha,
-        };
+        return { success: true, sha };
       } catch (error) {
         return {
           success: false,
           error: error instanceof Error ? error.message : 'Failed to commit changes',
         };
       }
-    }
-  );
-
-  // Get commit history
-  ipcMain.handle('git:log', async (_event, notebookId: string, limit?: number) => {
-    try {
-      const commits = await git.log(notebookId, limit);
-      return {
-        success: true,
-        commits,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get commit history',
-      };
-    }
+    },
   });
 
-  // Get repository status
-  ipcMain.handle('git:status', async (_event, notebookId: string) => {
-    try {
-      const status = await git.status(notebookId);
-      return {
-        success: true,
-        status,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get repository status',
-      };
-    }
+  defineIpcHandler({
+    channel: 'git:log',
+    args: z.tuple([IdSchema, z.number().int().positive().max(10000).optional()]),
+    handler: async (notebookId, limit) => {
+      try {
+        const commits = await git.log(notebookId, limit);
+        return { success: true, commits };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get commit history',
+        };
+      }
+    },
   });
 
-  // Checkout (revert to) a specific commit
-  ipcMain.handle('git:checkout', async (_event, notebookId: string, commitSha: string) => {
-    try {
-      await git.checkout(notebookId, commitSha);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to checkout commit',
-      };
-    }
+  defineIpcHandler({
+    channel: 'git:status',
+    args: z.tuple([IdSchema]),
+    handler: async notebookId => {
+      try {
+        const status = await git.status(notebookId);
+        return { success: true, status };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get repository status',
+        };
+      }
+    },
   });
 
-  // Write note file to git repository
-  ipcMain.handle(
-    'git:writeNote',
-    async (_event, notebookId: string, noteId: string, content: string) => {
+  defineIpcHandler({
+    channel: 'git:checkout',
+    args: z.tuple([IdSchema, ShaSchema]),
+    handler: async (notebookId, commitSha) => {
+      try {
+        await git.checkout(notebookId, commitSha);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to checkout commit',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'git:writeNote',
+    args: z.tuple([IdSchema, IdSchema, NoteContentSchema]),
+    handler: async (notebookId, noteId, content) => {
       try {
         await git.writeNoteFile(notebookId, noteId, content);
         return { success: true };
@@ -120,35 +140,38 @@ export function registerGitHandlers(deps: GitHandlerDeps): void {
           error: error instanceof Error ? error.message : 'Failed to write note file',
         };
       }
-    }
-  );
-
-  // Read note file from git repository
-  ipcMain.handle('git:readNote', async (_event, notebookId: string, noteId: string) => {
-    try {
-      const content = await git.readNoteFile(notebookId, noteId);
-      return {
-        success: true,
-        content,
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to read note file',
-      };
-    }
+    },
   });
 
-  // Delete note file from git repository
-  ipcMain.handle('git:deleteNote', async (_event, notebookId: string, noteId: string) => {
-    try {
-      await git.deleteNoteFile(notebookId, noteId);
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to delete note file',
-      };
-    }
+  defineIpcHandler({
+    channel: 'git:readNote',
+    args: z.tuple([IdSchema, IdSchema]),
+    handler: async (notebookId, noteId) => {
+      try {
+        const content = await git.readNoteFile(notebookId, noteId);
+        return { success: true, content };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to read note file',
+        };
+      }
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'git:deleteNote',
+    args: z.tuple([IdSchema, IdSchema]),
+    handler: async (notebookId, noteId) => {
+      try {
+        await git.deleteNoteFile(notebookId, noteId);
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to delete note file',
+        };
+      }
+    },
   });
 }

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -7,7 +7,7 @@
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { mkdir, writeFile } from 'fs/promises';
-import { ipcMain } from 'electron';
+import { z } from 'zod';
 import {
   createNoteOperation,
   updateNoteOperation,
@@ -26,6 +26,7 @@ import {
   type NoteStatus,
 } from '@readied/core';
 import { createNoteId, createNotebookId, createTag } from '@readied/core';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { SQLiteNoteRepository, DataPaths, NoteToSnapshotFn } from './types.js';
 
 export interface NoteHandlerDeps {
@@ -34,298 +35,327 @@ export interface NoteHandlerDeps {
   noteToSnapshot: NoteToSnapshotFn;
 }
 
+const IdSchema = z.string().min(1).max(128);
+const TitleSchema = z.string().max(512);
+const ContentSchema = z.string().max(10 * 1024 * 1024); // 10 MiB cap on note content
+const TagSchema = z.string().min(1).max(64);
+const StatusSchema: z.ZodType<NoteStatus> = z.enum(['active', 'on_hold', 'completed', 'dropped']);
+
 export function registerNoteHandlers(deps: NoteHandlerDeps): void {
   const { noteRepository: repo, dataPaths, noteToSnapshot } = deps;
 
-  // Create note
-  ipcMain.handle(
-    'notes:create',
-    async (_event, input: { content: string; id?: string; notebookId?: string }) => {
-      return createNoteOperation(input, repo);
-    }
-  );
+  // ── Notes CRUD ──────────────────────────────────────────────────────────
 
-  // Get note
-  ipcMain.handle('notes:get', async (_event, id: string) => {
-    const noteId = createNoteId(id);
-    return getNoteOperation({ id: noteId }, repo);
+  defineIpcHandler({
+    channel: 'notes:create',
+    args: z.tuple([
+      z.object({
+        content: ContentSchema,
+        id: IdSchema.optional(),
+        notebookId: IdSchema.optional(),
+      }),
+    ]),
+    handler: input => createNoteOperation(input, repo),
   });
 
-  // Update note content
-  ipcMain.handle('notes:update', async (_event, input: { id: string; content: string }) => {
-    const noteId = createNoteId(input.id);
-    return updateNoteOperation({ id: noteId, content: input.content }, repo);
+  defineIpcHandler({
+    channel: 'notes:get',
+    args: z.tuple([IdSchema]),
+    handler: id => getNoteOperation({ id: createNoteId(id) }, repo),
   });
 
-  // Update note title (structural, independent from content)
-  ipcMain.handle('notes:updateTitle', async (_event, input: { id: string; title: string }) => {
-    const noteId = createNoteId(input.id);
-    return updateTitleOperation({ id: noteId, title: input.title }, repo);
+  defineIpcHandler({
+    channel: 'notes:update',
+    args: z.tuple([z.object({ id: IdSchema, content: ContentSchema })]),
+    handler: input =>
+      updateNoteOperation({ id: createNoteId(input.id), content: input.content }, repo),
   });
 
-  // Delete note
-  ipcMain.handle('notes:delete', async (_event, id: string) => {
-    const noteId = createNoteId(id);
-    return deleteNoteOperation({ id: noteId }, repo);
+  defineIpcHandler({
+    channel: 'notes:updateTitle',
+    args: z.tuple([z.object({ id: IdSchema, title: TitleSchema })]),
+    handler: input =>
+      updateTitleOperation({ id: createNoteId(input.id), title: input.title }, repo),
   });
 
-  // Archive note
-  ipcMain.handle('notes:archive', async (_event, id: string) => {
-    const noteId = createNoteId(id);
-    return archiveNoteOperation({ id: noteId }, repo);
+  defineIpcHandler({
+    channel: 'notes:delete',
+    args: z.tuple([IdSchema]),
+    handler: id => deleteNoteOperation({ id: createNoteId(id) }, repo),
   });
 
-  // Restore note
-  ipcMain.handle('notes:restore', async (_event, id: string) => {
-    const noteId = createNoteId(id);
-    return restoreNoteOperation({ id: noteId }, repo);
+  defineIpcHandler({
+    channel: 'notes:archive',
+    args: z.tuple([IdSchema]),
+    handler: id => archiveNoteOperation({ id: createNoteId(id) }, repo),
   });
 
-  // Duplicate note
-  ipcMain.handle('notes:duplicate', async (_event, id: string) => {
-    const noteId = createNoteId(id);
-    return duplicateNoteOperation({ id: noteId }, repo);
+  defineIpcHandler({
+    channel: 'notes:restore',
+    args: z.tuple([IdSchema]),
+    handler: id => restoreNoteOperation({ id: createNoteId(id) }, repo),
   });
 
-  // Move note to notebook
-  ipcMain.handle('notes:move', async (_event, noteId: string, notebookId: string) => {
-    const note = await repo.get(createNoteId(noteId));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id: noteId } };
-    }
-
-    const movedNote = moveNoteToNotebook(note, createNotebookId(notebookId));
-    await repo.save(movedNote);
-
-    return {
-      ok: true,
-      data: noteToSnapshot(movedNote),
-    };
+  defineIpcHandler({
+    channel: 'notes:duplicate',
+    args: z.tuple([IdSchema]),
+    handler: id => duplicateNoteOperation({ id: createNoteId(id) }, repo),
   });
 
-  // Pin note
-  ipcMain.handle('notes:pin', async (_event, id: string) => {
-    const note = await repo.get(createNoteId(id));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id } };
-    }
-
-    const pinnedNote = pinNote(note);
-    await repo.save(pinnedNote);
-
-    return { ok: true, data: noteToSnapshot(pinnedNote) };
-  });
-
-  // Unpin note
-  ipcMain.handle('notes:unpin', async (_event, id: string) => {
-    const note = await repo.get(createNoteId(id));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id } };
-    }
-
-    const unpinnedNote = unpinNote(note);
-    await repo.save(unpinnedNote);
-
-    return { ok: true, data: noteToSnapshot(unpinnedNote) };
-  });
-
-  // Soft delete (move to trash)
-  ipcMain.handle('notes:softDelete', async (_event, id: string) => {
-    const note = await repo.get(createNoteId(id));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id } };
-    }
-
-    const deletedNote = softDeleteNote(note);
-    await repo.save(deletedNote);
-
-    return { ok: true, data: noteToSnapshot(deletedNote) };
-  });
-
-  // Restore from trash
-  ipcMain.handle('notes:restoreDeleted', async (_event, id: string) => {
-    const note = await repo.get(createNoteId(id));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id } };
-    }
-
-    const restoredNote = restoreDeletedNote(note);
-    await repo.save(restoredNote);
-
-    return { ok: true, data: noteToSnapshot(restoredNote) };
-  });
-
-  // Set note status
-  ipcMain.handle('notes:setStatus', async (_event, id: string, status: NoteStatus) => {
-    const note = await repo.get(createNoteId(id));
-    if (!note) {
-      return { ok: false, error: { type: 'NOT_FOUND', id } };
-    }
-
-    const updatedNote = setNoteStatus(note, status);
-    await repo.save(updatedNote);
-
-    return { ok: true, data: noteToSnapshot(updatedNote) };
-  });
-
-  // List notes
-  ipcMain.handle(
-    'notes:list',
-    async (
-      _event,
-      options?: {
-        limit?: number;
-        offset?: number;
-        tag?: string;
-        sortBy?: 'createdAt' | 'updatedAt' | 'title';
-        sortOrder?: 'asc' | 'desc';
-        archived?: 'active' | 'archived' | 'all';
+  defineIpcHandler({
+    channel: 'notes:move',
+    args: z.tuple([IdSchema, IdSchema]),
+    handler: async (noteId, notebookId) => {
+      const note = await repo.get(createNoteId(noteId));
+      if (!note) {
+        return { ok: false, error: { type: 'NOT_FOUND', id: noteId } };
       }
-    ) => {
+      const movedNote = moveNoteToNotebook(note, createNotebookId(notebookId));
+      await repo.save(movedNote);
+      return { ok: true, data: noteToSnapshot(movedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:pin',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const pinnedNote = pinNote(note);
+      await repo.save(pinnedNote);
+      return { ok: true, data: noteToSnapshot(pinnedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:unpin',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const unpinnedNote = unpinNote(note);
+      await repo.save(unpinnedNote);
+      return { ok: true, data: noteToSnapshot(unpinnedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:softDelete',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const deletedNote = softDeleteNote(note);
+      await repo.save(deletedNote);
+      return { ok: true, data: noteToSnapshot(deletedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:restoreDeleted',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const restoredNote = restoreDeletedNote(note);
+      await repo.save(restoredNote);
+      return { ok: true, data: noteToSnapshot(restoredNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:setStatus',
+    args: z.tuple([IdSchema, StatusSchema]),
+    handler: async (id, status) => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const updatedNote = setNoteStatus(note, status);
+      await repo.save(updatedNote);
+      return { ok: true, data: noteToSnapshot(updatedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:list',
+    args: z.tuple([
+      z
+        .object({
+          limit: z.number().int().positive().max(100000).optional(),
+          offset: z.number().int().nonnegative().optional(),
+          tag: TagSchema.optional(),
+          sortBy: z.enum(['createdAt', 'updatedAt', 'title']).optional(),
+          sortOrder: z.enum(['asc', 'desc']).optional(),
+          archived: z.enum(['active', 'archived', 'all']).optional(),
+        })
+        .optional(),
+    ]),
+    handler: async options => {
       const notes = await repo.list(options);
       return notes.map(note => noteToSnapshot(note));
-    }
-  );
-
-  // Search notes
-  ipcMain.handle('notes:search', async (_event, query: string, limit?: number) => {
-    const notes = await repo.search(query, limit);
-    return notes.map(note => noteToSnapshot(note));
+    },
   });
 
-  // Get all tags
-  ipcMain.handle('notes:tags', async () => {
-    return repo.getAllTags();
+  defineIpcHandler({
+    channel: 'notes:search',
+    args: z.tuple([z.string().max(2048), z.number().int().positive().max(10000).optional()]),
+    handler: async (query, limit) => {
+      const notes = await repo.search(query, limit);
+      return notes.map(note => noteToSnapshot(note));
+    },
   });
 
-  // Set manual tags (full replacement)
-  ipcMain.handle('notes:setManualTags', async (_event, noteId: string, tags: string[]) => {
-    const id = createNoteId(noteId);
-    // Normalize tags: trim, lowercase, strip leading '#', remove empties, dedupe
-    const normalizedTags = [
-      ...new Set(tags.map(t => t.trim().toLowerCase().replace(/^#/, '')).filter(t => t.length > 0)),
-    ];
-    repo.setManualTags(
-      id,
-      normalizedTags.map(t => createTag(t))
-    );
-    return { ok: true };
+  // ── Tags ────────────────────────────────────────────────────────────────
+
+  defineIpcHandler({
+    channel: 'notes:tags',
+    args: z.tuple([]),
+    handler: () => repo.getAllTags(),
   });
 
-  // Get manual tags only (for editor to know which are removable)
-  ipcMain.handle('notes:getManualTags', async (_event, noteId: string) => {
-    const id = createNoteId(noteId);
-    return repo.getManualTags(id);
+  defineIpcHandler({
+    channel: 'notes:setManualTags',
+    args: z.tuple([IdSchema, z.array(TagSchema).max(256)]),
+    handler: (noteId, tags) => {
+      const id = createNoteId(noteId);
+      const normalizedTags = [
+        ...new Set(
+          tags.map(t => t.trim().toLowerCase().replace(/^#/, '')).filter(t => t.length > 0)
+        ),
+      ];
+      repo.setManualTags(
+        id,
+        normalizedTags.map(t => createTag(t))
+      );
+      return { ok: true };
+    },
   });
 
-  // Get all tags with colors
-  ipcMain.handle('tags:listWithColors', async () => {
-    return repo.getAllTagsWithColors();
+  defineIpcHandler({
+    channel: 'notes:getManualTags',
+    args: z.tuple([IdSchema]),
+    handler: noteId => repo.getManualTags(createNoteId(noteId)),
   });
 
-  // Set tag color
-  ipcMain.handle('tags:setColor', async (_event, tagName: string, color: string | null) => {
-    repo.setTagColor(tagName, color);
-    return { ok: true };
+  defineIpcHandler({
+    channel: 'tags:listWithColors',
+    args: z.tuple([]),
+    handler: () => repo.getAllTagsWithColors(),
   });
 
-  // Delete tag from system
-  ipcMain.handle('tags:delete', async (_event, tagName: string) => {
-    repo.deleteTag(tagName);
-    return { ok: true };
+  defineIpcHandler({
+    channel: 'tags:setColor',
+    args: z.tuple([TagSchema, z.string().max(32).nullable()]),
+    handler: (tagName, color) => {
+      repo.setTagColor(tagName, color);
+      return { ok: true };
+    },
   });
 
-  // Rename tag across all notes
-  ipcMain.handle('tags:rename', async (_event, oldName: string, newName: string) => {
-    return repo.renameTag(oldName, newName);
+  defineIpcHandler({
+    channel: 'tags:delete',
+    args: z.tuple([TagSchema]),
+    handler: tagName => {
+      repo.deleteTag(tagName);
+      return { ok: true };
+    },
   });
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Links (Wikilinks / Backlinks)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  // Sync links for a note (call after saving note)
-  ipcMain.handle('links:sync', async (_event, noteId: string, content: string) => {
-    repo.syncLinks(createNoteId(noteId), content);
-    return { ok: true };
+  defineIpcHandler({
+    channel: 'tags:rename',
+    args: z.tuple([TagSchema, TagSchema]),
+    handler: (oldName, newName) => repo.renameTag(oldName, newName),
   });
 
-  // Get backlinks (notes that link TO this note)
-  ipcMain.handle('links:backlinks', async (_event, noteId: string) => {
-    return repo.getBacklinks(createNoteId(noteId));
+  // ── Links (Wikilinks / Backlinks) ───────────────────────────────────────
+
+  defineIpcHandler({
+    channel: 'links:sync',
+    args: z.tuple([IdSchema, ContentSchema]),
+    handler: (noteId, content) => {
+      repo.syncLinks(createNoteId(noteId), content);
+      return { ok: true };
+    },
   });
 
-  // Get outgoing links (notes this note links TO)
-  ipcMain.handle('links:outgoing', async (_event, noteId: string) => {
-    return repo.getOutgoingLinks(createNoteId(noteId));
+  defineIpcHandler({
+    channel: 'links:backlinks',
+    args: z.tuple([IdSchema]),
+    handler: noteId => repo.getBacklinks(createNoteId(noteId)),
   });
 
-  // Get graph data (all notes and links for visualization)
-  ipcMain.handle('links:graph', async () => {
-    try {
-      return repo.getGraphData();
-    } catch (error) {
-      console.error('Failed to get graph data:', error);
-      // Return empty data on error
-      return { nodes: [], edges: [] };
-    }
+  defineIpcHandler({
+    channel: 'links:outgoing',
+    args: z.tuple([IdSchema]),
+    handler: noteId => repo.getOutgoingLinks(createNoteId(noteId)),
   });
 
-  // ═══════════════════════════════════════════════════════════════════════════
-  // Embeds (File Resolution)
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  // Resolve embed target to asset:// URL
-  ipcMain.handle('embeds:resolve', async (_event, target: string, noteId: string) => {
-    // Build path to note's assets folder: /assets/{noteId}/{target}
-    const assetPath = join(dataPaths.assets, noteId, target);
-
-    // Check if file exists
-    if (existsSync(assetPath)) {
-      // Return asset:// URL with host (required for browser to recognize protocol)
-      return `asset://local/${noteId}/${target}`;
-    }
-
-    // File not found
-    return null;
+  defineIpcHandler({
+    channel: 'links:graph',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        return repo.getGraphData();
+      } catch (error) {
+        console.error('Failed to get graph data:', error);
+        return { nodes: [], edges: [] };
+      }
+    },
   });
 
-  // Batch resolve multiple embed targets (more efficient)
-  ipcMain.handle(
-    'embeds:resolveBatch',
-    async (_event, targets: string[], noteId: string): Promise<Record<string, string | null>> => {
+  // ── Embeds (File Resolution) ────────────────────────────────────────────
+
+  // Embed targets are filenames inside an asset folder — restrict to
+  // characters that can appear in a generated asset name (no slashes, no
+  // path traversal). The relative-path check inside `join` would catch
+  // most issues but rejecting at the boundary is cheaper.
+  const EmbedTargetSchema = z
+    .string()
+    .min(1)
+    .max(256)
+    .regex(/^[a-zA-Z0-9._-]+$/);
+
+  defineIpcHandler({
+    channel: 'embeds:resolve',
+    args: z.tuple([EmbedTargetSchema, IdSchema]),
+    handler: (target, noteId) => {
+      const assetPath = join(dataPaths.assets, noteId, target);
+      return existsSync(assetPath) ? `asset://local/${noteId}/${target}` : null;
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'embeds:resolveBatch',
+    args: z.tuple([z.array(EmbedTargetSchema).max(1000), IdSchema]),
+    handler: (targets, noteId): Record<string, string | null> => {
       const result: Record<string, string | null> = {};
       for (const target of targets) {
         const assetPath = join(dataPaths.assets, noteId, target);
-        // Return asset:// URL with host (required for browser to recognize protocol)
         result[target] = existsSync(assetPath) ? `asset://local/${noteId}/${target}` : null;
       }
       return result;
-    }
-  );
+    },
+  });
 
-  // Save asset (image/file) for a note via drag & drop or paste
-  ipcMain.handle(
-    'embeds:saveAsset',
-    async (
-      _event,
-      noteId: string,
-      mime: string,
-      bytes: ArrayBuffer,
-      originalName?: string
+  defineIpcHandler({
+    channel: 'embeds:saveAsset',
+    args: z.tuple([
+      IdSchema.regex(/^[\w-]+$/),
+      z.string().min(1).max(256),
+      z.instanceof(ArrayBuffer),
+      z.string().max(512).optional(),
+    ]),
+    handler: async (
+      noteId,
+      mime,
+      bytes,
+      originalName
     ): Promise<{ ok: true; filename: string; relPath: string } | { ok: false; error: string }> => {
-      // Validate noteId (non-empty, alphanumeric with hyphens/underscores)
-      if (!noteId || !/^[\w-]+$/.test(noteId)) {
-        return { ok: false, error: 'Invalid noteId' };
-      }
-
-      // Validate size (max 20MB)
       const MAX_SIZE = 20 * 1024 * 1024;
       if (bytes.byteLength > MAX_SIZE) {
         return { ok: false, error: 'File too large (max 20MB)' };
       }
 
-      // Derive extension from mime type
       const mimeToExt: Record<string, string> = {
         'image/png': 'png',
         'image/jpeg': 'jpg',
@@ -346,142 +376,122 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
 
       let ext = mimeToExt[mime];
       if (!ext && originalName) {
-        // Fallback to originalName extension
         const match = originalName.match(/\.([a-zA-Z0-9]+)$/);
         ext = match?.[1]?.toLowerCase() ?? 'bin';
       }
-      if (!ext) {
-        ext = 'bin';
-      }
+      if (!ext) ext = 'bin';
 
-      // Generate unique filename: timestamp-random.ext
       const timestamp = Date.now();
       const random = Math.random().toString(36).substring(2, 8);
       const filename = `${timestamp}-${random}.${ext}`;
 
-      // Ensure note's assets directory exists
       const noteAssetsDir = join(dataPaths.assets, noteId);
       await mkdir(noteAssetsDir, { recursive: true });
 
-      // Write file
       const assetPath = join(noteAssetsDir, filename);
       await writeFile(assetPath, Buffer.from(bytes));
 
-      return {
-        ok: true,
-        filename,
-        relPath: `${noteId}/${filename}`,
-      };
-    }
-  );
-
-  // Activity stats (notes created/updated per week, last 52 weeks)
-  ipcMain.handle('notes:activityStats', async () => {
-    const allNotes = await repo.list({ archived: 'all', limit: 10000 });
-    const now = Date.now();
-    const fiftyTwoWeeksAgo = now - 52 * 7 * 24 * 60 * 60 * 1000;
-
-    // Build a map of week -> { created, updated }
-    const weekMap = new Map<string, { created: number; updated: number }>();
-
-    for (const note of allNotes) {
-      const createdMs = new Date(note.metadata.createdAt).getTime();
-      const updatedMs = new Date(note.metadata.updatedAt).getTime();
-
-      if (createdMs >= fiftyTwoWeeksAgo) {
-        const weekKey = getISOWeek(new Date(note.metadata.createdAt));
-        const entry = weekMap.get(weekKey) ?? { created: 0, updated: 0 };
-        entry.created++;
-        weekMap.set(weekKey, entry);
-      }
-
-      if (updatedMs >= fiftyTwoWeeksAgo && updatedMs !== createdMs) {
-        const weekKey = getISOWeek(new Date(note.metadata.updatedAt));
-        const entry = weekMap.get(weekKey) ?? { created: 0, updated: 0 };
-        entry.updated++;
-        weekMap.set(weekKey, entry);
-      }
-    }
-
-    // Convert to sorted array
-    const weeks = Array.from(weekMap.entries())
-      .map(([week, counts]) => ({ week, ...counts }))
-      .sort((a, b) => a.week.localeCompare(b.week));
-
-    // Calculate current streak (consecutive weeks with activity ending at current week)
-    const currentWeek = getISOWeek(new Date());
-    let streak = 0;
-    let checkDate = new Date();
-    for (let i = 0; i < 52; i++) {
-      const weekKey = getISOWeek(checkDate);
-      const entry = weekMap.get(weekKey);
-      if (entry && (entry.created > 0 || entry.updated > 0)) {
-        streak++;
-      } else if (i > 0) {
-        // Allow current week to have no activity yet
-        break;
-      }
-      checkDate = new Date(checkDate.getTime() - 7 * 24 * 60 * 60 * 1000);
-    }
-
-    return {
-      weeks,
-      totalNotes: allNotes.length,
-      currentStreak: streak,
-      currentWeek,
-    };
+      return { ok: true, filename, relPath: `${noteId}/${filename}` };
+    },
   });
 
-  // Count notes
-  ipcMain.handle('notes:count', async () => {
-    // Get all notes to compute counts
-    const allNotes = await repo.list({ archived: 'all' });
+  // ── Stats / counts ──────────────────────────────────────────────────────
 
-    const counts = {
-      active: 0,
-      archived: 0,
-      total: allNotes.length,
-      pinned: 0,
-      deleted: 0,
-      byStatus: {
+  defineIpcHandler({
+    channel: 'notes:activityStats',
+    args: z.tuple([]),
+    handler: async () => {
+      const allNotes = await repo.list({ archived: 'all', limit: 10000 });
+      const now = Date.now();
+      const fiftyTwoWeeksAgo = now - 52 * 7 * 24 * 60 * 60 * 1000;
+
+      const weekMap = new Map<string, { created: number; updated: number }>();
+
+      for (const note of allNotes) {
+        const createdMs = new Date(note.metadata.createdAt).getTime();
+        const updatedMs = new Date(note.metadata.updatedAt).getTime();
+
+        if (createdMs >= fiftyTwoWeeksAgo) {
+          const weekKey = getISOWeek(new Date(note.metadata.createdAt));
+          const entry = weekMap.get(weekKey) ?? { created: 0, updated: 0 };
+          entry.created++;
+          weekMap.set(weekKey, entry);
+        }
+
+        if (updatedMs >= fiftyTwoWeeksAgo && updatedMs !== createdMs) {
+          const weekKey = getISOWeek(new Date(note.metadata.updatedAt));
+          const entry = weekMap.get(weekKey) ?? { created: 0, updated: 0 };
+          entry.updated++;
+          weekMap.set(weekKey, entry);
+        }
+      }
+
+      const weeks = Array.from(weekMap.entries())
+        .map(([week, counts]) => ({ week, ...counts }))
+        .sort((a, b) => a.week.localeCompare(b.week));
+
+      const currentWeek = getISOWeek(new Date());
+      let streak = 0;
+      let checkDate = new Date();
+      for (let i = 0; i < 52; i++) {
+        const weekKey = getISOWeek(checkDate);
+        const entry = weekMap.get(weekKey);
+        if (entry && (entry.created > 0 || entry.updated > 0)) {
+          streak++;
+        } else if (i > 0) {
+          break;
+        }
+        checkDate = new Date(checkDate.getTime() - 7 * 24 * 60 * 60 * 1000);
+      }
+
+      return {
+        weeks,
+        totalNotes: allNotes.length,
+        currentStreak: streak,
+        currentWeek,
+      };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:count',
+    args: z.tuple([]),
+    handler: async () => {
+      const allNotes = await repo.list({ archived: 'all' });
+
+      const counts = {
         active: 0,
-        on_hold: 0,
-        completed: 0,
-        dropped: 0,
-      } as Record<NoteStatus, number>,
-      byNotebook: {} as Record<string, number>,
-    };
+        archived: 0,
+        total: allNotes.length,
+        pinned: 0,
+        deleted: 0,
+        byStatus: {
+          active: 0,
+          on_hold: 0,
+          completed: 0,
+          dropped: 0,
+        } as Record<NoteStatus, number>,
+        byNotebook: {} as Record<string, number>,
+      };
 
-    for (const note of allNotes) {
-      // Count archived
-      if (note.metadata.archivedAt !== null) {
-        counts.archived++;
-      } else {
-        counts.active++;
+      for (const note of allNotes) {
+        if (note.metadata.archivedAt !== null) counts.archived++;
+        else counts.active++;
+
+        if (note.isPinned) counts.pinned++;
+        if (note.isDeleted) counts.deleted++;
+
+        if (note.status && counts.byStatus[note.status] !== undefined) {
+          counts.byStatus[note.status]++;
+        }
+
+        if (note.notebookId && !note.isDeleted && !note.metadata.archivedAt) {
+          counts.byNotebook[note.notebookId] = (counts.byNotebook[note.notebookId] || 0) + 1;
+        }
       }
 
-      // Count pinned
-      if (note.isPinned) {
-        counts.pinned++;
-      }
-
-      // Count deleted (in trash)
-      if (note.isDeleted) {
-        counts.deleted++;
-      }
-
-      // Count by status
-      if (note.status && counts.byStatus[note.status] !== undefined) {
-        counts.byStatus[note.status]++;
-      }
-
-      // Count by notebook (active, non-deleted notes only)
-      if (note.notebookId && !note.isDeleted && !note.metadata.archivedAt) {
-        counts.byNotebook[note.notebookId] = (counts.byNotebook[note.notebookId] || 0) + 1;
-      }
-    }
-
-    return counts;
+      return counts;
+    },
   });
 }
 
@@ -489,7 +499,6 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
 function getISOWeek(date: Date): string {
   const d = new Date(date.getTime());
   d.setHours(0, 0, 0, 0);
-  // Set to nearest Thursday (current date + 4 - current day number, with Sunday=7)
   d.setDate(d.getDate() + 4 - (d.getDay() || 7));
   const yearStart = new Date(d.getFullYear(), 0, 1);
   const weekNum = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);

--- a/apps/desktop/src/main/handlers/notebookHandlers.ts
+++ b/apps/desktop/src/main/handlers/notebookHandlers.ts
@@ -4,7 +4,7 @@
  * Handles notebook CRUD, git settings per notebook, and reordering.
  */
 
-import { ipcMain } from 'electron';
+import { z } from 'zod';
 import {
   createNotebookId,
   createNotebook,
@@ -12,267 +12,271 @@ import {
   moveNotebook,
   INBOX_NOTEBOOK_ID,
 } from '@readied/core';
+import { defineIpcHandler } from '../ipc/registry.js';
 import type { SQLiteNotebookRepository } from './types.js';
 
 export interface NotebookHandlerDeps {
   notebookRepository: SQLiteNotebookRepository;
 }
 
+const IdSchema = z.string().min(1).max(128);
+const NameSchema = z.string().min(1).max(256);
+
 export function registerNotebookHandlers(deps: NotebookHandlerDeps): void {
   const { notebookRepository: repo } = deps;
 
-  // List all notebooks
-  ipcMain.handle('notebooks:list', async () => {
-    const notebooks = await repo.getAll();
-    return notebooks.map(nb => ({
-      id: nb.id,
-      name: nb.name,
-      parentId: nb.parentId,
-      depth: nb.depth,
-      order: nb.order,
-      createdAt: nb.createdAt,
-      updatedAt: nb.updatedAt,
-    }));
+  const serialize = (nb: {
+    id: string;
+    name: string;
+    parentId: string | null;
+    depth: number;
+    order: number;
+    createdAt: string;
+    updatedAt: string;
+  }) => ({
+    id: nb.id,
+    name: nb.name,
+    parentId: nb.parentId,
+    depth: nb.depth,
+    order: nb.order,
+    createdAt: nb.createdAt,
+    updatedAt: nb.updatedAt,
   });
 
-  // Get notebook tree
-  ipcMain.handle('notebooks:tree', async () => {
-    return repo.getTree();
+  defineIpcHandler({
+    channel: 'notebooks:list',
+    args: z.tuple([]),
+    handler: async () => {
+      const notebooks = await repo.getAll();
+      return notebooks.map(serialize);
+    },
   });
 
-  // Get single notebook
-  ipcMain.handle('notebooks:get', async (_event, id: string) => {
-    const notebook = await repo.get(createNotebookId(id));
-    if (!notebook) return null;
-    return {
-      id: notebook.id,
-      name: notebook.name,
-      parentId: notebook.parentId,
-      depth: notebook.depth,
-      order: notebook.order,
-      createdAt: notebook.createdAt,
-      updatedAt: notebook.updatedAt,
-    };
+  defineIpcHandler({
+    channel: 'notebooks:tree',
+    args: z.tuple([]),
+    handler: () => repo.getTree(),
   });
 
-  // Get notebook with metadata
-  ipcMain.handle('notebooks:getWithMetadata', async (_event, id: string) => {
-    const notebook = await repo.getWithMetadata(createNotebookId(id));
-    if (!notebook) return null;
-    return {
-      id: notebook.id,
-      name: notebook.name,
-      parentId: notebook.parentId,
-      depth: notebook.depth,
-      order: notebook.order,
-      createdAt: notebook.createdAt,
-      updatedAt: notebook.updatedAt,
-      noteCount: notebook.noteCount,
-      childCount: notebook.childCount,
-    };
+  defineIpcHandler({
+    channel: 'notebooks:get',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const notebook = await repo.get(createNotebookId(id));
+      return notebook ? serialize(notebook) : null;
+    },
   });
 
-  // Create notebook
-  ipcMain.handle('notebooks:create', async (_event, input: { name: string; parentId?: string }) => {
-    let parentDepth = 0;
-    if (input.parentId) {
-      const parent = await repo.get(createNotebookId(input.parentId));
-      if (parent) {
-        parentDepth = parent.depth;
+  defineIpcHandler({
+    channel: 'notebooks:getWithMetadata',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const notebook = await repo.getWithMetadata(createNotebookId(id));
+      if (!notebook) return null;
+      return {
+        ...serialize(notebook),
+        noteCount: notebook.noteCount,
+        childCount: notebook.childCount,
+      };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notebooks:create',
+    args: z.tuple([
+      z.object({
+        name: NameSchema,
+        parentId: IdSchema.optional(),
+      }),
+    ]),
+    handler: async input => {
+      let parentDepth = 0;
+      if (input.parentId) {
+        const parent = await repo.get(createNotebookId(input.parentId));
+        if (parent) parentDepth = parent.depth;
       }
-    }
 
-    const nextOrder = await repo.getNextOrder(
-      input.parentId ? createNotebookId(input.parentId) : null
-    );
+      const nextOrder = await repo.getNextOrder(
+        input.parentId ? createNotebookId(input.parentId) : null
+      );
 
-    const notebook = createNotebook({
-      name: input.name,
-      parentId: input.parentId ? createNotebookId(input.parentId) : null,
-      parentDepth,
-      order: nextOrder,
-    });
+      const notebook = createNotebook({
+        name: input.name,
+        parentId: input.parentId ? createNotebookId(input.parentId) : null,
+        parentDepth,
+        order: nextOrder,
+      });
 
-    await repo.save(notebook);
-
-    return {
-      id: notebook.id,
-      name: notebook.name,
-      parentId: notebook.parentId,
-      depth: notebook.depth,
-      order: notebook.order,
-      createdAt: notebook.createdAt,
-      updatedAt: notebook.updatedAt,
-    };
+      await repo.save(notebook);
+      return serialize(notebook);
+    },
   });
 
-  // Rename notebook
-  ipcMain.handle('notebooks:rename', async (_event, id: string, name: string) => {
-    const notebook = await repo.get(createNotebookId(id));
-    if (!notebook) {
-      throw new Error('Notebook not found');
-    }
-
-    const updated = renameNotebook(notebook, name);
-    await repo.save(updated);
-
-    return {
-      id: updated.id,
-      name: updated.name,
-      parentId: updated.parentId,
-      depth: updated.depth,
-      order: updated.order,
-      createdAt: updated.createdAt,
-      updatedAt: updated.updatedAt,
-    };
+  defineIpcHandler({
+    channel: 'notebooks:rename',
+    args: z.tuple([IdSchema, NameSchema]),
+    handler: async (id, name) => {
+      const notebook = await repo.get(createNotebookId(id));
+      if (!notebook) {
+        throw new Error('Notebook not found');
+      }
+      const updated = renameNotebook(notebook, name);
+      await repo.save(updated);
+      return serialize(updated);
+    },
   });
 
-  // Move notebook (recursively updates children's depth)
-  ipcMain.handle('notebooks:move', async (_event, id: string, newParentId: string | null) => {
-    const notebook = await repo.get(createNotebookId(id));
-    if (!notebook) {
-      throw new Error('Notebook not found');
-    }
-
-    // Prevent circular reference: can't move a notebook into its own descendant
-    if (newParentId) {
-      let current = await repo.get(createNotebookId(newParentId));
-      while (current && current.parentId) {
-        if (current.parentId === notebook.id) {
-          throw new Error('CIRCULAR_REFERENCE');
-        }
-        current = await repo.get(current.parentId);
+  defineIpcHandler({
+    channel: 'notebooks:move',
+    args: z.tuple([IdSchema, IdSchema.nullable()]),
+    handler: async (id, newParentId) => {
+      const notebook = await repo.get(createNotebookId(id));
+      if (!notebook) {
+        throw new Error('Notebook not found');
       }
-    }
 
-    let newParentDepth = 0;
-    if (newParentId) {
-      const parent = await repo.get(createNotebookId(newParentId));
-      if (parent) {
-        newParentDepth = parent.depth;
-      }
-    }
-
-    const result = moveNotebook(
-      notebook,
-      newParentId ? createNotebookId(newParentId) : null,
-      newParentDepth
-    );
-
-    if (!result.success) {
-      throw new Error(result.reason);
-    }
-
-    await repo.save(result.notebook);
-
-    // Recursively update children's depth to match the new hierarchy
-    const updateChildrenDepth = async (parentId: string, parentDepth: number) => {
-      const children = await repo.getChildren(parentId as ReturnType<typeof createNotebookId>);
-      for (const child of children) {
-        const newChildDepth = parentDepth + 1;
-        if (child.depth !== newChildDepth) {
-          await repo.save({ ...child, depth: newChildDepth });
-          await updateChildrenDepth(child.id, newChildDepth);
+      // Prevent circular reference: can't move a notebook into its own descendant
+      if (newParentId) {
+        let current = await repo.get(createNotebookId(newParentId));
+        while (current && current.parentId) {
+          if (current.parentId === notebook.id) {
+            throw new Error('CIRCULAR_REFERENCE');
+          }
+          current = await repo.get(current.parentId);
         }
       }
-    };
-    await updateChildrenDepth(result.notebook.id, result.notebook.depth);
 
-    return {
-      id: result.notebook.id,
-      name: result.notebook.name,
-      parentId: result.notebook.parentId,
-      depth: result.notebook.depth,
-      order: result.notebook.order,
-      createdAt: result.notebook.createdAt,
-      updatedAt: result.notebook.updatedAt,
-    };
+      let newParentDepth = 0;
+      if (newParentId) {
+        const parent = await repo.get(createNotebookId(newParentId));
+        if (parent) newParentDepth = parent.depth;
+      }
+
+      const result = moveNotebook(
+        notebook,
+        newParentId ? createNotebookId(newParentId) : null,
+        newParentDepth
+      );
+
+      if (!result.success) {
+        throw new Error(result.reason);
+      }
+
+      await repo.save(result.notebook);
+
+      const updateChildrenDepth = async (parentId: string, parentDepth: number) => {
+        const children = await repo.getChildren(parentId as ReturnType<typeof createNotebookId>);
+        for (const child of children) {
+          const newChildDepth = parentDepth + 1;
+          if (child.depth !== newChildDepth) {
+            await repo.save({ ...child, depth: newChildDepth });
+            await updateChildrenDepth(child.id, newChildDepth);
+          }
+        }
+      };
+      await updateChildrenDepth(result.notebook.id, result.notebook.depth);
+
+      return serialize(result.notebook);
+    },
   });
 
-  // Delete notebook
-  ipcMain.handle('notebooks:delete', async (_event, id: string) => {
-    const notebookId = createNotebookId(id);
-
-    if (notebookId === INBOX_NOTEBOOK_ID) {
-      throw new Error('Cannot delete Inbox notebook');
-    }
-
-    await repo.delete(notebookId);
-    return { success: true };
+  defineIpcHandler({
+    channel: 'notebooks:delete',
+    args: z.tuple([IdSchema]),
+    handler: async id => {
+      const notebookId = createNotebookId(id);
+      if (notebookId === INBOX_NOTEBOOK_ID) {
+        throw new Error('Cannot delete Inbox notebook');
+      }
+      await repo.delete(notebookId);
+      return { success: true };
+    },
   });
 
-  // Reorder notebooks within a parent
-  ipcMain.handle(
-    'notebooks:reorder',
-    async (_event, parentId: string | null, orderedIds: string[]) => {
+  defineIpcHandler({
+    channel: 'notebooks:reorder',
+    args: z.tuple([IdSchema.nullable(), z.array(IdSchema).max(10000)]),
+    handler: async (parentId, orderedIds) => {
       await repo.reorder(
         parentId ? createNotebookId(parentId) : null,
         orderedIds.map(id => createNotebookId(id))
       );
       return { success: true };
-    }
-  );
+    },
+  });
 
   // ═══════════════════════════════════════════════════════════════════════════
   // Git Settings per Notebook
   // ═══════════════════════════════════════════════════════════════════════════
 
-  // Enable git for a notebook
-  ipcMain.handle('notebooks:enableGit', async (_event, notebookId: string) => {
-    try {
-      repo.enableGit(createNotebookId(notebookId));
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to enable git',
-      };
-    }
+  defineIpcHandler({
+    channel: 'notebooks:enableGit',
+    args: z.tuple([IdSchema]),
+    handler: notebookId => {
+      try {
+        repo.enableGit(createNotebookId(notebookId));
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to enable git',
+        };
+      }
+    },
   });
 
-  // Disable git for a notebook
-  ipcMain.handle('notebooks:disableGit', async (_event, notebookId: string) => {
-    try {
-      repo.disableGit(createNotebookId(notebookId));
-      return { success: true };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to disable git',
-      };
-    }
+  defineIpcHandler({
+    channel: 'notebooks:disableGit',
+    args: z.tuple([IdSchema]),
+    handler: notebookId => {
+      try {
+        repo.disableGit(createNotebookId(notebookId));
+        return { success: true };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to disable git',
+        };
+      }
+    },
   });
 
-  // Check if git is enabled for a notebook
-  ipcMain.handle('notebooks:isGitEnabled', async (_event, notebookId: string) => {
-    try {
-      const enabled = repo.isGitEnabled(createNotebookId(notebookId));
-      return { success: true, enabled };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to check git status',
-      };
-    }
+  defineIpcHandler({
+    channel: 'notebooks:isGitEnabled',
+    args: z.tuple([IdSchema]),
+    handler: notebookId => {
+      try {
+        const enabled = repo.isGitEnabled(createNotebookId(notebookId));
+        return { success: true, enabled };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to check git status',
+        };
+      }
+    },
   });
 
-  // Get git settings for a notebook
-  ipcMain.handle('notebooks:getGitSettings', async (_event, notebookId: string) => {
-    try {
-      const settings = repo.getGitSettings(createNotebookId(notebookId));
-      return { success: true, settings };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get git settings',
-      };
-    }
+  defineIpcHandler({
+    channel: 'notebooks:getGitSettings',
+    args: z.tuple([IdSchema]),
+    handler: notebookId => {
+      try {
+        const settings = repo.getGitSettings(createNotebookId(notebookId));
+        return { success: true, settings };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get git settings',
+        };
+      }
+    },
   });
 
-  // Toggle auto-commit for a notebook
-  ipcMain.handle(
-    'notebooks:setGitAutoCommit',
-    async (_event, notebookId: string, enabled: boolean) => {
+  defineIpcHandler({
+    channel: 'notebooks:setGitAutoCommit',
+    args: z.tuple([IdSchema, z.boolean()]),
+    handler: (notebookId, enabled) => {
       try {
         repo.setGitAutoCommit(createNotebookId(notebookId), enabled);
         return { success: true };
@@ -282,30 +286,22 @@ export function registerNotebookHandlers(deps: NotebookHandlerDeps): void {
           error: error instanceof Error ? error.message : 'Failed to set auto-commit',
         };
       }
-    }
-  );
+    },
+  });
 
-  // Get all git-enabled notebooks
-  ipcMain.handle('notebooks:getGitEnabled', async () => {
-    try {
-      const notebooks = repo.getGitEnabledNotebooks();
-      return {
-        success: true,
-        notebooks: notebooks.map(nb => ({
-          id: nb.id,
-          name: nb.name,
-          parentId: nb.parentId,
-          depth: nb.depth,
-          order: nb.order,
-          createdAt: nb.createdAt,
-          updatedAt: nb.updatedAt,
-        })),
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : 'Failed to get git-enabled notebooks',
-      };
-    }
+  defineIpcHandler({
+    channel: 'notebooks:getGitEnabled',
+    args: z.tuple([]),
+    handler: () => {
+      try {
+        const notebooks = repo.getGitEnabledNotebooks();
+        return { success: true, notebooks: notebooks.map(serialize) };
+      } catch (error) {
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : 'Failed to get git-enabled notebooks',
+        };
+      }
+    },
   });
 }


### PR DESCRIPTION
## Summary

Completes the IPC registry migration started in #272 (registry) → #273 (light handlers). Five remaining handler modules (~97 channels) now run through \`defineIpcHandler\` with Zod tuple validation at the boundary. **The full IPC surface of the desktop app is now validated.**

## Files

| Module | Channels | Notes |
|---|---|---|
| \`notebookHandlers.ts\` | 15 | Notebook CRUD + per-notebook git settings. Common \`serialize(nb)\` helper avoids 6 copies of the same object spread. |
| \`gitHandlers.ts\` | 9 | Short-SHA accepted (≥7 hex), commit message ≤8 KiB, note content ≤1 MiB. |
| \`dataHandlers.ts\` | 7 of 8 | backup/list/export/exportNote/import/paths/openFolder migrated. **\`data:backup:restore\`** stays raw — the integrity-check + rollback state machine from #271 doesn't fit the registry's wrapper cleanly. |
| \`noteHandlers.ts\` | 32 | Notes CRUD, tags, links, embeds, stats. \`EmbedTargetSchema\` regex-constrained to filename-safe characters (no slashes, no path traversal) at the boundary in addition to the existing \`join()\` guard. \`ArrayBuffer\` validated via \`z.instanceof(ArrayBuffer)\` on \`embeds:saveAsset\`. |
| \`authSyncHandlers.ts\` | 33 | Auth/magic-link, sync (pull/push/syncNow/conflicts/auto-sync/history), E2EE key management, subscription portal, devices. \`SyncChangeSchema\` is the most complex shape here. |

## Exceptions (still raw \`ipcMain\`)

After this PR every \`ipcMain.handle\` in \`apps/desktop/src/main/handlers/\` either goes through \`defineIpcHandler\` or has an explanatory comment:

| Channel | Why raw |
|---|---|
| \`updates:installNow\` | Synchronous quit + window destruction path; registry's async wrapper would interfere |
| \`plugins:requestReload\` | Uses \`ipcMain.on\` — fire-and-forget event, not invoke |
| \`data:backup:restore\` | Integrity-check rollback state machine from PR #271 |

These are documented in code as well as listed here.

## Schema highlights

- \`SyncChangeSchema\`: \`{ noteId, operation: enum, content?: ≤10 MiB, localVersion?: int }\` — the boundary now catches malformed push payloads instead of letting them flow into the sync engine.
- \`EmbedTargetSchema\`: \`/^[a-zA-Z0-9._-]+$/\` — defense in depth on top of \`join()\` for path traversal.
- \`KeyHexSchema\` for encryption export/import — strict hex format, length 32–256 chars.
- All \`IdSchema\`s capped at 128 chars; \`TagSchema\` at 64; \`ContentSchema\` at 10 MiB; \`CommitMessageSchema\` at 8 KiB.

## Test plan

- [x] \`pnpm -r typecheck\` — green.
- [x] \`pnpm test\` — 17/17 packages.
- [ ] Manual: exercise notes CRUD, tag operations, sync cycle, encryption setup, device management.
- [ ] Manual: send malformed payloads via DevTools (e.g. \`window.readied.sync.push('not-an-array')\`) and expect \`IpcValidationError\`.

## Stack context

**PR-F5** in the audit stack. Stacked on top of #273 (PR-F4) → #272 (PR-F1) → #271 (PR-I) → #270 (PR-J) → #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B).

## Follow-ups (per Tomy's review)

- **PR-F2** — keychain storage for AI keys via Electron \`safeStorage\` (not keytar).
- **PR-F3** — license verification with **asymmetric** crypto (server signs, client verifies with embedded public key). The original audit's HMAC suggestion is wrong: a client that can verify can also forge.
- **PR-E** — Playwright Electron E2E (deferred until architecture settles).
- **PR-G** — split god files (deferred — too risky to mix with this stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal data validation across IPC handlers for authentication, synchronization, data management, git operations, notes, and notebooks with centralized validation mechanisms.
  * Reorganized handler registrations to ensure consistent response structures and improved runtime argument validation throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->