### PR TITLE
refactor(main): extract FileLicenseStorage and window state to services (PR-G)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,8 +11,7 @@ import { initSentry } from './sentry';
 initSentry();
 
 import { join, normalize } from 'path';
-import { readFile, writeFile, unlink } from 'fs/promises';
-import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 import {
   app,
   BrowserWindow,
@@ -31,16 +30,11 @@ import {
   SQLiteNotebookRepository,
 } from '@readied/storage-sqlite';
 import { createNoteId, createNoteOperation, type NoteStatus } from '@readied/core';
-// eslint-disable-next-line @typescript-eslint/no-deprecated
-import type {
-  LicenseStorage,
-  StoredTrialData,
-  StoredLicenseData,
-  StoredSubscriptionData,
-} from '@readied/licensing';
 import { initLogger, getLogger, loggers } from './logger';
 import { TokenStorage } from './services/tokenStorage.js';
 import { AiKeyStorage } from './services/aiKeyStorage.js';
+import { FileLicenseStorage } from './services/fileLicenseStorage.js';
+import { loadWindowState, saveWindowState } from './services/windowState.js';
 import { getOrCreateDeviceInfo, type DeviceInfo } from './services/deviceInfo.js';
 import { ApiClient } from './services/apiClient.js';
 import { EncryptionService } from './services/encryptionService.js';
@@ -139,119 +133,10 @@ export function noteToSnapshot(note: {
   };
 }
 
-// ============================================================================
-// File-based License Storage
-// ============================================================================
-
-class FileLicenseStorage implements LicenseStorage {
-  private licensePath: string;
-  private trialPath: string;
-  private subscriptionPath: string;
-
-  constructor(dataDir: string) {
-    this.licensePath = join(dataDir, 'license.json');
-    this.trialPath = join(dataDir, 'trial.json');
-    this.subscriptionPath = join(dataDir, 'subscription.json');
-  }
-
-  async readLicenseData(): Promise<StoredLicenseData | null> {
-    try {
-      if (!existsSync(this.licensePath)) {
-        return null;
-      }
-      const content = await readFile(this.licensePath, 'utf-8');
-      return JSON.parse(content) as StoredLicenseData;
-    } catch {
-      return null;
-    }
-  }
-
-  async writeLicenseData(data: StoredLicenseData): Promise<void> {
-    await writeFile(this.licensePath, JSON.stringify(data, null, 2), 'utf-8');
-  }
-
-  async removeLicenseData(): Promise<void> {
-    if (existsSync(this.licensePath)) {
-      await unlink(this.licensePath);
-    }
-  }
-
-  async readTrialData(): Promise<StoredTrialData | null> {
-    try {
-      if (!existsSync(this.trialPath)) {
-        return null;
-      }
-      const content = await readFile(this.trialPath, 'utf-8');
-      return JSON.parse(content) as StoredTrialData;
-    } catch {
-      return null;
-    }
-  }
-
-  async writeTrialData(data: StoredTrialData): Promise<void> {
-    await writeFile(this.trialPath, JSON.stringify(data, null, 2), 'utf-8');
-  }
-
-  async readSubscriptionData(): Promise<StoredSubscriptionData | null> {
-    try {
-      if (!existsSync(this.subscriptionPath)) {
-        return null;
-      }
-      const content = await readFile(this.subscriptionPath, 'utf-8');
-      return JSON.parse(content) as StoredSubscriptionData;
-    } catch {
-      return null;
-    }
-  }
-
-  async writeSubscriptionData(data: StoredSubscriptionData): Promise<void> {
-    await writeFile(this.subscriptionPath, JSON.stringify(data, null, 2), 'utf-8');
-  }
-
-  async removeSubscriptionData(): Promise<void> {
-    if (existsSync(this.subscriptionPath)) {
-      await unlink(this.subscriptionPath);
-    }
-  }
-}
-
-// ============================================================================
-// Window State Persistence
-// ============================================================================
-
-interface WindowState {
-  x?: number;
-  y?: number;
-  width: number;
-  height: number;
-  isMaximized?: boolean;
-}
-
-const DEFAULT_WINDOW_STATE: WindowState = {
-  width: 1200,
-  height: 800,
-};
-
-function getWindowStatePath(): string {
-  return join(app.getPath('userData'), 'window-state.json');
-}
-
-function loadWindowState(): WindowState {
-  try {
-    const data = readFileSync(getWindowStatePath(), 'utf-8');
-    return { ...DEFAULT_WINDOW_STATE, ...JSON.parse(data) };
-  } catch {
-    return DEFAULT_WINDOW_STATE;
-  }
-}
-
-function saveWindowState(state: WindowState): void {
-  try {
-    writeFileSync(getWindowStatePath(), JSON.stringify(state, null, 2));
-  } catch (err) {
-    console.error('Failed to save window state:', err);
-  }
-}
+// File-based license storage and window state persistence live in
+// dedicated modules under ./services/. See:
+//   - services/fileLicenseStorage.ts
+//   - services/windowState.ts
 
 // ============================================================================
 // Initialization

--- a/apps/desktop/src/main/services/fileLicenseStorage.ts
+++ b/apps/desktop/src/main/services/fileLicenseStorage.ts
@@ -1,0 +1,83 @@
+/**
+ * File-backed implementation of @readied/licensing's LicenseStorage.
+ *
+ * Lives alongside the other services. Persists three small JSON files
+ * under the user's data directory:
+ *
+ *   license.json       — legacy LicenseFile (StoredLicenseData)
+ *   trial.json         — local trial start (StoredTrialData)
+ *   subscription.json  — cached subscription state (StoredSubscriptionData)
+ *
+ * Note: trial.json is unsigned by design (see packages/licensing/README.md).
+ * subscription.json will move to a signed-envelope wire format once the
+ * server emits SignedSubscriptionEnvelope (see @readied/licensing
+ * verifySubscriptionSignature). Until then, the cache is best-effort.
+ */
+
+import { readFile, writeFile, unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type {
+  LicenseStorage,
+  StoredLicenseData,
+  StoredTrialData,
+  StoredSubscriptionData,
+} from '@readied/licensing';
+
+export class FileLicenseStorage implements LicenseStorage {
+  private readonly licensePath: string;
+  private readonly trialPath: string;
+  private readonly subscriptionPath: string;
+
+  constructor(dataDir: string) {
+    this.licensePath = join(dataDir, 'license.json');
+    this.trialPath = join(dataDir, 'trial.json');
+    this.subscriptionPath = join(dataDir, 'subscription.json');
+  }
+
+  async readLicenseData(): Promise<StoredLicenseData | null> {
+    return readJsonOrNull<StoredLicenseData>(this.licensePath);
+  }
+
+  async writeLicenseData(data: StoredLicenseData): Promise<void> {
+    await writeFile(this.licensePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  async removeLicenseData(): Promise<void> {
+    if (existsSync(this.licensePath)) {
+      await unlink(this.licensePath);
+    }
+  }
+
+  async readTrialData(): Promise<StoredTrialData | null> {
+    return readJsonOrNull<StoredTrialData>(this.trialPath);
+  }
+
+  async writeTrialData(data: StoredTrialData): Promise<void> {
+    await writeFile(this.trialPath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  async readSubscriptionData(): Promise<StoredSubscriptionData | null> {
+    return readJsonOrNull<StoredSubscriptionData>(this.subscriptionPath);
+  }
+
+  async writeSubscriptionData(data: StoredSubscriptionData): Promise<void> {
+    await writeFile(this.subscriptionPath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  async removeSubscriptionData(): Promise<void> {
+    if (existsSync(this.subscriptionPath)) {
+      await unlink(this.subscriptionPath);
+    }
+  }
+}
+
+async function readJsonOrNull<T>(path: string): Promise<T | null> {
+  try {
+    if (!existsSync(path)) return null;
+    const content = await readFile(path, 'utf-8');
+    return JSON.parse(content) as T;
+  } catch {
+    return null;
+  }
+}

--- a/apps/desktop/src/main/services/windowState.ts
+++ b/apps/desktop/src/main/services/windowState.ts
@@ -1,0 +1,48 @@
+/**
+ * Window position/size persistence.
+ *
+ * Saved to `window-state.json` under Electron's `userData` directory so
+ * the desktop reopens the last window in the same place across launches.
+ *
+ * Sync file I/O is intentional — `loadWindowState` is called during
+ * window construction before the renderer mounts, and `saveWindowState`
+ * runs during window close where event handlers don't await.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { app } from 'electron';
+
+export interface WindowState {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+  isMaximized?: boolean;
+}
+
+export const DEFAULT_WINDOW_STATE: WindowState = {
+  width: 1200,
+  height: 800,
+};
+
+function getWindowStatePath(): string {
+  return join(app.getPath('userData'), 'window-state.json');
+}
+
+export function loadWindowState(): WindowState {
+  try {
+    const data = readFileSync(getWindowStatePath(), 'utf-8');
+    return { ...DEFAULT_WINDOW_STATE, ...JSON.parse(data) };
+  } catch {
+    return DEFAULT_WINDOW_STATE;
+  }
+}
+
+export function saveWindowState(state: WindowState): void {
+  try {
+    writeFileSync(getWindowStatePath(), JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error('Failed to save window state:', err);
+  }
+}


### PR DESCRIPTION
## Summary

**First scoped slice of the PR-G \"split god files\" effort.**

\`apps/desktop/src/main/index.ts\` goes from **1065 → 950 lines** (-11%). No behavior change. All extractions are self-contained and surface-area preserving — no API changes, no runtime touch.

## What moved

| New file | Was at | Notes |
|---|---|---|
| \`services/fileLicenseStorage.ts\` | \`index.ts:146–216\` | Three \`readJsonOrNull\` helpers fold the repeated try/catch/return-null pattern into one private function. Header comment points at PR-F3 so the next step (move to signed envelopes) is unambiguous. |
| \`services/windowState.ts\` | \`index.ts:218–254\` | Header comment now documents *why* the file I/O is synchronous (called during \`BrowserWindow\` construction before the renderer mounts, and during close where handlers don't await). |

## What this PR DELIBERATELY does NOT touch

Per your earlier guidance about merge-conflict risk:

| File | Why deferred |
|---|---|
| \`packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts\` (1121 L) | Splitting into \`NoteCrudRepository\` + \`NoteTagRepository\` + \`NoteArchiveRepository\` + \`NoteSyncRepository\` needs runtime verification against a real DB. Risk of merge conflicts with every other in-flight PR. Separate effort. |
| \`apps/desktop/src/renderer/components/MarkdownEditor.tsx\` (724 L) | The CodeMirror surface is too entangled to split without an E2E suite to catch regressions. Defer until PR-E (#277) is stabilized; then refactor under test coverage. |

The principle is established here: surgical extractions of self-contained pieces, each verifying typecheck+tests, no behavior change. Future PRs can keep slicing under the same discipline.

## Test plan

- [x] \`pnpm -r typecheck\` — green
- [x] \`pnpm test\` — 17/17 packages
- [x] \`pnpm --filter @readied/desktop typecheck\` — green (includes the e2e tsconfig from #277)
- [ ] Manual smoke: launch the app, confirm window remembers its position after close+reopen, confirm license/trial files still read/write correctly

## Stack context

**PR-G** in the audit stack. Stacked on top of #277 (PR-E) → #276 (PR-F3) → #275 (PR-F2) → #274 (PR-F5) → #273 (PR-F4) → #272 (PR-F1) → #271 (PR-I) → #270 (PR-J) → #269 (PR-D) → #268 (PR-H) → #267 (PR-C) → #266 (PR-A) → #265 (PR-B). **14 PRs deep.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)