### PR TITLE
chore(license): set real SUBSCRIPTION_PUBLIC_KEY

### DIFF
--- a/apps/desktop/src/main/services/fileLicenseStorage.ts
+++ b/apps/desktop/src/main/services/fileLicenseStorage.ts
@@ -35,15 +35,20 @@ import { loggers } from '../logger';
 /**
  * Ed25519 public key used to verify SignedSubscriptionEnvelope payloads.
  *
- * REPLACE BEFORE SHIPPING signed subscriptions. The all-zeros placeholder
- * means verification WILL fail for any real signed envelope — that's the
- * desired failure mode while the server isn't yet emitting envelopes
- * (we fall through to "no envelope" and use the lenient path).
+ * Public-by-design: the client needs it to verify. The matching PRIVATE
+ * key MUST live ONLY on the licensing server (env var, never the repo).
  *
- * The matching private key lives only on the licensing server. Never
- * commit it.
+ * Rotation procedure when this key needs to change:
+ *   1. Generate a new keypair on a trusted machine
+ *      (see packages/licensing/README.md > "Rolling the signing key")
+ *   2. Ship a desktop release with the new public key embedded HERE
+ *   3. Wait for the install base to update
+ *   4. Switch the server to sign with the new private key
+ *   Clients on the old release will stop verifying envelopes signed
+ *   with the new key, falling back to the "no-envelope" lenient log —
+ *   no hard lockout, but they'll re-fetch on every cache miss.
  */
-const SUBSCRIPTION_PUBLIC_KEY = '0000000000000000000000000000000000000000000000000000000000000000';
+const SUBSCRIPTION_PUBLIC_KEY = 'd049019b2ff05ccfd3802e0619d5897e21431a6f946af724c13ed7ecca7ec01f';
 
 export class FileLicenseStorage implements LicenseStorage {
   private readonly licensePath: string;


### PR DESCRIPTION
## Summary

Replaces the all-zeros placeholder from #281 with a real Ed25519 public key. The matching private key was generated in this session and is held outside the repo — see notes below.

## Public key (this PR)

\`\`\`
d049019b2ff05ccfd3802e0619d5897e21431a6f946af724c13ed7ecca7ec01f
\`\`\`

Public by design — the client needs it to verify. Safe to commit.

## Private key (NOT in this PR)

Lives only on the licensing server. Tomy received it in the dev session that produced this PR and is responsible for storing it as the server's \`LICENSE_SIGNING_PRIVATE_KEY\` env var (Vercel env / Doppler / 1Password / wherever your secrets live).

**This keypair was generated in a dev chat session and is considered "dev/staging-grade".** For production, rotate before the first signed envelope ships: generate a new pair on a trusted machine, push a new desktop release with the new public key here, then switch the server. The rotation procedure is documented in the constant's comment.

## Behavior change

| State | Before (placeholder) | After (real key) |
|---|---|---|
| Cache without envelope | Warning logged, accepted (lenient) | Warning logged, accepted (lenient) |
| Cache with envelope signed by matching key | Cannot occur | Silently accepted |
| Cache with envelope signed by wrong key | Refused → refetch | Refused → refetch |
| Cache with tampered envelope | Refused → refetch | Refused → refetch |

The lenient branch (no envelope) is unchanged — existing users are unaffected. The strict branch (envelope present) now actually works: real envelopes verify, fakes get rejected.

## Test plan

- [x] \`pnpm --filter @readied/desktop typecheck:main\` — green
- [ ] After merge: server team uses \`signSubscriptionPayload(payload, LICENSE_SIGNING_PRIVATE_KEY)\` from \`@readied/licensing\`. Round-trip test:
\`\`\`bash
cd packages/licensing
node -e "
import('./src/validator.js').then(async ({ signSubscriptionPayload, verifySubscriptionSignature }) => {
  const PRIV = process.env.LICENSE_SIGNING_PRIVATE_KEY;
  const env = await signSubscriptionPayload({
    payloadVersion: 1,
    subscription: { subscriptionId:'sub_test', customerId:'cus_test', email:'x@x.com', plan:'monthly', status:'active', currentPeriodStart: new Date().toISOString(), currentPeriodEnd: new Date(Date.now()+30*86400e3).toISOString(), cancelAtPeriodEnd:false },
    issuedAt: new Date().toISOString(),
  }, PRIV);
  const r = await verifySubscriptionSignature(env, { publicKey: 'd049019b2ff05ccfd3802e0619d5897e21431a6f946af724c13ed7ecca7ec01f' });
  console.log(r.valid ? '✅' : '❌ ' + r.error);
});
"
\`\`\`

## Stack context

**PR-Set-Key** at the tip of the stack. Sits on top of editor split (#283) → note repo split (#282) → ... down to PR-B (#265). **20 PRs deep.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)