### PR TITLE
fix(ci): scope deploy-api install to the API workspace

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -31,7 +31,12 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      # Install only the API workspace and its transitive deps. The full
+      # `pnpm install` would also run apps/desktop's postinstall (electron-builder
+      # install-app-deps -> better-sqlite3 native rebuild), which fails on the
+      # Linux + Node 22 runner against current Electron headers. The API worker
+      # has no need for any of that.
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Typecheck
         run: pnpm --filter @readied/api typecheck
@@ -53,7 +58,7 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Determine environment
         id: env


### PR DESCRIPTION
## Summary

The Deploy API workflow has been failing since at least 2026-03-29 (every run since). Root cause: \`pnpm install\` in the Test + Deploy jobs runs the postinstall scripts of EVERY workspace, including \`apps/desktop\`'s \`electron-builder install-app-deps\` step that rebuilds \`better-sqlite3\` against Electron headers via \`node-gyp\`.

That rebuild fails on the Linux + Node 22 runner due to a V8 API mismatch in better-sqlite3 12.10.0 against the current Electron headers (\`no matching function for call to 'v8::External::Value()'\` and similar errors).

The API worker has **nothing to do with** better-sqlite3 or Electron. It runs on Cloudflare Workers and only needs its own transitive deps.

## Change

\`\`\`diff
-      - run: pnpm install
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
\`\`\`

Applied in both the \`test\` and \`deploy\` jobs.

- \`--filter '@readied/api...'\` brings in \`@readied/api\` and everything it depends on (transitive workspace + npm deps), nothing else.
- \`--ignore-scripts\` is belt-and-suspenders so we don't run \`install-app-deps\` even if some transitive dep declares a similar postinstall later.

## Why this is release-blocking

The v0.15.0 release (PR #245) auto-deploys the API to production when it merges (the workflow runs on \`push\` to main affecting \`packages/api/**\`). The audit stack modifies \`packages/api/wrangler.toml\` (documentation comment for LICENSE_SIGNING_PRIVATE_KEY), which triggers the path filter. Without this fix, that auto-deploy fails on merge.

## Verification

After this PR merges to develop and the release PR (#245) carries it to main, the next manually-triggered deploy:
\`\`\`
gh workflow run deploy-api.yml -f environment=staging
\`\`\`
should succeed end-to-end (Test → Deploy → wrangler deploy --env staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the API deployment workflow's dependency installation process to use a filtered installation limited to API workspace dependencies, reducing unnecessary build steps and improving deployment reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->