### PR TITLE
hotfix(ci): bring deploy-api install-scope fix to main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -31,7 +31,12 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      # Install only the API workspace and its transitive deps. The full
+      # `pnpm install` would also run apps/desktop's postinstall (electron-builder
+      # install-app-deps -> better-sqlite3 native rebuild), which fails on the
+      # Linux + Node 22 runner against current Electron headers. The API worker
+      # has no need for any of that.
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Typecheck
         run: pnpm --filter @readied/api typecheck
@@ -53,7 +58,7 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Determine environment
         id: env


### PR DESCRIPTION
## Why hotfix to main

PR #245 (audit release develop→main) merged **before** PR #286 (deploy-api install scope fix) reached develop. Net result: main got the audit work without the workflow fix. The auto-deploy of \`@readied/api\` on the #245 merge failed, and manual \`workflow_dispatch\` from main still fails because the workflow file in main is the pre-fix version.

This PR cherry-picks the one-commit fix from develop (\`53577d3\`) directly onto main. Same diff as PR #286, no new logic.

## What this changes

\`\`\`diff
- - run: pnpm install
+ - run: pnpm install --filter '@readied/api...' --ignore-scripts
\`\`\`

Applied in both the \`test\` and \`deploy\` jobs of \`.github/workflows/deploy-api.yml\`.

Scope: prevent \`pnpm install\` from running every workspace's postinstall on the CI runner. Specifically, blocks \`apps/desktop\`'s \`electron-builder install-app-deps\` step that rebuilds better-sqlite3 against Electron headers — a build that fails on Linux + Node 22 due to a V8 API mismatch in better-sqlite3 12.10.0.

## Verification (already done)

The same fix on develop was validated by run https://github.com/tomymaritano/readide/actions/runs/27183894368 — \`@readied/api\` deployed cleanly to \`readied-api-staging\`, smoke test returned HTTP 200 with \`{"name":"Readied API","version":"0.1.0","status":"healthy"}\`.

The failing main deploy was https://github.com/tomymaritano/readide/actions/runs/27184061589.

## What lands after this merges

1. Manual re-trigger of Deploy API workflow from main → expected pass against \`readied-api-production\`
2. Then we can trigger the Release workflow for desktop v0.15.0

## Why directly to main (not via develop again)

- develop already has this exact fix from #286
- Going through develop → main release PR would re-stack the entire audit work that just released; only delta is one workflow line
- This is the textbook case for a hotfix branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)