### PR TITLE
hotfix(ci): skip postinstall scripts in release workflow

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -31,7 +31,12 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      # Install only the API workspace and its transitive deps. The full
+      # `pnpm install` would also run apps/desktop's postinstall (electron-builder
+      # install-app-deps -> better-sqlite3 native rebuild), which fails on the
+      # Linux + Node 22 runner against current Electron headers. The API worker
+      # has no need for any of that.
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Typecheck
         run: pnpm --filter @readied/api typecheck
@@ -53,7 +58,7 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
 
-      - run: pnpm install
+      - run: pnpm install --filter '@readied/api...' --ignore-scripts
 
       - name: Determine environment
         id: env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,14 @@ jobs:
       - name: Force HTTPS for GitHub git dependencies
         run: git config --global 'url.https://github.com/.insteadOf' 'git@github.com:'
 
+      # semantic-release only needs root-level devDeps (semantic-release itself,
+      # commit-analyzer, github plugin, etc). It does NOT need any workspace's
+      # native deps. Skipping postinstall scripts avoids apps/desktop's
+      # electron-builder install-app-deps step that rebuilds better-sqlite3 —
+      # that rebuild fails on the Linux + Node 22 runner against current
+      # Electron headers (V8 API mismatch in better-sqlite3 12.10.0).
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run semantic-release
         env:


### PR DESCRIPTION
## Why

The Release workflow (\`semantic-release\`) was failing on the v0.15.0 release with the same better-sqlite3 native-build error that #287 fixed for \`deploy-api.yml\`. Same root cause, slightly different fix shape.

semantic-release **never imports anything from apps/* or packages/*** — it only needs the root \`devDeps\` (\`semantic-release\`, \`@semantic-release/commit-analyzer\`, \`@semantic-release/github\`, etc.) plus the lockfile. So we don't need the \`--filter\` flag from #287; just \`--ignore-scripts\` is enough.

## Change

\`\`\`diff
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
\`\`\`

## What got blocked

Release run: https://github.com/tomymaritano/readide/actions/runs/27184255087 — failed on \`pnpm install\` step with the V8 API mismatch error (\`better-sqlite3 12.10.0\` vs current Electron headers, on Linux + Node 22 runner).

## What unblocks once this merges

1. Manual re-trigger of Release workflow → \`semantic-release\` analyses conventional commits since the last release tag, bumps version (probably to \`v0.15.0\` because of multiple \`feat:\` commits in the audit), creates GitHub Release draft + tag
2. Tag push auto-triggers \`build.yml\` (mac/win/linux parallel)
3. All three builds green → release un-drafts itself

## Related

- #287 (deploy-api fix, same problem in a different workflow) — already merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)