### PR TITLE
feat(release): cut v0.15.0 audit release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -32,12 +32,12 @@ export default {
       },
     ],
     '@semantic-release/changelog',
-    [
-      '@semantic-release/exec',
-      {
-        prepareCmd: 'node scripts/bump-version.js ${nextRelease.version}',
-      },
-    ],
+    // Note: the previous @semantic-release/exec step ran a custom
+    // scripts/bump-version.js to sync per-package versions. That script was
+    // deleted in the knip cleanup (#279) and the desktop release only needs
+    // the root + apps/desktop package.json versions bumped — which the
+    // @semantic-release/git plugin below does via the `assets` list. So we
+    // drop the exec step entirely.
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION
## Why this PR

PR #245 squash-merged 19 individual PRs (#266-#284) into a single commit on main: \`release: audit + Ed25519 signed envelopes + lefthook (v0.15.0) (#245)\`. That message **isn't a conventional commit type that semantic-release recognises**, so the analyser saw 11 commits since the last tag and concluded *"no release"*. The actual feat:/fix:/refactor: messages from the 19 underlying PRs were lost in the squash.

Concretely, run [27184456847](https://github.com/tomymaritano/readide/actions/runs/27184456847) finished cleanly but logged:

\`\`\`
[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 11 commits complete: no release
[semantic-release] › ℹ  There are no relevant changes, so no new version is released.
\`\`\`

## What this PR does

### 1. Provides the release signal

This commit's title is \`feat(release): cut v0.15.0 audit release\` — a recognised conventional type. semantic-release will analyse it as a **minor bump** (v0.14.x → v0.15.0).

### 2. Drops the broken \`@semantic-release/exec\` step

\`release.config.js\` referenced \`node scripts/bump-version.js \${nextRelease.version}\` in a prepareCmd, but that script was deleted in the knip cleanup (#279) and the config wasn't updated. Any release triggered now would fail at the prepare step with \`ENOENT\`.

The remaining \`@semantic-release/git\` plugin already commits root \`package.json\` + \`apps/desktop/package.json\` + \`CHANGELOG.md\` via its \`assets\` list — that's everything the desktop release needs bumped. Workspace packages stay at \`workspace:*\` and their numeric versions aren't user-visible.

## Side effect

\`@semantic-release/exec\` is still listed in \`package.json\` devDeps but unused after this PR. Not removing it here to keep this PR surgical; can be dropped in the next knip pass.

## After this merges

1. Manually re-trigger Release workflow on main
2. semantic-release picks up this commit + the existing release notes generator → cuts **v0.15.0**
3. Creates GitHub Release draft + tag
4. Tag push fires Build workflow → mac/win/linux artefacts
5. Builds complete → release un-drafts → electron-updater serves it

## Related

- #287 (deploy-api workflow fix)
- #288 (release workflow install fix)
- #279 (knip cleanup that deleted bump-version.js without updating release.config.js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)