### PR TITLE
fix(desktop): pin electron to ^41.7.1 for better-sqlite3 prebuild compat (Phase 0 A1)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -75,7 +75,7 @@
     "@types/turndown": "^5.0.6",
     "@playwright/test": "^1.49.1",
     "@vitejs/plugin-react": "^6.0.2",
-    "electron": "^42.3.3",
+    "electron": "^41.7.1",
     "electron-builder": "^26.15.2",
     "electron-devtools-installer": "^4.0.0",
     "electron-vite": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,8 +205,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       electron:
-        specifier: ^42.3.3
-        version: 42.3.3
+        specifier: ^41.7.1
+        version: 41.7.1
       electron-builder:
         specifier: ^26.15.2
         version: 26.15.2(electron-builder-squirrel-windows@26.0.12)
@@ -1033,13 +1033,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
+  '@electron/get@2.0.3':
+    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
+    engines: {node: '>=12'}
+
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
-
-  '@electron/get@5.0.0':
-    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
-    engines: {node: '>=22.12.0'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
     resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
@@ -4682,9 +4682,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.3.3:
-    resolution: {integrity: sha512-0MwYp9wTb7TrtTalOYqeW+suqd9T/Znstr/nDLKqFGIjHdBZX339guo3mQqTPURRZ/UQmYM4uMpzKpI5wLptfQ==}
-    engines: {node: '>= 22.12.0'}
+  electron@41.7.1:
+    resolution: {integrity: sha512-pdRvNNP99Qfvs1lyIxo/sfIGAwJP0CrJFNCE3goFKc7/fV+kjK3EPxx5Nt6sLTkzqTyeRYylpwPUfpeGojiyyw==}
+    engines: {node: '>= 12.20.55'}
     hasBin: true
 
   emoji-regex@10.6.0:
@@ -7983,10 +7983,6 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
-    engines: {node: '>=20.18.1'}
-
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -9096,7 +9092,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@3.1.0':
+  '@electron/get@2.0.3':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -9110,16 +9106,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@5.0.0':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 3.0.0
-      graceful-fs: 4.2.11
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
       progress: 2.0.3
-      semver: 7.8.2
+      semver: 6.3.1
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 7.27.2
+      global-agent: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -12693,9 +12690,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.3.3:
+  electron@41.7.1:
     dependencies:
-      '@electron/get': 5.0.0
+      '@electron/get': 2.0.3
       '@types/node': 24.13.1
       extract-zip: 2.0.1
     transitivePeerDependencies:
@@ -12734,7 +12731,8 @@ snapshots:
 
   env-paths@2.2.1: {}
 
-  env-paths@3.0.0: {}
+  env-paths@3.0.0:
+    optional: true
 
   environment@1.1.0: {}
 
@@ -16590,9 +16588,6 @@ snapshots:
   undici@7.24.8: {}
 
   undici@7.25.0: {}
-
-  undici@7.27.2:
-    optional: true
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 0 A1 of the post-audit devops roadmap. **Unblocks v0.15.x Build.**

The v0.15.0 Build workflow failed on all 3 platforms (run [27184736470](https://github.com/tomymaritano/readide/actions/runs/27184736470)) because **better-sqlite3 12.10.0 explicitly removed Electron v42 prebuilds** ([WiseLibs/better-sqlite3#1470](https://github.com/WiseLibs/better-sqlite3/pull/1470)). Without a prebuild, \`electron-builder install-app-deps\` falls through to a source build via \`@electron/rebuild\`, which then hits V8 13.x API breakages:
- \`SetNativeDataProperty\` ambiguity (3 candidate overloads)
- \`External::Value()\` requires \`ExternalPointerTypeTag\` argument
- \`External::New()\` signature change

Same root cause on Linux/macOS (GCC/clang) and Windows (MSVC).

## Fix

Pin Electron to \`^41.7.1\` (latest 41.x as of 2026-05-26). better-sqlite3 has prebuilts for it.

## Local validation

\`\`\`
apps/desktop postinstall: electronVersion=41.7.1 arch=arm64
apps/desktop postinstall: buildFromSource=false
apps/desktop postinstall: preparing       moduleName=better-sqlite3
apps/desktop postinstall: finished        moduleName=better-sqlite3
apps/desktop postinstall: completed installing native dependencies
\`\`\`

\`buildFromSource=false\` = the prebuilt was found and consumed; no V8 errors.

- ✅ \`pnpm install\` (with scripts) — succeeds
- ✅ \`pnpm -r typecheck\` — green
- ✅ \`pnpm test\` — 17/17 packages

## When to bump back to 42

Watch [WiseLibs/better-sqlite3 releases](https://github.com/WiseLibs/better-sqlite3/releases) for v42 prebuild restoration. As of 2026-06-09 there's no public ETA. When it lands: bump electron to \`^42.x\` + better-sqlite3 to the version that re-includes v42 prebuilds, in a single PR.

## Stack context

This is **A1** of Phase 0 (devops stabilization). A2-A4, B1-B5, C1-C2, D follow in subsequent PRs against develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime dependency for the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->