### PR TITLE
fix(release): restore version bumping via scripts/bump-version.mjs (Phase 0 A2)

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -32,12 +32,18 @@ export default {
       },
     ],
     '@semantic-release/changelog',
-    // Note: the previous @semantic-release/exec step ran a custom
-    // scripts/bump-version.js to sync per-package versions. That script was
-    // deleted in the knip cleanup (#279) and the desktop release only needs
-    // the root + apps/desktop package.json versions bumped — which the
-    // @semantic-release/git plugin below does via the `assets` list. So we
-    // drop the exec step entirely.
+    // The @semantic-release/git plugin below only COMMITS files; it does
+    // not mutate them. Without this exec step, package.json and
+    // apps/desktop/package.json stay at the previous version even after
+    // tag/release (the v0.15.0 bug). bump-version.mjs is a pure-ESM,
+    // zero-dependency script that only touches the `version` field of
+    // exactly the two files in scope.
+    [
+      '@semantic-release/exec',
+      {
+        prepareCmd: 'node scripts/bump-version.mjs ${nextRelease.version}',
+      },
+    ],
     [
       '@semantic-release/git',
       {

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Sync the `version` field across the monorepo's release-relevant
+ * package.json files. Called by @semantic-release/exec at the
+ * `prepareCmd` step so the @semantic-release/git plugin actually has
+ * a diff to commit.
+ *
+ * Why this script exists (history):
+ *
+ *   1. semantic-release/git's `assets` list is COMMIT-only — it does
+ *      not mutate files. Something else has to bump the versions first.
+ *   2. The original scripts/bump-version.js was deleted in the knip
+ *      cleanup (#279) under the false assumption nothing referenced it.
+ *      release.config.js still had a prepareCmd pointing at it,
+ *      so v0.15.0 shipped with both package.json files reading 0.14.0
+ *      (visible mismatch in the v0.15.0 tag).
+ *   3. PR #289 patched release.config.js by removing the prepareCmd,
+ *      which made semantic-release runnable but kept versions stale.
+ *   4. This script restores step (1) properly. It's pure ESM, has no
+ *      dependencies, and updates ONLY the version field — no other
+ *      package.json keys are touched.
+ *
+ * Usage:
+ *
+ *   node scripts/bump-version.mjs 0.15.1
+ *
+ * Fails non-zero if:
+ *   - the version arg is missing or empty
+ *   - any target file can't be parsed as JSON
+ *   - a target file has no `version` field to update
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+/**
+ * Files whose `version` should track the desktop release.
+ *
+ * Keep this list explicit (not a glob) so we never accidentally bump
+ * a workspace package that's intentionally on its own version line
+ * (e.g. packages/api which deploys on its own cycle to Cloudflare).
+ */
+const targets = ['package.json', 'apps/desktop/package.json'];
+
+const newVersion = process.argv[2];
+if (!newVersion || newVersion.trim().length === 0) {
+  console.error('bump-version: missing version argument');
+  console.error('usage: node scripts/bump-version.mjs <version>');
+  process.exit(1);
+}
+
+let bumped = 0;
+for (const rel of targets) {
+  const abs = resolve(repoRoot, rel);
+  const raw = await readFile(abs, 'utf-8');
+
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(`bump-version: cannot parse ${rel} as JSON: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (typeof parsed.version !== 'string') {
+    console.error(`bump-version: ${rel} has no version field to update`);
+    process.exit(1);
+  }
+
+  const old = parsed.version;
+  if (old === newVersion) {
+    console.log(`bump-version: ${rel} already at ${newVersion}, skipped`);
+    continue;
+  }
+
+  parsed.version = newVersion;
+
+  // Preserve a trailing newline if the original file had one — Prettier and
+  // most editors expect it. Detecting from `raw` keeps the diff minimal.
+  const trailingNewline = raw.endsWith('\n') ? '\n' : '';
+  await writeFile(abs, JSON.stringify(parsed, null, 2) + trailingNewline, 'utf-8');
+
+  console.log(`bump-version: ${rel} ${old} -> ${newVersion}`);
+  bumped++;
+}
+
+console.log(`bump-version: updated ${bumped} of ${targets.length} target(s)`);


### PR DESCRIPTION
## Summary

Phase 0 A2. Restores the version-bump step semantic-release needs to actually write the new version into the package.json files BEFORE the git plugin commits them.

## What was broken

The v0.15.0 tag points at a commit where both \`package.json\` and \`apps/desktop/package.json\` still read \`0.14.0\`:

\`\`\`
$ git show v0.15.0:package.json | jq -r .version
0.14.0
$ git show v0.15.0:apps/desktop/package.json | jq -r .version
0.14.0
\`\`\`

Symptom: electron-updater sees mismatched versions; any consumer reading from package.json drifts from the tag; ship-it-and-forget-it release becomes "wait, what version is this?".

### Why

semantic-release pipeline is a chain. Each plugin has a contract.

| Plugin | Contract |
|---|---|
| \`commit-analyzer\` | decides next version |
| \`release-notes-generator\` | writes release notes |
| \`changelog\` | mutates CHANGELOG.md |
| \`exec.prepareCmd\` | **mutates package.json (this step was missing)** |
| \`git\` | commits the mutated files via \`assets:\` list |
| \`github\` | creates draft release |

The \`assets:\` list in \`@semantic-release/git\` ONLY commits files; it doesn't create the diff. Without an explicit mutation step, the git plugin sees no changes to package.json and commits an effectively empty diff (just the CHANGELOG update).

The original \`scripts/bump-version.js\` performed that mutation, wired via \`@semantic-release/exec\`. It was deleted in the knip cleanup (#279) under the false assumption nothing referenced it — knip didn't scan \`release.config.js\` as an entry point.

PR #289 patched \`release.config.js\` to remove the dangling \`prepareCmd\`, which made the workflow stop crashing but left versions stale.

## Fix

1. **\`scripts/bump-version.mjs\`** (new) — pure-ESM, zero dependencies, updates ONLY the \`version\` field of exactly two files (\`package.json\` and \`apps/desktop/package.json\`). Preserves existing trailing-newline. Fails non-zero on missing version arg, unparseable JSON, or absent version field.

2. **\`release.config.js\`** — re-wires the \`@semantic-release/exec\` plugin (already a devDep) with \`prepareCmd: 'node scripts/bump-version.mjs \${nextRelease.version}'\`. Comment block in the file documents the history so the next maintainer doesn't repeat the mistake.

Packages with independent release cycles (notably \`packages/api\` on Cloudflare Workers, \`packages/mcp-server\`) are deliberately NOT in the target list. If we ever need to bump them, that's a separate concern with a separate script.

## Verification

\`\`\`
$ node scripts/bump-version.mjs 0.15.1
bump-version: package.json 0.14.0 -> 0.15.1
bump-version: apps/desktop/package.json 0.14.0 -> 0.15.1
bump-version: updated 2 of 2 target(s)
\`\`\`

Edge cases:
- \`node scripts/bump-version.mjs\` (no arg) → \`missing version argument\`, exit 1
- \`node scripts/bump-version.mjs 0.14.0\` (already at version) → \`already at 0.14.0, skipped\`, exit 0
- Same version on already-bumped files → idempotent, no diff

- ✅ \`pnpm -r typecheck\` — green
- ✅ \`pnpm test\` — 17/17 packages

## Stack context

Phase 0 A2 of the post-audit devops roadmap. Pairs with #290 (A1, electron pin). Independent files, can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)