### PR TITLE
chore(ci): workflow surface cleanup (Phase 0 B-bundle)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ env:
   NODE_VERSION: '22'
   ELECTRON_CACHE: ~/.cache/electron
   ELECTRON_BUILDER_CACHE: ~/.cache/electron-builder
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:
@@ -23,7 +22,10 @@ jobs:
         include:
           - os: macos-14
             platform: mac
-          - os: windows-latest
+          # Pin Windows runner explicitly. `windows-latest` migrates to
+          # `windows-2025-vs2026` on 2026-06-15; pinning ahead avoids a
+          # surprise toolchain swap mid-release. Revisit on each new GA.
+          - os: windows-2025-vs2026
             platform: win
           - os: ubuntu-latest
             platform: linux
@@ -32,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
           fetch-depth: 0
@@ -41,20 +43,20 @@ jobs:
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ matrix.platform }}-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: pnpm-${{ matrix.platform }}-
 
       - name: Cache Electron downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.ELECTRON_CACHE }}
           key: electron-v3-${{ matrix.platform }}-${{ hashFiles('apps/desktop/package.json') }}
@@ -105,7 +107,7 @@ jobs:
         run: pnpm dist:linux --publish always
 
       - name: Upload artifacts (backup)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.platform }}-build
           path: |
@@ -116,7 +118,11 @@ jobs:
             apps/desktop/release/*.deb
             apps/desktop/release/latest*.yml
             apps/desktop/release/*.blockmap
-          if-no-files-found: ignore
+          # `error` (was `ignore`) — if the build silently produced zero
+          # artefacts (signing failure, electron-builder swallowed an
+          # error, wrong working-directory, etc.) we want the job to fail
+          # loud here, not let the release un-draft with no installers.
+          if-no-files-found: error
           retention-days: 30
 
   publish:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'pnpm'
@@ -44,7 +44,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Cache node_modules
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             node_modules
@@ -57,14 +57,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -87,14 +87,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: |
@@ -123,14 +123,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -156,14 +156,14 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -186,7 +186,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: apps/desktop/playwright-report/
@@ -197,14 +197,14 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -225,14 +225,14 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -17,16 +17,23 @@ on:
           - staging
           - production
 
+# Minimum-privilege default. The Cloudflare deploy doesn't push commits
+# or create issues; checkout + read of the workflow definition is all
+# the GITHUB_TOKEN side needs. Wrangler authenticates via the
+# CLOUDFLARE_API_TOKEN secret separately.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test API
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -49,11 +56,11 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,15 +9,18 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -25,15 +28,20 @@ jobs:
       - name: Force HTTPS for GitHub git dependencies
         run: git config --global 'url.https://github.com/.insteadOf' 'git@github.com:'
 
-      - run: pnpm install
+      # Marketing site only needs @readied/web + product-config's transitive
+      # deps. Plain `pnpm install` would also run apps/desktop's postinstall
+      # (electron-builder install-app-deps -> better-sqlite3 native rebuild),
+      # which fails on the Linux + Node 22 runner. See #287 for the
+      # deploy-api workflow and #288 for release.yml — same fix shape.
+      - run: pnpm install --filter '@readied/web...' --ignore-scripts
 
       - name: Build web app
-        run: |
-          cd apps/web
-          pnpm exec fumadocs-mdx
-          pnpm exec next build
+        working-directory: apps/web
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pnpm exec fumadocs-mdx
+          pnpm exec next build
 
       - name: Deploy to Cloudflare Pages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
         uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'pnpm'
@@ -68,10 +68,13 @@ jobs:
             exit 1
           fi
 
+      # HUSKY: '0' was leftover from the husky->lefthook migration in #267
+      # (kept hooks from firing inside the workflow's commit step). Lefthook
+      # only reads .git/hooks if those files exist, and they don't on a
+      # fresh CI clone, so the env var is no longer needed.
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          HUSKY: '0'
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_COMMITTER_NAME: github-actions[bot]


### PR DESCRIPTION
## Summary

Phase 0 B-bundle of the post-audit roadmap. Six independent fixes batched into one PR because they all touch the workflow YAML surface and reviewing them together is faster than three ping-pong PRs that all conflict on the same files.

## docs.yml

| Change | Why |
|---|---|
| \`pnpm install\` → \`pnpm install --filter '@readied/web...' --ignore-scripts\` | Marketing-site install was the last workflow still firing apps/desktop's \`electron-builder install-app-deps\` step that fails on Linux + Node 22. Same shape as #287 (deploy-api) and #288 (release). |
| Added \`permissions: contents: read\` | Cloudflare Pages deploy doesn't need anything beyond checkout |
| Build step moved into \`working-directory: apps/web\` | Was inline \`cd apps/web && ...\` — explicit working-directory reads better |

## build.yml

| Change | Why |
|---|---|
| \`windows-latest\` → \`windows-2025-vs2026\` | GitHub announced \`windows-latest\` migration to that image on **2026-06-15** (6 days from this commit). Pinning ahead avoids a surprise toolchain swap mid-release. |
| Removed \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` env | This was the migration toggle for the Node 20→24 actions rollout. With all actions now on @v5 (Node 24-native) it's no-op. |
| Artifact upload \`if-no-files-found: ignore\` → \`error\` | Silent zero-asset releases are worse than a failed upload. If electron-builder swallowed an error, signing failed, working-directory drifted, etc., we want loud failure here, not a release un-drafted with no installers. |

## release.yml

| Change | Why |
|---|---|
| Removed \`HUSKY: '0'\` env | Leftover from the husky → lefthook migration in #267. Lefthook only reads .git/hooks if those files exist; on fresh CI clones they don't. |

## deploy-api.yml

| Change | Why |
|---|---|
| Added \`permissions: contents: read\` | Cloudflare deploy doesn't push commits or create issues; minimum-privilege default. |

## Action versions sweep (all 8 workflows)

| From | To |
|---|---|
| \`actions/checkout@v4\` | \`@v5\` |
| \`actions/setup-node@v4\` | \`@v5\` |
| \`actions/cache@v4\` | \`@v5\` |
| \`actions/cache/save@v4\` | \`@v5\` |
| \`actions/cache/restore@v4\` | \`@v5\` |
| \`actions/upload-artifact@v4\` | \`@v5\` |

GitHub announced Node 20-based actions deprecation on **2026-06-16** (7 days from this commit). The \`@v5\` family runs on Node 24.

## Verification

- ✅ \`pnpm -r typecheck\` — green
- ✅ \`pnpm test\` — 17/17 (untouched)
- ✅ YAML parsed locally; no syntax errors

## Stack context

Phase 0 B-bundle. Pairs with #290 (A1 electron pin) and #291 (A2 bump-version). Independent files, can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)