### PR TITLE
chore(ci): add release.yml pre-flight and post-flight guardrails (Phase 0 A4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,30 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # Dry-run gate: figure out whether a release WOULD be cut from the
+      # current commit log before we actually try. The trap we're closing:
+      # if the most recent merge to main used a non-conventional title
+      # (squash merge eats the PR title), semantic-release silently exits
+      # with "no release" and the workflow ends green. The user then
+      # wonders why no tag appeared. Fail loud here instead.
+      - name: Pre-flight (dry-run) check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          set -o pipefail
+          npx semantic-release --dry-run 2>&1 | tee /tmp/sr-dry.log
+          if grep -qE "There are no relevant changes" /tmp/sr-dry.log; then
+            echo "::error::semantic-release dry-run: no release will be cut."
+            echo "::error::Most recent main commit's conventional type is not in releaseRules."
+            echo "::error::Check release.config.js > releaseRules and the commit message that landed on main."
+            exit 1
+          fi
+          if ! grep -qE "next release version is" /tmp/sr-dry.log; then
+            echo "::error::semantic-release dry-run did not announce a next release version."
+            echo "::error::Aborting before --ci to avoid a silent no-op."
+            exit 1
+          fi
+
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -53,3 +77,30 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
         run: npx semantic-release
+
+      # Post-flight assertion: after semantic-release runs,
+      # package.json + apps/desktop/package.json should both match the
+      # version the dry-run announced. If scripts/bump-version.mjs (via
+      # @semantic-release/exec) didn't run or didn't touch one of the
+      # files, we catch it here BEFORE the tag-triggered build downloads
+      # stale package.json — closes the v0.15.0-style "tag at old
+      # version" trap.
+      - name: Verify version bump applied
+        run: |
+          expected=$(grep -oE "next release version is [0-9]+\.[0-9]+\.[0-9]+" /tmp/sr-dry.log \
+                     | tail -n 1 | awk '{print $NF}')
+          if [ -z "$expected" ]; then
+            echo "::warning::Could not extract expected version from dry-run log; skipping bump check."
+            exit 0
+          fi
+          root_v=$(jq -r .version package.json)
+          desk_v=$(jq -r .version apps/desktop/package.json)
+          if [ "$root_v" != "$expected" ] || [ "$desk_v" != "$expected" ]; then
+            echo "::error::Version mismatch after semantic-release."
+            echo "::error::Expected: $expected"
+            echo "::error::package.json: $root_v"
+            echo "::error::apps/desktop/package.json: $desk_v"
+            echo "::error::scripts/bump-version.mjs did not run or did not update both files."
+            exit 1
+          fi
+          echo "Version bump verified: both package.json files at $expected"


### PR DESCRIPTION
## Summary

Phase 0 A4. Two guardrails on \`release.yml\` to make a silent or partial release impossible.

## Why

The v0.15.0 release pipeline failed silently twice:

1. **Silent no-op**: PR #245's squash-merge title (\`release: audit + Ed25519 signed envelopes + lefthook (v0.15.0) (#245)\`) didn't match a conventional commit type in \`releaseRules\`. semantic-release exited cleanly with \"no release\" and the workflow ended green; the operator only noticed because no tag appeared. We patched this with #289 by adding a forcing \`feat:\` commit, but the trap will fire again on the next big squash unless the workflow refuses to silently no-op.
2. **Stale version**: even when the release finally cut, both \`package.json\` files still read \`0.14.0\` because the deleted \`scripts/bump-version.js\` was never re-introduced (fixed in PR #291). Tag points at one version, file content reads another — visible by anyone running \`jq .version package.json\` against the tag.

## Guardrails

### Pre-flight (dry-run)

\`\`\`yaml
- name: Pre-flight (dry-run) check
  run: |
    npx semantic-release --dry-run 2>&1 | tee /tmp/sr-dry.log
    if grep -qE \"There are no relevant changes\" /tmp/sr-dry.log; then
      echo \"::error::semantic-release dry-run: no release will be cut.\"
      exit 1
    fi
    if ! grep -qE \"next release version is\" /tmp/sr-dry.log; then
      echo \"::error::semantic-release dry-run did not announce a next release version.\"
      exit 1
    fi
\`\`\`

Stops the workflow loud and clear before \`--ci\` if commit-analyzer would have returned \"no release\". Actionable error messages point at \`release.config.js > releaseRules\` and the commit log.

### Post-flight (version assertion)

\`\`\`yaml
- name: Verify version bump applied
  run: |
    expected=$(grep -oE \"next release version is [0-9]+\\.[0-9]+\\.[0-9]+\" /tmp/sr-dry.log | tail -n 1 | awk '{print $NF}')
    root_v=$(jq -r .version package.json)
    desk_v=$(jq -r .version apps/desktop/package.json)
    if [ \"$root_v\" != \"$expected\" ] || [ \"$desk_v\" != \"$expected\" ]; then
      echo \"::error::Version mismatch after semantic-release.\"
      exit 1
    fi
\`\`\`

Re-uses the captured dry-run log to know what version SHOULD have been written. Catches a misconfigured or skipped \`scripts/bump-version.mjs\` (PR #291) BEFORE the tag-triggered build downloads the stale package.json.

## What gets caught

| Trap | Caught by |
|---|---|
| Non-conventional PR title (#245 trap) | Pre-flight: \"no relevant changes\" |
| Wrong releaseRules / type filter | Pre-flight: \"did not announce next release\" |
| \`prepareCmd\` missing or wrong path | Post-flight: version mismatch |
| \`bump-version.mjs\` only updated one file | Post-flight: per-file diff |
| semantic-release crashed mid-cycle | Native exit code from \`Run semantic-release\` step |

## Verification

I dry-ran the gate logic locally against the current main commit log; the dry-run output contains the expected lines for both happy-path and no-op cases. No way to test end-to-end without actually invoking the workflow.

## Stack context

Phase 0 A4. Independent from A1 (#290), A2 (#291), B-bundle (#292). Different files / steps; no overlapping changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)