### PR TITLE
ci: add PR-title commitlint as standalone workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,9 @@ jobs:
       - name: Prettier
         run: pnpm format:check
 
-      - name: Commitlint (PR title)
-        if: github.event_name == 'pull_request'
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | pnpm commitlint
+      # PR title commitlint moved to .github/workflows/pr-title.yml so it
+      # exposes a stable, standalone status-check name for branch protection
+      # (squash-merge makes the PR title the release-trigger commit message).
 
   # ── Tier 1: Tests + Coverage ───────────────────────
   test:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,54 @@
+name: PR title
+
+# Runs commitlint against the PR title as a standalone status check.
+#
+# Why standalone (and not a step inside ci.yml `lint`):
+# - The repo enforces squash merges (see GitHub Settings > Pull Requests).
+#   On squash, the PR title becomes the commit message on develop/main.
+# - semantic-release then analyses that message with the type-enum from
+#   commitlint.config.js to decide whether to cut a release. If the type
+#   isn't recognised (e.g. PR #245's "release: audit..."), semantic-release
+#   silently exits with "no release". This is the trap that blew up
+#   v0.15.0.
+# - Pulling the check into its own workflow gives it a clear, stable
+#   status-check name so branch protection on develop and main can require
+#   it independently of the broader CI lint job.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Re-running on title edits is cheap; cancel any in-flight check for
+  # the same PR when a new event arrives.
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      # Title check only needs commitlint + its config — no workspace
+      # native deps, no postinstall.
+      - name: Install commitlint
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Lint PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s' "$PR_TITLE" | pnpm commitlint


### PR DESCRIPTION
## Why

Phase 0 **C1** of the DevOps cleanup roadmap. After v0.15.0 traced back to PR #245's squash-merge producing a non-conventional commit message (`release: audit...`) which semantic-release silently rejected, the merge gate needs to block non-conventional PR titles **upstream of merge** — not just whine in CI.

The check already existed as a step inside `ci.yml`'s `lint` job, but it shipped as a sub-step of a multi-purpose job. Branch protection can only require whole status checks, so requiring \`lint\` would also block on ESLint/Prettier failures. Pulling commitlint into its own workflow gives branch protection a clean, single-responsibility check name to require: \`PR title / commitlint\`.

## What changes

- **New: \`.github/workflows/pr-title.yml\`** — runs commitlint against \`github.event.pull_request.title\` on pull_request \`opened\`, \`edited\`, \`reopened\`, \`synchronize\`.
- **\`ci.yml\`** — drops the duplicated step from the \`lint\` job and leaves a one-line breadcrumb pointing at the new workflow.

## Security shape

The workflow follows the [GitHub command-injection guidance](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/):

- \`github.event.pull_request.title\` is **never** interpolated directly into a \`run:\` script. It passes through \`env:\` as \`PR_TITLE\` and the shell reads \`\$PR_TITLE\` from the process environment.
- The script uses \`printf '%s' "\$PR_TITLE" | pnpm commitlint\` instead of \`echo\` — a PR title beginning with \`-e\` or \`-n\` would otherwise be treated as an echo flag in bash/sh.

## Verification

- \`pnpm commitlint --config commitlint.config.js\` on the local checkout exits non-zero for \`release: foo\`, \`hotfix: foo\`, \`Add feature\`; zero for \`feat: foo\`, \`fix(scope): foo\`, \`chore!: foo\`.
- Type enum used: \`feat | fix | refactor | docs | test | chore | style | perf | ci | build | revert\` (sourced from \`commitlint.config.js\`).

## Follow-ups (Phase 0 C2)

Once this merges, **C2** sets \`PR title / commitlint\` as a required status check on \`develop\` and \`main\` via \`gh api\` — that's the step that actually blocks #245-style merges. C1 is the pre-req: required checks must exist on the default branch before they can be required.

## Roadmap status

- [x] A1 #290 — electron 41.7.1 pin
- [x] A2 #291 — \`scripts/bump-version.mjs\` + release.config.js wire
- [x] B   #292 — workflow surface cleanup
- [x] A4 #293 — release dry-run + version-assertion guardrails
- [x] **C1 (this PR)** — PR-title commitlint standalone
- [ ] C2 — branch protection \`gh api\` (next)
- [ ] D  — cut v0.15.1