### PR TITLE
fix(lint): unblock develop CI baseline

### DIFF
--- a/apps/desktop/src/main/services/encryptionService.ts
+++ b/apps/desktop/src/main/services/encryptionService.ts
@@ -112,7 +112,8 @@ export class EncryptionService {
       return false; // No key available — passphrase setup required
     } catch (error) {
       throw new Error(
-        `Failed to initialize encryption: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to initialize encryption: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
   }
@@ -259,7 +260,8 @@ export class EncryptionService {
       );
     } catch (error) {
       throw new Error(
-        `Failed to encrypt content: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to encrypt content: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
   }
@@ -290,7 +292,8 @@ export class EncryptionService {
       return decrypted.toString('utf-8');
     } catch (error) {
       throw new Error(
-        `Failed to decrypt content: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to decrypt content: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
   }
@@ -349,7 +352,8 @@ export class EncryptionService {
       await this.cacheCek(this.key);
     } catch (error) {
       throw new Error(
-        `Failed to import key: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to import key: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
   }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "tsx src/index.ts",
     "test": "vitest run"
   },

--- a/packages/mcp-server/tsconfig.build.json
+++ b/packages/mcp-server/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["src/__tests__"]
+}

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -4,8 +4,7 @@
     "noEmit": false,
     "outDir": "dist",
     "rootDir": "src",
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
-  "include": ["src"],
-  "exclude": ["src/__tests__"]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Why

develop's lint job has been failing since **2026-04-24** (over a month). Until this lands, **every Phase 0 PR (#290–#294) is structurally unmergeable** because branch protection requires \`lint\` to pass and \`strict: true\` requires PRs to match develop's tip.

This is the unblock for the whole post-audit release stack.

## What

Two orthogonal fixes that together get \`pnpm lint\` to **0 errors**.

### 1. \`preserve-caught-error\` × 4 in \`encryptionService.ts\`

Four \`try/catch\` blocks re-throw a wrapped error without attaching the caught one:

\`\`\`ts
} catch (error) {
  throw new Error(
    \`Failed to encrypt content: \${error instanceof Error ? error.message : 'Unknown error'}\`,
+    { cause: error }  // ← lints clean and preserves the stack
  );
}
\`\`\`

Affected throw sites: \`initialize\` (114), \`encrypt\` (261), \`decrypt\` (292), \`importKey\` (351). The \`{ cause }\` payload is the standard ES2022 way to chain errors; runtime semantics unchanged.

### 2. mcp-server tsconfig refactor for ESLint projectService

\`packages/mcp-server/tsconfig.json\` was excluding \`src/__tests__\`. ESLint uses \`@typescript-eslint/parser\` with \`projectService: true\`, which delegates project discovery to the TypeScript LSP. The LSP walked up from the test file, found mcp-server/tsconfig.json with the explicit exclude, and rejected the test → **parsing error: \"was not found by the project service\"**.

Fix: split build vs editor configs.

- **tsconfig.json** — single source of truth for editors/lint/test. Includes everything under \`src\`. Adds \`vitest/globals\` to \`types\`.
- **tsconfig.build.json** — extends tsconfig.json, re-adds \`exclude: [\"src/__tests__\"]\`. Used by the build script.
- **package.json** — \`\"build\": \"tsc\"\` → \`\"build\": \"tsc -p tsconfig.build.json\"\`.

Confirmed locally:
- \`pnpm lint\` → 0 errors (39 warnings unchanged, all pre-existing import-x/order).
- \`pnpm --filter @readied/mcp-server build\` succeeds; \`dist/__tests__/\` does not exist.
- \`pnpm --filter @readied/mcp-server test\` → 5/5 pass.
- \`pnpm -r typecheck\` succeeds.

## Why a separate PR (not bundled with #290 / A1)

A1 is the Electron-pin commit. Mixing in a multi-file lint fix would muddy what's a release-pipeline change vs a code-hygiene change. Keeping this separate also means: this PR can go in first, then #290–#294 can rebase one by one and pass CI cleanly.

## Roadmap status

- [ ] **this PR** — lint baseline unblock
- [ ] #290 A1 (electron 41.7.1)
- [ ] #291 A2 (bump-version.mjs)
- [ ] #292 B (workflow surface)
- [ ] #293 A4 (release guardrails)
- [ ] #294 C1 (pr-title commitlint)
- [ ] C2 follow-up — add \`commitlint\` to required checks after #294 lands
- [ ] D — cut v0.15.1