### PR TITLE
fix(desktop): set linux.executableName for AppImage build

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -151,7 +151,8 @@
       ],
       "icon": "resources/icons",
       "category": "Office",
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "executableName": "readied"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Why

v0.15.1 Build run (27212685957) failed on linux:

\`\`\`
⨯ failed to build AppImage error=executableName contains characters that
  cannot be safely used in file paths: @readieddesktop. Please use only
  letters, digits, hyphens, underscores, dots, and spaces.
\`\`\`

electron-builder defaults Linux's \`executableName\` to the package.json \`name\` field, stripped of unsafe chars. \`@readied/desktop\` → \`@readieddesktop\`, still leading with \`@\`, still invalid.

mac and win didn't fail because they use \`productName\` ("Readied") and the \`appId\` (\`app.readied.desktop\`) respectively — Linux is the strict one for the on-disk binary name.

## Fix

Add \`linux.executableName: "readied"\` to apps/desktop/package.json's \`build\` config.

## Knock-on

v0.15.1 Build flow was:
1. linux job ⨯ fails at AppImage step
2. \`publish\` job (\`needs: build\`) skipped
3. \`sync-develop\` (\`needs: publish\`) skipped
4. Release left with no binary assets, no electron-updater feed

After this lands, the next Release will produce binaries for all 3 platforms.

## v0.15.1 cleanup

The published v0.15.1 GitHub Release will be marked as draft via gh api so it doesn't surface to users with electron-updater. v0.15.2 will be cut after this PR merges.