### PR TITLE
fix(release): cut v0.15.2 with linux executableName fix

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -151,7 +151,8 @@
       ],
       "icon": "resources/icons",
       "category": "Office",
-      "artifactName": "${productName}-${version}-${arch}.${ext}"
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
+      "executableName": "readied"
     },
     "nsis": {
       "oneClick": false,


### PR DESCRIPTION
## Why

v0.15.1 Build (run 27212685957) failed on linux because electron-builder rejected the AppImage build: \`executableName contains invalid chars: @readieddesktop\`. publish job (\`needs: build\`) was skipped, no binaries reached the GitHub Release, v0.15.1 has been marked draft.

This brings the linux fix from #298 (already on develop) into main as a cherry-pick so semantic-release can cut v0.15.2.

## Why not the original develop → main PR (#299)

I created a sync PR (#300) earlier to bring main's release-cycle commits (CHANGELOG + version bump) back to develop. Squash-merging that sync PR collapsed the merge ancestry — develop has main's content but not main's commit history, so #299 stayed permanently BEHIND.

Cherry-picking the linux fix straight to main sidesteps that. After this lands and Release cuts v0.15.2, the auto sync-develop job in build.yml will bring the v0.15.2 release commits back to develop with proper ancestry.

## Diff

\`apps/desktop/package.json\`: \`"executableName": "readied"\` added to \`build.linux\`. Single line. mac+win already build cleanly because they use \`productName\` ("Readied") and \`appId\` (\`app.readied.desktop\`) respectively.

## Expected Build flow

semantic-release reads main's commit log since v0.15.1:
- \`fix(desktop): set linux.executableName for AppImage build (#298)\` → patch bump

→ v0.15.2 cut as draft → Build runs on mac/win/linux → all 3 publish to draft → \`publish\` job undrafts → \`sync-develop\` PRs main → develop.