### PR TITLE
fix(desktop): prevent 'Object has been destroyed' and 'db not open' crashes

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -220,6 +220,7 @@ function createWindow(): void {
   mainWindow.on('move', debouncedSave);
 
   mainWindow.on('maximize', () => {
+    if (mainWindow.isDestroyed()) return;
     saveWindowState({
       ...mainWindow.getBounds(),
       isMaximized: true,
@@ -227,26 +228,30 @@ function createWindow(): void {
   });
 
   mainWindow.on('unmaximize', () => {
-    const bounds = mainWindow.getBounds();
+    if (mainWindow.isDestroyed()) return;
     saveWindowState({
-      ...bounds,
+      ...mainWindow.getBounds(),
       isMaximized: false,
     });
   });
 
   mainWindow.on('ready-to-show', () => {
+    if (mainWindow.isDestroyed()) return;
     mainWindow.show();
   });
 
-  // Deliver any pending deep link auth token once the renderer is ready
+  // Deliver any pending deep link auth token once the renderer is ready.
+  // Guard against window destruction — did-finish-load can fire late during
+  // app shutdown or auto-update restart, and the captured `mainWindow` ref
+  // would throw 'Object has been destroyed' on .send/.show/.focus.
   mainWindow.webContents.on('did-finish-load', () => {
-    if (pendingAuthToken) {
-      getLogger().info('Delivering queued auth token to renderer');
-      mainWindow.webContents.send('auth:verify-token', pendingAuthToken);
-      mainWindow.show();
-      mainWindow.focus();
-      pendingAuthToken = null;
-    }
+    if (!pendingAuthToken) return;
+    if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) return;
+    getLogger().info('Delivering queued auth token to renderer');
+    mainWindow.webContents.send('auth:verify-token', pendingAuthToken);
+    mainWindow.show();
+    mainWindow.focus();
+    pendingAuthToken = null;
   });
 
   // Load renderer
@@ -279,6 +284,7 @@ function createNoteWindow(noteId: string, noteTitle: string): void {
   });
 
   noteWindow.on('ready-to-show', () => {
+    if (noteWindow.isDestroyed()) return;
     noteWindow.show();
     if (process.env.NODE_ENV === 'development') {
       noteWindow.webContents.openDevTools();
@@ -837,12 +843,28 @@ app.on('before-quit', async event => {
     );
   }
 
-  if (db) {
-    db.close();
-    getLogger().info('Database closed');
-  }
-
+  // Don't close the DB here — windows are still alive and may issue IPC
+  // requests (e.g. notebooks:tree on reload) until they fully unmount.
+  // The DB is closed in `will-quit`, after window-all-closed has fired.
   app.quit();
+});
+
+// Close the database after all windows are gone but before the process exits.
+// This avoids the "database connection is not open" race where the renderer
+// fires an IPC request between db.close() and window destruction.
+app.on('will-quit', () => {
+  if (db) {
+    try {
+      db.close();
+      getLogger().info('Database closed');
+    } catch (err) {
+      getLogger().error(
+        { error: err instanceof Error ? err.message : String(err) },
+        'Error closing database during shutdown'
+      );
+    }
+    db = null;
+  }
 });
 
 // Deep link handler for readied:// protocol (macOS)

--- a/apps/desktop/src/main/pluginWatcher.ts
+++ b/apps/desktop/src/main/pluginWatcher.ts
@@ -27,11 +27,15 @@ export function startPluginWatcher(pluginsDir: string): void {
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   const broadcastReload = () => {
-    BrowserWindow.getAllWindows().forEach(win => {
-      if (!win.isDestroyed()) {
-        win.webContents.send('plugins:reload');
+    for (const win of BrowserWindow.getAllWindows()) {
+      try {
+        if (!win.isDestroyed() && !win.webContents.isDestroyed()) {
+          win.webContents.send('plugins:reload');
+        }
+      } catch {
+        // Window destroyed between check and send — ignore
       }
-    });
+    }
   };
 
   try {


### PR DESCRIPTION
## Summary

Two related lifecycle bugs reported after v0.15.2 install (production):

1. **`TypeError: Object has been destroyed`** at `BrowserWindow.<anonymous>` / `WebContents.<anonymous>` — surfaced as an `Uncaught Exception` dialog.
2. **`TypeError: The database connection is not open`** thrown by `notebooks:tree` IPC handler.

## Root cause

**(1) Object has been destroyed:** `mainWindow` event handlers (`maximize`, `unmaximize`, `ready-to-show`, `did-finish-load`) called `getBounds()`/`show()`/`focus()`/`webContents.send()` without checking `isDestroyed()`. During shutdown or auto-update restart, these events can fire after the window is destroyed, throwing. `noteWindow.ready-to-show` had the same gap. `pluginWatcher.broadcastReload` was missing the `webContents.isDestroyed` + `try/catch` pattern used elsewhere.

**(2) DB not open:** `db.close()` ran inside `before-quit` *before* windows finished unmounting, so the renderer could fire an IPC request (e.g. `notebooks:tree` on a late reload) between `close()` and actual quit, hitting a closed connection.

## Changes

- `apps/desktop/src/main/index.ts`
  - Add `isDestroyed()` guard to `mainWindow` handlers (`maximize`, `unmaximize`, `ready-to-show`, `did-finish-load`) and to `noteWindow.ready-to-show`.
  - Move `db.close()` from `before-quit` to a new `will-quit` listener (fires after `window-all-closed`), with `try/catch` and null-out so re-entry is safe.
- `apps/desktop/src/main/pluginWatcher.ts`
  - Harden `broadcastReload` with `webContents.isDestroyed()` check and `try/catch`, matching the production `broadcastToWindows` pattern.

## Out of scope (follow-up)

`dataHandlers.ts:setDb` updates the top-level `db` reference after backup restore but doesn't recreate `noteRepository` / `notebookRepository` — those still hold the closed connection. A restore today leaves the app in a broken state until manual restart. Tracking separately; not in this PR.

## Test plan

- [x] `pnpm typecheck` — all 4 desktop projects pass
- [x] `pnpm test` — 17/17 successful
- [x] `pnpm --filter @readied/desktop build` — succeeds
- [ ] Manual: quit + relaunch the packaged app, confirm no uncaught exception dialog and notebooks load on first paint
- [ ] Manual: trigger Cmd+Q while the renderer is reloading, confirm no `notebooks:tree` error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability when closing windows by preventing errors during shutdown
  * Enhanced app shutdown sequence to better handle timing issues with database closure

* **Refactor**
  * Strengthened plugin reload mechanism with additional safety checks and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->