### PR TITLE
fix(changelog): remove leftover merge conflict markers from v0.15.2 sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
-<<<<<<< HEAD
-=======
 ## [0.15.2](https://github.com/tomymaritano/readide/compare/v0.15.1...v0.15.2) (2026-06-09)
 
 ### Bug Fixes
 
 * **release:** cut v0.15.2 with linux executableName fix ([#301](https://github.com/tomymaritano/readide/issues/301)) ([33769fc](https://github.com/tomymaritano/readide/commit/33769fc8be341b4787d06260bb1b0e45486fac8c)), closes [#298](https://github.com/tomymaritano/readide/issues/298) [#299](https://github.com/tomymaritano/readide/issues/299) [#300](https://github.com/tomymaritano/readide/issues/300) [#299](https://github.com/tomymaritano/readide/issues/299) [#298](https://github.com/tomymaritano/readide/issues/298)
 
->>>>>>> origin/main
 ## [0.15.1](https://github.com/tomymaritano/readide/compare/v0.15.0...v0.15.1) (2026-06-09)
 
 ### Bug Fixes


### PR DESCRIPTION
## Summary

The v0.15.2 sync (#302) committed `CHANGELOG.md` with unresolved merge conflict markers (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main`). This makes the release PR #304 (`develop` → `main`) report `CONFLICTING`.

This PR restores `CHANGELOG.md` on `develop` to match `main` exactly (the canonical version — semantic-release writes the changelog on `main`). Identical content on both sides means #304 merges cleanly.

**Diff: 3 deleted lines** (the markers), nothing else.

## Unblocks

- #304 — release PR for v0.15.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)