### PR TITLE
fix(desktop): harden security across IPC, storage, CSP, and rendering

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -83,6 +83,7 @@
     "react-dom": "^19.2.7",
     "react-force-graph-2d": "^1.29.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"

--- a/apps/desktop/src/main/ai/ipc-ai.ts
+++ b/apps/desktop/src/main/ai/ipc-ai.ts
@@ -1,10 +1,59 @@
 // apps/desktop/src/main/ai/ipc-ai.ts
-import { ipcMain, app, dialog } from 'electron';
 import { readFile, writeFile } from 'node:fs/promises';
+import { ipcMain, app, dialog } from 'electron';
+import { z } from 'zod';
 import type { AIService, ChatHandle, ToolChatHandle, ToolCall } from '@readied/ai-core';
 import type { ToolRegistry } from '@readied/ai-core';
 
 const BATCH_INTERVAL_MS = 50;
+
+// ─── Input validation ───────────────────────────────────
+// These channels stream (they need event.sender) so they can't use the
+// tuple-based defineIpcHandler, but renderer input is still untrusted and
+// must be bounded. Parse before touching business logic.
+
+const MAX_CONTENT = 1024 * 1024; // 1 MB per field
+const IdStrSchema = z.string().min(1).max(256);
+const NoteContextSchema = z.object({
+  id: z.string().max(256),
+  title: z.string().max(4096),
+  content: z.string().max(MAX_CONTENT),
+});
+const ChatRequestSchema = z.object({
+  query: z.string().max(MAX_CONTENT),
+  currentNote: NoteContextSchema.nullish(),
+  relevantNotes: z.array(NoteContextSchema).max(200).default([]),
+  history: z
+    .array(
+      z.object({
+        role: z.enum(['user', 'assistant']),
+        content: z.string().max(MAX_CONTENT),
+      })
+    )
+    .max(1000)
+    .default([]),
+  mode: z.enum(['chat', 'ask-notes']),
+  provider: z.string().min(1).max(64),
+  model: z.string().min(1).max(256),
+  providerConfig: z
+    .object({
+      apiKey: z.string().max(4096).optional(),
+      baseUrl: z.string().max(2048).optional(),
+    })
+    .default({}),
+  maxResponseTokens: z.number().int().positive().max(200_000).optional(),
+  tools: z.boolean().optional(),
+});
+const ValidateConfigSchema = z.object({
+  provider: z.string().min(1).max(64),
+  apiKey: z.string().max(4096).optional(),
+  baseUrl: z.string().max(2048).optional(),
+});
+const RendererToolResultSchema = z.object({
+  ok: z.boolean(),
+  content: z.string().max(MAX_CONTENT),
+  error: z.string().max(4096).optional(),
+});
 
 // Per-window active handle tracking
 const activeHandles = new Map<number, Map<string, ChatHandle | ToolChatHandle>>();
@@ -39,6 +88,12 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
         tools?: boolean;
       }
     ) => {
+      const parsed = ChatRequestSchema.safeParse(request);
+      if (!parsed.success) {
+        throw new Error(`Invalid ai:chat request: ${parsed.error.message}`);
+      }
+      request = parsed.data as typeof request;
+
       const windowId = event.sender.id;
       const toolDefs = request.tools ? toolRegistry.getDefinitions() : [];
 
@@ -94,6 +149,7 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
 
   // ─── Cancel ─────────────────────────────────────────────
   ipcMain.handle('ai:cancel', (event, requestId: string) => {
+    if (!IdStrSchema.safeParse(requestId).success) return;
     const windowId = event.sender.id;
     const handles = activeHandles.get(windowId);
     const handle = handles?.get(requestId);
@@ -107,6 +163,11 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
   ipcMain.handle(
     'ai:validate',
     async (_event, config: { provider: string; apiKey?: string; baseUrl?: string }) => {
+      const parsedConfig = ValidateConfigSchema.safeParse(config);
+      if (!parsedConfig.success) {
+        return { ok: false, error: `Invalid ai:validate config: ${parsedConfig.error.message}` };
+      }
+      config = parsedConfig.data;
       try {
         const handle = service.chat({
           query: 'Say "ok".',
@@ -172,6 +233,13 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
   ipcMain.handle(
     'ai:tool-confirm',
     (event, requestId: string, callId: string, approved: boolean) => {
+      if (
+        !IdStrSchema.safeParse(requestId).success ||
+        !IdStrSchema.safeParse(callId).success ||
+        typeof approved !== 'boolean'
+      ) {
+        return;
+      }
       // Verify the sender owns this request
       const windowId = event.sender.id;
       if (!activeHandles.get(windowId)?.has(requestId)) return;
@@ -193,6 +261,13 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
       callId: string,
       result: { ok: boolean; content: string; error?: string }
     ) => {
+      if (
+        !IdStrSchema.safeParse(requestId).success ||
+        !IdStrSchema.safeParse(callId).success ||
+        !RendererToolResultSchema.safeParse(result).success
+      ) {
+        return;
+      }
       // Verify the sender owns this request
       const windowId = event.sender.id;
       if (!activeHandles.get(windowId)?.has(requestId)) return;

--- a/apps/desktop/src/main/handlers/gitHandlers.ts
+++ b/apps/desktop/src/main/handlers/gitHandlers.ts
@@ -12,7 +12,14 @@ export interface GitHandlerDeps {
   gitService: GitService;
 }
 
-const IdSchema = z.string().min(1).max(128);
+// Notebook/note IDs are UUIDs (crypto.randomUUID) or safe slugs like 'inbox'.
+// Restrict the charset: these values flow into path.join() inside GitService,
+// so an unconstrained string (e.g. "../../..") would enable path traversal.
+const IdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'ID must be alphanumeric (letters, digits, _ or -)');
 // SHAs are hex; allow short-SHAs (≥7) up to full 40-char.
 const ShaSchema = z
   .string()

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -21,6 +21,7 @@ import {
   nativeTheme,
   globalShortcut,
   screen,
+  shell,
 } from 'electron';
 import { runMigrations, createDataPaths, type DataPaths } from '@readied/storage-core';
 import {
@@ -425,6 +426,39 @@ function createSettingsWindow(): void {
     });
   }
 }
+
+// ============================================================================
+// Navigation hardening
+// ============================================================================
+
+/** Only the app's own renderer origin (dev server) or packaged file:// loads. */
+function isInternalNavigation(url: string): boolean {
+  if (url.startsWith('file://')) return true;
+  const devUrl = process.env.ELECTRON_RENDERER_URL;
+  if (devUrl && url.startsWith(devUrl)) return true;
+  return false;
+}
+
+/** Protocols we are willing to hand off to the OS via shell.openExternal. */
+function isSafeExternalUrl(url: string): boolean {
+  return url.startsWith('https://') || url.startsWith('http://') || url.startsWith('mailto:');
+}
+
+// SECURITY: rendered note/AI content can contain arbitrary links (rehypeRaw is
+// enabled). Deny all in-app navigation and window.open by default; route only
+// vetted external URLs to the system browser. Applied to every web contents.
+app.on('web-contents-created', (_event, contents) => {
+  contents.setWindowOpenHandler(({ url }) => {
+    if (isSafeExternalUrl(url)) void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+
+  contents.on('will-navigate', (event, url) => {
+    if (isInternalNavigation(url)) return;
+    event.preventDefault();
+    if (isSafeExternalUrl(url)) void shell.openExternal(url);
+  });
+});
 
 // ============================================================================
 // Window Management IPC (small enough to keep inline)

--- a/apps/desktop/src/main/services/gitService.ts
+++ b/apps/desktop/src/main/services/gitService.ts
@@ -125,7 +125,7 @@ export class GitService {
    */
   async writeNoteFile(notebookId: string, noteId: string, content: string): Promise<void> {
     const repoPath = this.getRepoPath(notebookId);
-    const filePath = path.join(repoPath, `${noteId}.md`);
+    const filePath = this.getNoteFilePath(repoPath, noteId);
 
     // Ensure directory exists
     if (!fs.existsSync(repoPath)) {
@@ -141,7 +141,7 @@ export class GitService {
    */
   async readNoteFile(notebookId: string, noteId: string): Promise<string | null> {
     const repoPath = this.getRepoPath(notebookId);
-    const filePath = path.join(repoPath, `${noteId}.md`);
+    const filePath = this.getNoteFilePath(repoPath, noteId);
 
     if (!fs.existsSync(filePath)) {
       return null;
@@ -155,7 +155,7 @@ export class GitService {
    */
   async deleteNoteFile(notebookId: string, noteId: string): Promise<void> {
     const repoPath = this.getRepoPath(notebookId);
-    const filePath = path.join(repoPath, `${noteId}.md`);
+    const filePath = this.getNoteFilePath(repoPath, noteId);
 
     if (fs.existsSync(filePath)) {
       fs.unlinkSync(filePath);
@@ -430,10 +430,33 @@ export class GitService {
   // ==========================================================================
 
   /**
+   * Resolve `segments` against `base` and guarantee the result stays inside
+   * `base`. Defense-in-depth against path traversal: the IPC layer already
+   * restricts ID charsets (see gitHandlers.ts), but this ensures a malformed
+   * or future-changed ID can never escape the notebooks directory.
+   */
+  private resolveWithin(base: string, ...segments: string[]): string {
+    const normalizedBase = path.resolve(base);
+    const target = path.resolve(normalizedBase, ...segments);
+    if (target !== normalizedBase && !target.startsWith(normalizedBase + path.sep)) {
+      throw new Error('Resolved path escapes the allowed directory');
+    }
+    return target;
+  }
+
+  /**
    * Get the filesystem path to a notebook's git repository
    */
   private getRepoPath(notebookId: string): string {
-    return path.join(this.baseDir, 'notebooks', notebookId);
+    return this.resolveWithin(path.join(this.baseDir, 'notebooks'), notebookId);
+  }
+
+  /**
+   * Get the filesystem path to a note file within a notebook repo, validating
+   * that it stays inside the repository directory.
+   */
+  private getNoteFilePath(repoPath: string, noteId: string): string {
+    return this.resolveWithin(repoPath, `${noteId}.md`);
   }
 
   /**

--- a/apps/desktop/src/renderer/components/ai/AiPanel.tsx
+++ b/apps/desktop/src/renderer/components/ai/AiPanel.tsx
@@ -100,6 +100,30 @@ export function AiPanel({
     inputRef.current?.focus();
   }, []);
 
+  // Rehydrate the API key from safeStorage (OS keychain) into the in-memory
+  // store. The key is intentionally NOT persisted to localStorage (see
+  // settingsStore partialize), so after an app restart it must be loaded from
+  // the encrypted keychain before the chat flow can use it.
+  useEffect(() => {
+    if (aiSettings.provider === 'ollama') return;
+    if (aiSettings.apiKey) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const key = await window.readied.ai.getKey(aiSettings.provider);
+        if (!cancelled && key) {
+          useSettingsStore.getState().updateAi({ apiKey: key });
+        }
+      } catch {
+        // safeStorage unavailable (e.g. locked keychain) — leave key empty;
+        // the submit handler surfaces a "set your API key" message.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [aiSettings.provider, aiSettings.apiKey]);
+
   // Sync mode when initialMode prop changes (e.g. ai:ask-notes command while panel open)
   useEffect(() => {
     setMode(initialMode);

--- a/apps/desktop/src/renderer/components/editor/MarkdownPreview.tsx
+++ b/apps/desktop/src/renderer/components/editor/MarkdownPreview.tsx
@@ -10,6 +10,7 @@ import {
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import rehypeHighlight from 'rehype-highlight';
 import '../../styles/code-highlight.css';
 import { Clock, CalendarPlus, ListChecks } from 'lucide-react';
@@ -86,6 +87,39 @@ export const MarkdownPreview = forwardRef<MarkdownPreviewHandle, MarkdownPreview
       codeBlockStore.subscribe,
       () => codeBlockStore.getState().registrations
     );
+
+    // SECURITY: rehypeRaw parses raw HTML embedded in note markdown, so the
+    // output must be sanitized before rendering (defends against XSS via
+    // <script>, event handlers, javascript: URLs, etc.). The schema extends the
+    // GitHub-flavored default to preserve app features: the custom <embed-image>
+    // element, task-list checkboxes, className/data-* (wikilinks, syntax
+    // highlight), asset:// image URLs, and plugin-registered preview elements.
+    // Runs BEFORE rehypeHighlight so highlight's generated spans/classes are
+    // trusted output rather than sanitized input.
+    const sanitizeSchema = useMemo(() => {
+      const base = defaultSchema;
+      const attrs = base.attributes ?? {};
+      const star = (attrs['*'] ?? []) as unknown[];
+      return {
+        ...base,
+        tagNames: [
+          ...(base.tagNames ?? []),
+          'embed-image',
+          ...pluginComponentRegs.map(r => r.tagName),
+        ],
+        attributes: {
+          ...attrs,
+          '*': [...star, 'className', 'data*'],
+          'embed-image': ['src', 'alt', 'className', 'loading'],
+          input: ['type', 'checked', 'disabled'],
+        },
+        protocols: {
+          ...base.protocols,
+          // Local embeds are resolved to asset:// URLs before rendering.
+          src: [...(base.protocols?.src ?? []), 'asset'],
+        },
+      } as typeof defaultSchema;
+    }, [pluginComponentRegs]);
 
     // Use live buffer content if available for this note, otherwise fall back to prop
     const liveContent = useEditorBufferStore(selectContentForNote(noteId));
@@ -263,6 +297,7 @@ export const MarkdownPreview = forwardRef<MarkdownPreviewHandle, MarkdownPreview
           rehypePlugins={
             [
               rehypeRaw,
+              [rehypeSanitize, sanitizeSchema],
               rehypeHighlight,
               ...pluginRehypeRegs.map(r => r.plugin),
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https:;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https:;" />
     <title>Readied</title>
   </head>
   <body>

--- a/apps/desktop/src/renderer/stores/settings/settingsStore.ts
+++ b/apps/desktop/src/renderer/stores/settings/settingsStore.ts
@@ -195,6 +195,16 @@ export const useSettingsStore = create<SettingsStore>()(
       name: 'readied-settings',
       version: SETTINGS_VERSION,
       migrate: migrateSettings,
+      // SECURITY: never persist the AI API key to localStorage. The key is
+      // stored encrypted via Electron safeStorage (OS keychain) and rehydrated
+      // into memory on demand (see AiPanel/AiSection). Writing it here would
+      // leave it in cleartext on disk, defeating safeStorage.
+      partialize: state => ({
+        settings: {
+          ...state.settings,
+          ai: { ...state.settings.ai, apiKey: '' },
+        },
+      }),
     }
   )
 );
@@ -264,7 +274,14 @@ if (typeof window !== 'undefined' && window.readied?.settings) {
   let prevSettings = useSettingsStore.getState().settings;
   useSettingsStore.subscribe(state => {
     if (!isRemoteUpdate && state.settings !== prevSettings) {
-      window.readied.settings.broadcast(state.settings as unknown as Record<string, unknown>);
+      // SECURITY: strip the API key before broadcasting across windows. Each
+      // window rehydrates the key from safeStorage on its own; it must never
+      // travel over the cross-window IPC channel in cleartext.
+      const safeSettings = {
+        ...state.settings,
+        ai: { ...state.settings.ai, apiKey: '' },
+      };
+      window.readied.settings.broadcast(safeSettings as unknown as Record<string, unknown>);
     }
     prevSettings = state.settings;
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -5321,6 +5324,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-from-package@0.0.0:
@@ -5416,6 +5420,9 @@ packages:
 
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
@@ -5922,6 +5929,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lie@3.3.0:
@@ -7264,6 +7272,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -13662,6 +13673,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -15777,6 +15794,11 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves all 5 findings from the security audit in a single hardening pass. Scoped to `apps/desktop` (plus `rehype-sanitize` added to lockfile).

| # | Sev | Fix |
|---|-----|-----|
| 1 | **HIGH** | **Path traversal in git handlers** — `IdSchema` now restricts notebook/note IDs to `[A-Za-z0-9_-]`; `GitService` adds `resolveWithin()` containment checks so a resolved path can never escape the notebooks dir. |
| 2 | **HIGH** | **LLM API key in localStorage** — settings store no longer persists `ai.apiKey` (persist `partialize`) and strips it from the cross-window broadcast. Key lives only in the OS keychain (`safeStorage`); `AiPanel` rehydrates it into memory on demand. |
| 3 | **MEDIUM** | **Weak CSP** — dropped `'unsafe-eval'` from renderer `script-src`, aligning with `settings.html`. |
| 4 | **MEDIUM** | **Unvalidated AI IPC** — bounded Zod schemas on `ai:chat` / `ai:cancel` / `ai:validate` / `ai:tool-confirm` / `ai:tool-renderer-result`. |
| 5 | **LOW** | **XSS surface + navigation** — `rehype-sanitize` on `rehypeRaw` output (schema preserves `embed-image`, task checkboxes, `className`/`data-*`, `asset://` URLs, plugin elements); global deny of in-app navigation / `window.open`, external links routed through `shell.openExternal`. |

## Verification

- ✅ `pnpm typecheck` (main / preload / renderer / e2e)
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm test` — 17/17 packages pass
- ✅ App boots clean in dev with all changes loaded

## Notes / follow-ups

- **CSP `img-src https:` left as-is.** Tightening it would break legitimate remote images embedded in user notes — that's a product decision, flagged for discussion rather than silently changed.
- **Needs a manual visual QA pass on Markdown preview** (finding #5): syntax highlighting, `![[embed]]` images, task-list checkboxes, and wikilinks — to confirm the sanitize schema preserves them. Automated checks (typecheck/lint/tests) pass but can't exercise the rendered preview.
- Pre-existing, unrelated: a CodeMirror `tags is not iterable` console error on note open, and 38 Dependabot advisories on the default branch — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Tightened app navigation and external link handling for safer browsing.
  * Added stronger protection against unsafe file paths and restricted content rendering.

* **Bug Fixes**
  * Improved AI settings recovery so saved API keys reappear more reliably when available.
  * Prevented invalid AI and note inputs from causing unexpected behavior.

* **New Features**
  * Added safer handling for rendered Markdown content, including local embedded assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->