### PR TITLE
fix(api): make desktop magic-link email clickable

### DIFF
--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -51,12 +51,19 @@ auth.post('/magic-link', zValidator('json', magicLinkSchema), async c => {
     expiresAt,
   });
 
-  // Send email — desktop clients get a readied:// deep link URL
+  // Send email — ALWAYS link to the https web verify page, which is clickable
+  // in email clients and then hands off to the desktop app via the custom-
+  // scheme deep link (see apps/web .../auth/verify: it redirects to
+  // readied://auth/verify and shows an "Open" fallback button).
+  //
+  // A custom-scheme URL (readied://…) placed directly in an email is NOT
+  // clickable in most mail clients (Gmail, Apple Mail, Outlook strip or ignore
+  // non-http(s) hrefs), which left desktop users unable to click the link.
+  // The `client` param is forwarded so the web page can tailor its messaging.
   const emailService = createEmailService(c.env.RESEND_API_KEY);
-  const magicLinkUrl =
-    client === 'desktop'
-      ? `readied://auth/verify?token=${token}`
-      : `https://readied.app/auth/verify?token=${token}`;
+  const magicLinkUrl = `https://readied.app/auth/verify?token=${token}&client=${encodeURIComponent(
+    client
+  )}`;
   const emailSent = await emailService.sendMagicLink(email, magicLinkUrl);
 
   if (!emailSent) {


### PR DESCRIPTION
## Problem

Desktop users receive the sign-in email but **can't click the link to log in**.

Root cause: `packages/api/src/routes/auth.ts` emailed a raw custom-scheme URL for desktop clients:

```ts
client === 'desktop'
  ? `readied://auth/verify?token=${token}`   // ← not clickable in email
  : `https://readied.app/auth/verify?token=${token}`
```

Email clients (Gmail, Apple Mail, Outlook) only render `http(s)://` and `mailto:` as clickable anchors — a `readied://` href is stripped or shown as inert text.

## Fix

Always link to the **https web verify page**, which is clickable and already performs the deep-link handoff (`apps/web/.../auth/verify/AuthVerifyContent.tsx` redirects to `readied://auth/verify` and shows an "Open in Readied" fallback button). The `client` value is forwarded as a query param.

## Verification

- ✅ `pnpm --filter @readied/api typecheck`
- ✅ `pnpm lint` (0 errors)
- ✅ `pnpm --filter @readied/api test` — 42 tests pass

## Notes

- **Dev caveat:** even with the email fixed, in a dev build the `readied://` protocol may not be registered to the unbundled Electron on macOS, so the handoff can fail locally. The audit also flagged `readied.app` must be deployed for the link to resolve.
- **Rename dependency:** `readied.app` and the `readied://` scheme will change with the dripnex rename — this fix is orthogonal (it's about link *structure*, not the brand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Magic-link emails now always use a clickable HTTPS verification link, improving reliability across devices.
  * Client type is included in the verification link so the sign-in flow can adapt appropriately after email verification.
  * Removed the desktop-specific deep link behavior in favor of a consistent web-based flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->