### PR TITLE
fix(desktop): apply CodeRabbit review fixes missed by #432 merge

### DIFF
--- a/apps/desktop/src/main/ai/ipc-ai.ts
+++ b/apps/desktop/src/main/ai/ipc-ai.ts
@@ -62,7 +62,7 @@ const activeHandles = new Map<number, Map<string, ChatHandle | ToolChatHandle>>(
 const pendingConfirmations = new Map<string, Map<string, (approved: boolean) => void>>();
 const CONFIRM_TIMEOUT_MS = 60_000;
 
-// Pending renderer tool results: callId -> resolve function
+// Pending renderer tool results: `${requestId}:${callId}` -> resolve function
 const pendingRendererResults = new Map<
   string,
   (result: { ok: boolean; content: string; error?: string }) => void
@@ -272,10 +272,11 @@ export function registerAIHandlers(service: AIService, toolRegistry: ToolRegistr
       const windowId = event.sender.id;
       if (!activeHandles.get(windowId)?.has(requestId)) return;
 
-      const resolve = pendingRendererResults.get(callId);
+      const key = `${requestId}:${callId}`;
+      const resolve = pendingRendererResults.get(key);
       if (resolve) {
         resolve(result);
-        pendingRendererResults.delete(callId);
+        pendingRendererResults.delete(key);
       }
     }
   );
@@ -321,13 +322,16 @@ export function executeToolInRenderer(
   toolName: string,
   args: Record<string, unknown>
 ): Promise<{ ok: boolean; content: string; error?: string }> {
+  // Key by (requestId, callId): callId is only unique within a request, so two
+  // concurrent requests could otherwise collide and resolve each other's promise.
+  const key = `${requestId}:${callId}`;
   return new Promise(resolve => {
-    pendingRendererResults.set(callId, resolve);
+    pendingRendererResults.set(key, resolve);
     sender.send('ai:tool-execute-in-renderer', requestId, callId, toolName, args);
 
     setTimeout(() => {
-      if (pendingRendererResults.has(callId)) {
-        pendingRendererResults.delete(callId);
+      if (pendingRendererResults.has(key)) {
+        pendingRendererResults.delete(key);
         resolve({ ok: false, content: 'Renderer tool timed out', error: 'Timeout' });
       }
     }, RENDERER_TOOL_TIMEOUT_MS);

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -11,6 +11,7 @@ import { initSentry } from './sentry';
 initSentry();
 
 import { join, normalize } from 'path';
+import { pathToFileURL } from 'url';
 import { existsSync } from 'fs';
 import {
   app,
@@ -431,11 +432,36 @@ function createSettingsWindow(): void {
 // Navigation hardening
 // ============================================================================
 
-/** Only the app's own renderer origin (dev server) or packaged file:// loads. */
+/**
+ * Only the app's own renderer origin (dev server) or packaged file:// loads
+ * under the app's output directory. Uses parsed-origin / path-prefix checks
+ * rather than string startsWith, which would let `http://localhost:5174.evil.com`
+ * or `file:///etc/passwd` pass.
+ */
 function isInternalNavigation(url: string): boolean {
-  if (url.startsWith('file://')) return true;
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return false;
+  }
+
   const devUrl = process.env.ELECTRON_RENDERER_URL;
-  if (devUrl && url.startsWith(devUrl)) return true;
+  if (devUrl) {
+    try {
+      if (u.origin === new URL(devUrl).origin) return true;
+    } catch {
+      // malformed dev URL — ignore
+    }
+  }
+
+  if (u.protocol === 'file:') {
+    // Packaged renderer is loaded from the app's `out/` dir via loadFile. Only
+    // allow file:// navigations that stay within it.
+    const appDirUrl = pathToFileURL(join(__dirname, '..') + '/').href;
+    return u.href.startsWith(appDirUrl);
+  }
+
   return false;
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -10,8 +10,8 @@
 import { initSentry } from './sentry';
 initSentry();
 
-import { join, normalize } from 'path';
-import { pathToFileURL } from 'url';
+import { join, normalize, relative, isAbsolute } from 'path';
+import { fileURLToPath } from 'url';
 import { existsSync } from 'fs';
 import {
   app,
@@ -523,9 +523,18 @@ function isInternalNavigation(url: string): boolean {
 
   if (u.protocol === 'file:') {
     // Packaged renderer is loaded from the app's `out/` dir via loadFile. Only
-    // allow file:// navigations that stay within it.
-    const appDirUrl = pathToFileURL(join(__dirname, '..') + '/').href;
-    return u.href.startsWith(appDirUrl);
+    // allow file:// navigations that resolve INSIDE it. Compare real filesystem
+    // paths via path.relative (handles `..`, separators, and percent-encoding)
+    // rather than a URL string prefix, which normalization could sidestep.
+    let target: string;
+    try {
+      target = fileURLToPath(u);
+    } catch {
+      return false;
+    }
+    const appDir = join(__dirname, '..');
+    const rel = relative(appDir, target);
+    return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
   }
 
   return false;

--- a/apps/desktop/src/renderer/components/ai/AiPanel.tsx
+++ b/apps/desktop/src/renderer/components/ai/AiPanel.tsx
@@ -104,15 +104,19 @@ export function AiPanel({
   // store. The key is intentionally NOT persisted to localStorage (see
   // settingsStore partialize), so after an app restart it must be loaded from
   // the encrypted keychain before the chat flow can use it.
+  //
+  // Keyed on provider only: whenever the provider changes we must load THAT
+  // provider's key (and clear a stale key from the previous provider), so we
+  // don't send provider A's key to provider B. Depending on apiKey too would
+  // both loop and skip reloads when a stale key is present.
   useEffect(() => {
     if (aiSettings.provider === 'ollama') return;
-    if (aiSettings.apiKey) return;
     let cancelled = false;
     void (async () => {
       try {
         const key = await window.readied.ai.getKey(aiSettings.provider);
-        if (!cancelled && key) {
-          useSettingsStore.getState().updateAi({ apiKey: key });
+        if (!cancelled) {
+          useSettingsStore.getState().updateAi({ apiKey: key ?? '' });
         }
       } catch {
         // safeStorage unavailable (e.g. locked keychain) — leave key empty;
@@ -122,7 +126,7 @@ export function AiPanel({
     return () => {
       cancelled = true;
     };
-  }, [aiSettings.provider, aiSettings.apiKey]);
+  }, [aiSettings.provider]);
 
   // Sync mode when initialMode prop changes (e.g. ai:ask-notes command while panel open)
   useEffect(() => {

--- a/apps/desktop/src/renderer/stores/settings/settingsStore.ts
+++ b/apps/desktop/src/renderer/stores/settings/settingsStore.ts
@@ -282,7 +282,12 @@ if (typeof window !== 'undefined' && window.readied?.settings) {
     // incoming sync always carries apiKey=''. Preserve THIS window's in-memory
     // key instead of clobbering it — each window hydrates its own key from
     // safeStorage and must not lose it when another window changes a setting.
-    const localApiKey = useSettingsStore.getState().settings.ai.apiKey;
+    // BUT if the sync also switches the provider, the in-memory key belongs to
+    // the OLD provider — drop it and let AiPanel rehydrate the new provider's
+    // key from safeStorage, so we never carry provider A's key into provider B.
+    const currentAi = useSettingsStore.getState().settings.ai;
+    const incomingProvider = s.ai?.provider ?? currentAi.provider;
+    const preservedApiKey = incomingProvider === currentAi.provider ? currentAi.apiKey : '';
 
     // Merge with defaults to ensure no section is undefined
     const merged: SettingsSchema = {
@@ -291,7 +296,7 @@ if (typeof window !== 'undefined' && window.readied?.settings) {
       general: { ...DEFAULT_GENERAL, ...s.general },
       updates: { ...DEFAULT_UPDATES, ...s.updates },
       appearance: { ...DEFAULT_APPEARANCE, ...s.appearance },
-      ai: { ...DEFAULT_AI, ...s.ai, apiKey: localApiKey },
+      ai: { ...DEFAULT_AI, ...s.ai, apiKey: preservedApiKey },
       editor: { ...DEFAULT_EDITOR, ...s.editor },
       backup: { ...DEFAULT_BACKUP, ...s.backup },
     };

--- a/apps/desktop/src/renderer/stores/settings/settingsStore.ts
+++ b/apps/desktop/src/renderer/stores/settings/settingsStore.ts
@@ -236,6 +236,31 @@ export const selectIndentWithTabs = (state: SettingsStore) => state.settings.edi
 export const selectSpellCheck = (state: SettingsStore) => state.settings.editor.spellCheck;
 
 // ============================================================================
+// One-time migration: scrub a previously-persisted API key
+// ============================================================================
+
+// Builds before the `partialize` fix wrote `ai.apiKey` to localStorage in
+// cleartext. `partialize` stops FUTURE writes, but an already-stored key would
+// linger until the next persist. Proactively strip it from the stored blob on
+// startup. The in-memory value (rehydrated from this same blob) is then
+// re-sourced from safeStorage by AiPanel/AiSection.
+if (typeof window !== 'undefined') {
+  try {
+    const STORAGE_KEY = 'readied-settings';
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed?.state?.settings?.ai?.apiKey) {
+        parsed.state.settings.ai.apiKey = '';
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsed));
+      }
+    }
+  } catch {
+    // Malformed/absent storage — nothing to scrub.
+  }
+}
+
+// ============================================================================
 // Cross-Window Sync via IPC
 // ============================================================================
 
@@ -253,6 +278,12 @@ if (typeof window !== 'undefined' && window.readied?.settings) {
     // Cast through unknown to satisfy TS
     const s = data as unknown as Partial<SettingsSchema>;
 
+    // The API key is intentionally stripped from the broadcast (see below), so
+    // incoming sync always carries apiKey=''. Preserve THIS window's in-memory
+    // key instead of clobbering it — each window hydrates its own key from
+    // safeStorage and must not lose it when another window changes a setting.
+    const localApiKey = useSettingsStore.getState().settings.ai.apiKey;
+
     // Merge with defaults to ensure no section is undefined
     const merged: SettingsSchema = {
       ...DEFAULT_SETTINGS,
@@ -260,7 +291,7 @@ if (typeof window !== 'undefined' && window.readied?.settings) {
       general: { ...DEFAULT_GENERAL, ...s.general },
       updates: { ...DEFAULT_UPDATES, ...s.updates },
       appearance: { ...DEFAULT_APPEARANCE, ...s.appearance },
-      ai: { ...DEFAULT_AI, ...s.ai },
+      ai: { ...DEFAULT_AI, ...s.ai, apiKey: localApiKey },
       editor: { ...DEFAULT_EDITOR, ...s.editor },
       backup: { ...DEFAULT_BACKUP, ...s.backup },
     };


### PR DESCRIPTION
## Why

PR #432 was merged **without** the follow-up commit that addressed CodeRabbit's review, so develop currently contains the flagged issues. This PR re-applies those fixes (cherry-picked from the #432 branch).

## Fixes (from CodeRabbit review of #432)

- **nav guard**: `isInternalNavigation` compares parsed origins and restricts `file://` to the app's `out/` dir, instead of `startsWith` (which let `http://localhost:5174.evil.com` / `file:///etc/passwd` through).
- **ipc-ai**: key `pendingRendererResults` by `${requestId}:${callId}` — callId is only unique within a request, so concurrent requests could resolve the wrong renderer-tool promise.
- **settings cross-window sync**: preserve this window's in-memory `ai.apiKey` when applying an incoming (key-stripped) broadcast, so a setting change in one window no longer wipes the key in others.
- **settings**: one-time scrub of any `ai.apiKey` previously persisted to localStorage by pre-`partialize` builds.
- **AiPanel**: rehydrate the key per-provider (effect keyed on provider only) so switching providers loads the right key.

## Verification

- ✅ typecheck (main + renderer), lint (0 errors), `pnpm --filter @readied/desktop test` (51 pass)

Follow-up to #432. Not addressed (by design): rehype-sanitize `asset:` on src — app-internal protocol required for embeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI tool-result matching for concurrent tool runs so responses are routed to the correct request.
  * Strengthened internal navigation validation to block malformed/unintended URLs and restrict file-based loads to within the app output.
  * Refined AI provider key handling: keys now refresh only when the selected provider changes, and missing keys are cleared.
  * Improved AI settings synchronization by preserving the current key only when the provider matches, and removing any previously stored legacy cleartext AI key on startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->