### PR TITLE
fix(security): eliminate polynomial ReDoS in regexes (CodeQL high)

### DIFF
--- a/packages/ai-core/src/providers/ollama.ts
+++ b/packages/ai-core/src/providers/ollama.ts
@@ -4,6 +4,17 @@ import type { LLMEvent, ChatOptions, MessageContent, ContentPart } from '../type
 
 const DEFAULT_BASE_URL = 'http://localhost:11434';
 
+/**
+ * Strip trailing slashes without a regex. `String.replace(/\/+$/, '')` is
+ * flagged as polynomial ReDoS (js/polynomial-redos) because baseUrl is
+ * config-controlled; a linear scan is backtracking-free.
+ */
+function stripTrailingSlashes(url: string): string {
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47 /* '/' */) end--;
+  return url.slice(0, end);
+}
+
 function normalizeContent(content: MessageContent): string {
   if (typeof content === 'string') return content;
   return content
@@ -57,7 +68,7 @@ export class OllamaProvider implements LLMProvider {
 
   async *chat(options: ChatOptions, config: ProviderConfig): AsyncIterable<LLMEvent> {
     const { model, system, messages, maxTokens, signal, tools } = options;
-    const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    const baseUrl = stripTrailingSlashes(config.baseUrl ?? DEFAULT_BASE_URL);
 
     // Build Ollama message format
     const ollamaMessages: Array<Record<string, unknown>> = [];
@@ -271,7 +282,7 @@ export class OllamaProvider implements LLMProvider {
   }
 
   async validate(config: ProviderConfig): Promise<{ ok: boolean; error?: string }> {
-    const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    const baseUrl = stripTrailingSlashes(config.baseUrl ?? DEFAULT_BASE_URL);
 
     try {
       const response = await this.fetchFn(`${baseUrl}/api/tags`, {
@@ -304,7 +315,7 @@ export class OllamaProvider implements LLMProvider {
   }
 
   async listModels(config: ProviderConfig): Promise<ModelInfo[]> {
-    const baseUrl = (config.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+    const baseUrl = stripTrailingSlashes(config.baseUrl ?? DEFAULT_BASE_URL);
 
     try {
       const response = await this.fetchFn(`${baseUrl}/api/tags`, {

--- a/packages/ai-core/src/retry.ts
+++ b/packages/ai-core/src/retry.ts
@@ -33,7 +33,7 @@ export function classifyError(err: unknown): LLMErrorCode {
     const msg = err.message.toLowerCase();
     if (msg.includes('429') || msg.includes('rate limit') || msg.includes('rate_limit'))
       return 'rate_limit';
-    if (msg.includes('401') || msg.includes('unauthorized') || /invalid.*key/.test(msg))
+    if (msg.includes('401') || msg.includes('unauthorized') || /invalid.{0,80}key/.test(msg))
       return 'auth_failed';
     if (msg.includes('context') || msg.includes('too long') || msg.includes('too many tokens'))
       return 'context_overflow';

--- a/packages/wikilinks/src/core/parsing.ts
+++ b/packages/wikilinks/src/core/parsing.ts
@@ -16,7 +16,11 @@ import type { WikilinkRef } from './types.js';
  *
  * Groups: [1]=target, [2]=anchor (optional), [3]=display (optional)
  */
-const WIKILINK_PATTERN = /\[\[([^[\]|#]+)(?:#([^[\]|]+))?(?:\|([^\]]+))?\]\]/g;
+// Segment lengths are bounded ({1,200}) to prevent polynomial-time backtracking
+// (ReDoS, js/polynomial-redos): the three adjacent quantifiers over overlapping
+// character classes could otherwise blow up on crafted note content. A wikilink
+// target/anchor/display longer than 200 chars is not a real case.
+const WIKILINK_PATTERN = /\[\[([^[\]|#]{1,200})(?:#([^[\]|]{1,200}))?(?:\|([^\]]{1,200}))?\]\]/g;
 
 /**
  * Extract all wikilinks from markdown content.


### PR DESCRIPTION
## Summary

Resolves the **5 CodeQL `js/polynomial-redos` (high)** alerts surfaced on develop. Each regex runs on config- or content-controlled input and could backtrack polynomially on crafted input (hang the thread).

| File | Fix |
|------|-----|
| `packages/wikilinks/src/core/parsing.ts` | `WIKILINK_PATTERN`: bound the three adjacent segment quantifiers to `{1,200}` (overlapping unbounded `+` groups were the ReDoS source). 200 chars ≫ any real target/anchor/alias. |
| `packages/ai-core/src/providers/ollama.ts` (×3) | Replace `(baseUrl).replace(/\/+$/, '')` with a backtracking-free `stripTrailingSlashes()` linear scan. |
| `packages/ai-core/src/retry.ts` | `/invalid.*key/` → `/invalid.{0,80}key/` (unbounded `.*` between anchors is O(n²) with repeated "invalid"). |

These were **pre-existing** on develop (not introduced by any recent PR) — CodeQL re-attributed them to the large rename PR (#437), which is how they surfaced.

## Verification
- ✅ typecheck, lint (0 warnings)
- ✅ `@dripnex/wikilinks` (17) + `@dripnex/ai-core` (128) tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Ollama endpoint handling by normalizing server URLs more consistently.
  * Refined error detection for invalid API keys, reducing misclassification of certain failures.
  * Updated wikilink parsing to better handle long inputs and reduce the risk of slow or problematic link matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->