### PR TITLE
refactor(api): use @dripnex/sync-core for notebook tree validation

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,6 +27,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dripnex/sync-core": "workspace:*",
     "@hono/zod-validator": "^0.8.0",
     "@libsql/client": "^0.17.3",
     "drizzle-orm": "^0.45.2",

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -13,6 +13,7 @@ import { Hono } from 'hono';
 import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import { eq, and, gt, desc, sql } from 'drizzle-orm';
+import { validateNotebookTree, type TreeNode } from '@dripnex/sync-core';
 import { createDb, type Env } from '../db/client.js';
 import {
   syncLog,
@@ -257,62 +258,9 @@ const notebookPushSchema = z.object({
   deviceId: z.string().uuid(),
 });
 
-/**
- * Validate notebook tree integrity before accepting push.
- * Checks: depth <= 2, parentId exists, no circular references.
- */
-function validateNotebookTree(
-  changes: Array<{ notebookId: string; operation: string; data?: string | null }>,
-  existingNotebooks: Map<string, { parentId: string | null; depth: number }>
-): { valid: true } | { valid: false; error: string; notebookId: string } {
-  const tree = new Map(existingNotebooks);
-
-  for (const change of changes) {
-    if (change.operation === 'delete') {
-      tree.delete(change.notebookId);
-      continue;
-    }
-    if (!change.data) continue;
-    const parsed = JSON.parse(change.data) as {
-      name: string;
-      parentId: string | null;
-      depth: number;
-      order: number;
-    };
-
-    if (parsed.depth > 2) {
-      return {
-        valid: false,
-        error: `depth exceeds max (2), got ${parsed.depth}`,
-        notebookId: change.notebookId,
-      };
-    }
-    if (parsed.parentId && !tree.has(parsed.parentId)) {
-      return {
-        valid: false,
-        error: `parentId '${parsed.parentId}' not found`,
-        notebookId: change.notebookId,
-      };
-    }
-    if (parsed.parentId) {
-      const visited = new Set<string>([change.notebookId]);
-      let current: string | null = parsed.parentId;
-      while (current) {
-        if (visited.has(current)) {
-          return {
-            valid: false,
-            error: 'circular reference detected',
-            notebookId: change.notebookId,
-          };
-        }
-        visited.add(current);
-        current = tree.get(current)?.parentId ?? null;
-      }
-    }
-    tree.set(change.notebookId, { parentId: parsed.parentId, depth: parsed.depth });
-  }
-  return { valid: true };
-}
+// Notebook tree validation (depth<=2, parent exists, no cycles) is shared with
+// the desktop/sync logic — imported from @dripnex/sync-core (single source of
+// truth) instead of a duplicated inline copy.
 
 // Pull notebook changes
 sync.get('/notebooks', zValidator('query', pullSchema), async c => {
@@ -377,7 +325,7 @@ sync.post('/notebooks', zValidator('json', notebookPushSchema), async c => {
     .where(eq(notebookSyncLog.userId, userId))
     .orderBy(desc(notebookSyncLog.version));
 
-  const latestByNotebook = new Map<string, { parentId: string | null; depth: number }>();
+  const latestByNotebook = new Map<string, TreeNode>();
   const processedIds = new Set<string>();
   for (const entry of existingEntries) {
     if (processedIds.has(entry.notebookId)) continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
 
   packages/api:
     dependencies:
+      '@dripnex/sync-core':
+        specifier: workspace:*
+        version: link:../sync-core
       '@hono/zod-validator':
         specifier: ^0.8.0
         version: 0.8.0(hono@4.12.23)(zod@4.4.3)


### PR DESCRIPTION
## Summary

The API (`routes/sync.ts`) had an **inline copy** of `validateNotebookTree` byte-identical to the one already exported by `@dripnex/sync-core` (same `TreeNode` / `TreeValidationResult` shapes). Import the shared one and delete the duplicate.

- Single source of truth for the notebook-tree rules (depth ≤ 2, parent exists, no cycles).
- **Resolves the "sync-core is dead code" finding**: the package was previously unused; the API is now its first consumer, so it earns its keep as the shared sync-logic source.
- First workspace dependency in the API Worker — verified it **bundles cleanly** via `wrangler deploy --dry-run`.

## Verification
- ✅ `pnpm install`, api `typecheck`, api tests (42), lint (0)
- ✅ `wrangler deploy --dry-run` builds the Worker with the new dep

## Multi-repo note
When the repo is split, `@dripnex/sync-core` is a natural **shared package** between the API repo and the desktop repo — this consolidation is exactly the seam that becomes a published shared lib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook sync consistency by using a shared validation source, reducing the chance of tree integrity mismatches during pushes.
  * Kept notebook update and conflict handling behavior unchanged while aligning validation data with the sync engine’s expected structure.

* **Chores**
  * Added a shared sync package dependency to support the updated notebook validation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->