### PR TITLE
fix(api): distributed rate limiting via Cloudflare Workers Rate Limiting

### DIFF
--- a/packages/api/src/db/client.ts
+++ b/packages/api/src/db/client.ts
@@ -9,6 +9,11 @@ import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 import * as schema from './schema.js';
 
+/** Cloudflare Workers Rate Limiting binding (configured in wrangler.toml). */
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
 export type Env = {
   TURSO_DATABASE_URL: string;
   TURSO_AUTH_TOKEN: string;
@@ -21,6 +26,10 @@ export type Env = {
   SITE_URL?: string;
   ADMIN_TOKEN?: string;
   ENVIRONMENT: string;
+  // Rate limiting bindings (optional so unit tests / local runs without the
+  // binding fail open rather than crash — see middleware/rateLimit.ts).
+  AUTH_RL?: RateLimitBinding;
+  SYNC_RL?: RateLimitBinding;
 };
 
 /**

--- a/packages/api/src/middleware/rateLimit.ts
+++ b/packages/api/src/middleware/rateLimit.ts
@@ -58,7 +58,6 @@ export function rateLimit(config: RateLimitConfig) {
       const { success } = await limiter.limit({ key: keyGenerator(c) });
       if (!success) {
         c.header('Retry-After', String(windowSeconds));
-        c.header('X-RateLimit-Remaining', '0');
         return deny(c);
       }
     }

--- a/packages/api/src/middleware/rateLimit.ts
+++ b/packages/api/src/middleware/rateLimit.ts
@@ -1,157 +1,74 @@
 /**
  * Rate Limiting Middleware
  *
- * Implements sliding window rate limiting to prevent abuse.
- * Uses in-memory storage for development, can be upgraded to Cloudflare KV for production.
+ * Uses Cloudflare's Workers Rate Limiting binding — account-global and
+ * consistent across isolates — instead of a per-isolate in-memory Map (which
+ * reset on every isolate and never shared state, so it did not actually limit
+ * anything in production). Bindings are configured in wrangler.toml
+ * (`[[unsafe.bindings]]` with `type = "ratelimit"`); the `namespace_id` is a
+ * self-assigned integer (no resource to provision) and `period` must be 10 or 60s.
  *
- * Strategy:
- * - Public endpoints (auth): Rate limit by IP address
- * - Authenticated endpoints (sync): Rate limit by user ID
+ * - auth endpoints: 10 requests / 60s per IP  → AUTH_RL
+ * - sync endpoints: 100 requests / 60s per IP → SYNC_RL
  */
 
 import type { Context, Next } from 'hono';
-import type { Env } from '../db/client.js';
+import type { Env, RateLimitBinding } from '../db/client.js';
 
-interface RateLimitEntry {
-  count: number;
-  resetAt: number;
-}
+type BindingName = 'AUTH_RL' | 'SYNC_RL';
 
-// In-memory store (per-worker, not shared)
-// For production, upgrade to Cloudflare KV for distributed rate limiting
-const rateLimitStore = new Map<string, RateLimitEntry>();
-
-/**
- * Cleanup expired entries from rate limit store
- * Called inline during rate limit checks to avoid global scope timers
- */
-function cleanupExpiredEntries() {
-  const now = Date.now();
-  for (const [key, entry] of rateLimitStore.entries()) {
-    if (entry.resetAt < now) {
-      rateLimitStore.delete(key);
-    }
-  }
-}
-
-export interface RateLimitOptions {
-  /**
-   * Maximum number of requests allowed in the window
-   */
+export interface RateLimitConfig {
+  /** wrangler.toml ratelimit binding to enforce against. */
+  binding: BindingName;
+  /** Configured limit — mirrored into the X-RateLimit-Limit header. */
   max: number;
-
-  /**
-   * Window duration in milliseconds
-   */
-  windowMs: number;
-
-  /**
-   * Key generator function
-   * Default: Uses IP address from CF-Connecting-IP header
-   */
+  /** Configured window in seconds — surfaced via Retry-After. */
+  windowSeconds: number;
+  /** Key to bucket by. Default: client IP. */
   keyGenerator?: (c: Context<{ Bindings: Env }>) => string;
-
-  /**
-   * Handler when rate limit is exceeded
-   */
+  /** Response when the limit is exceeded. */
   handler?: (c: Context<{ Bindings: Env }>) => Response;
 }
 
-/**
- * Rate limiting middleware factory
- */
-export function rateLimit(options: RateLimitOptions) {
-  const {
-    max,
-    windowMs,
-    keyGenerator = c => {
-      // Use Cloudflare's CF-Connecting-IP header (real client IP)
-      const ip = c.req.header('CF-Connecting-IP') || c.req.header('X-Forwarded-For') || 'unknown';
-      return ip;
-    },
-    handler = c => {
-      return c.json(
+function clientIp(c: Context<{ Bindings: Env }>): string {
+  return c.req.header('CF-Connecting-IP') || c.req.header('X-Forwarded-For') || 'unknown';
+}
+
+export function rateLimit(config: RateLimitConfig) {
+  const { binding, max, windowSeconds, keyGenerator = clientIp, handler } = config;
+  const deny =
+    handler ??
+    ((c: Context<{ Bindings: Env }>) =>
+      c.json(
         {
           error: 'Too Many Requests',
           message: 'Rate limit exceeded. Please try again later.',
-          retryAfter: Math.ceil(windowMs / 1000),
+          retryAfter: windowSeconds,
         },
         429
-      );
-    },
-  } = options;
+      ));
 
   return async (c: Context<{ Bindings: Env }>, next: Next) => {
-    // Cleanup expired entries periodically
-    cleanupExpiredEntries();
+    c.header('X-RateLimit-Limit', String(max));
 
-    const key = keyGenerator(c);
-    const now = Date.now();
-
-    // Get or create rate limit entry
-    let entry = rateLimitStore.get(key);
-
-    if (!entry || entry.resetAt < now) {
-      // Create new window
-      entry = {
-        count: 0,
-        resetAt: now + windowMs,
-      };
-      rateLimitStore.set(key, entry);
+    const limiter = c.env[binding] as RateLimitBinding | undefined;
+    // Fail open ONLY when the binding is absent — i.e. unit tests or a local
+    // run without the binding configured. Deployed Workers always have it.
+    if (limiter) {
+      const { success } = await limiter.limit({ key: keyGenerator(c) });
+      if (!success) {
+        c.header('Retry-After', String(windowSeconds));
+        c.header('X-RateLimit-Remaining', '0');
+        return deny(c);
+      }
     }
-
-    // Increment request count
-    entry.count++;
-
-    // Check if limit exceeded
-    if (entry.count > max) {
-      const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
-      c.header('Retry-After', retryAfter.toString());
-      c.header('X-RateLimit-Limit', max.toString());
-      c.header('X-RateLimit-Remaining', '0');
-      c.header('X-RateLimit-Reset', entry.resetAt.toString());
-      return handler(c);
-    }
-
-    // Add rate limit headers
-    c.header('X-RateLimit-Limit', max.toString());
-    c.header('X-RateLimit-Remaining', Math.max(0, max - entry.count).toString());
-    c.header('X-RateLimit-Reset', entry.resetAt.toString());
 
     await next();
   };
 }
 
-/**
- * Pre-configured rate limiters
- */
+/** Strict limit for auth endpoints: 10 requests / 60s per IP. */
+export const authRateLimit = rateLimit({ binding: 'AUTH_RL', max: 10, windowSeconds: 60 });
 
-/**
- * Strict rate limit for authentication endpoints
- * 10 requests per minute per IP
- */
-export const authRateLimit = rateLimit({
-  max: 10,
-  windowMs: 60 * 1000, // 1 minute
-});
-
-/**
- * Moderate rate limit for sync endpoints
- * 100 requests per minute per IP
- *
- * Note: Uses IP-based rate limiting for simplicity.
- * For user-based rate limiting, upgrade to Cloudflare KV storage.
- */
-export const syncRateLimit = rateLimit({
-  max: 100,
-  windowMs: 60 * 1000, // 1 minute
-});
-
-/**
- * Lenient rate limit for general API endpoints
- * 300 requests per minute per IP
- */
-export const generalRateLimit = rateLimit({
-  max: 300,
-  windowMs: 60 * 1000, // 1 minute
-});
+/** Moderate limit for sync endpoints: 100 requests / 60s per IP. */
+export const syncRateLimit = rateLimit({ binding: 'SYNC_RL', max: 100, windowSeconds: 60 });

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -6,15 +6,53 @@ compatibility_date = "2024-12-01"
 [vars]
 ENVIRONMENT = "development"
 
+# Rate limiting bindings (Workers Rate Limiting API). namespace_id is a
+# self-assigned integer — no resource to provision. period must be 10 or 60.
+[[unsafe.bindings]]
+name = "AUTH_RL"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 10, period = 60 }
+
+[[unsafe.bindings]]
+name = "SYNC_RL"
+type = "ratelimit"
+namespace_id = "1002"
+simple = { limit = 100, period = 60 }
+
 # Staging environment
 [env.staging]
 name = "readied-api-staging"
 vars = { ENVIRONMENT = "staging" }
 
+[[env.staging.unsafe.bindings]]
+name = "AUTH_RL"
+type = "ratelimit"
+namespace_id = "2001"
+simple = { limit = 10, period = 60 }
+
+[[env.staging.unsafe.bindings]]
+name = "SYNC_RL"
+type = "ratelimit"
+namespace_id = "2002"
+simple = { limit = 100, period = 60 }
+
 # Production environment
 [env.production]
 name = "readied-api-production"
 vars = { ENVIRONMENT = "production" }
+
+[[env.production.unsafe.bindings]]
+name = "AUTH_RL"
+type = "ratelimit"
+namespace_id = "3001"
+simple = { limit = 10, period = 60 }
+
+[[env.production.unsafe.bindings]]
+name = "SYNC_RL"
+type = "ratelimit"
+namespace_id = "3002"
+simple = { limit = 100, period = 60 }
 
 # Secrets (set via wrangler secret put):
 # - Development: wrangler secret put <KEY>

--- a/packages/api/wrangler.toml
+++ b/packages/api/wrangler.toml
@@ -6,17 +6,15 @@ compatibility_date = "2024-12-01"
 [vars]
 ENVIRONMENT = "development"
 
-# Rate limiting bindings (Workers Rate Limiting API). namespace_id is a
-# self-assigned integer — no resource to provision. period must be 10 or 60.
-[[unsafe.bindings]]
+# Rate limiting (Workers Rate Limiting API, GA). namespace_id is a self-assigned
+# integer — no resource to provision. period must be 10 or 60.
+[[ratelimits]]
 name = "AUTH_RL"
-type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 10, period = 60 }
 
-[[unsafe.bindings]]
+[[ratelimits]]
 name = "SYNC_RL"
-type = "ratelimit"
 namespace_id = "1002"
 simple = { limit = 100, period = 60 }
 
@@ -25,15 +23,13 @@ simple = { limit = 100, period = 60 }
 name = "readied-api-staging"
 vars = { ENVIRONMENT = "staging" }
 
-[[env.staging.unsafe.bindings]]
+[[env.staging.ratelimits]]
 name = "AUTH_RL"
-type = "ratelimit"
 namespace_id = "2001"
 simple = { limit = 10, period = 60 }
 
-[[env.staging.unsafe.bindings]]
+[[env.staging.ratelimits]]
 name = "SYNC_RL"
-type = "ratelimit"
 namespace_id = "2002"
 simple = { limit = 100, period = 60 }
 
@@ -42,15 +38,13 @@ simple = { limit = 100, period = 60 }
 name = "readied-api-production"
 vars = { ENVIRONMENT = "production" }
 
-[[env.production.unsafe.bindings]]
+[[env.production.ratelimits]]
 name = "AUTH_RL"
-type = "ratelimit"
 namespace_id = "3001"
 simple = { limit = 10, period = 60 }
 
-[[env.production.unsafe.bindings]]
+[[env.production.ratelimits]]
 name = "SYNC_RL"
-type = "ratelimit"
 namespace_id = "3002"
 simple = { limit = 100, period = 60 }
 


### PR DESCRIPTION
## Summary

The audit found the API rate limiter was a **per-isolate in-memory Map** — it reset on every isolate and shared no state, so in production it didn't actually limit anything. This replaces it with **Cloudflare's Workers Rate Limiting binding** (account-global, consistent across isolates). Stays on Cloudflare per the platform decision.

## Changes
- `middleware/rateLimit.ts`: enforce via `env.AUTH_RL` / `env.SYNC_RL` `.limit({key})`. Keeps the auth (10/60s) and sync (100/60s) **per-IP** limiters; drops the unused `generalRateLimit` and the in-memory store. **Fails open only when the binding is absent** (unit tests / local without it) — deployed Workers always have it.
- `db/client.ts`: `RateLimitBinding` type + optional `AUTH_RL`/`SYNC_RL` on `Env`.
- `wrangler.toml`: `[[unsafe.bindings]]` (`type = "ratelimit"`) for default/staging/production, with **distinct `namespace_id`s per env** so staging and production don't share counters. `period = 60` fits both limiters; `namespace_id` is a self-assigned integer — **no resource to provision, no migration**.

## Verification
- ✅ `pnpm --filter @dripnex/api typecheck`, 42 tests, lint (0)
- ✅ `wrangler deploy --dry-run` (default **and** `--env production`) — both recognize `env.AUTH_RL (ratelimit)` / `env.SYNC_RL (ratelimit)`

## Notes
- The `[[unsafe.bindings]]` form emits a "unsafe fields are experimental" wrangler warning — expected; the Workers Rate Limiting binding still lives under `unsafe`.
- Trade-off vs the old code: the binding returns `{ success }` only, so exact `X-RateLimit-Remaining`/`Reset` headers are dropped (kept `X-RateLimit-Limit` + `Retry-After`). Enforcement is now real and distributed, which is the point.
- Recommend deploying **staging first** to confirm the binding behaves before production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting now uses configured edge rate-limit bindings for more consistent enforcement across environments.
  * Added separate limits for authentication and synchronization traffic.
  * When rate limiting isn’t available, requests are allowed through (fail-open).

* **Bug Fixes**
  * Exceeded-limit responses now include `Retry-After` aligned to the configured window.
  * Rate-limit header behavior was adjusted to match binding-based enforcement (no longer includes previous reset/remaining fields).

* **Configuration**
  * Updated Workers rate-limit configuration for local, staging, and production environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->