### PR TITLE
feat(planning): Planning Kanban board (data + UI)

### DIFF
--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -65,7 +65,7 @@ export function registerLocalServerHandlers(deps: LocalServerHandlerDeps): void 
         notebookId: snap.notebookId,
         createdAt: snap.createdAt,
         updatedAt: snap.updatedAt,
-        tags: snap.tags,
+        tags: [...snap.tags],
         wordCount: snap.wordCount,
         isPinned: snap.isPinned,
       };

--- a/apps/desktop/src/main/handlers/localServerHandlers.ts
+++ b/apps/desktop/src/main/handlers/localServerHandlers.ts
@@ -14,7 +14,7 @@ import {
   type LocalServerHandlers,
 } from '../services/localServer.js';
 import { defineIpcHandler } from '../ipc/registry.js';
-import type { SQLiteNoteRepository, DataPaths } from './types.js';
+import type { SQLiteNoteRepository, DataPaths, NoteToSnapshotFn } from './types.js';
 
 // ============================================================================
 // Types
@@ -23,36 +23,7 @@ import type { SQLiteNoteRepository, DataPaths } from './types.js';
 export interface LocalServerHandlerDeps {
   noteRepository: SQLiteNoteRepository;
   dataPaths: DataPaths;
-  noteToSnapshot: (note: {
-    id: string;
-    notebookId: string;
-    content: string;
-    title: string;
-    isPinned: boolean;
-    isDeleted: boolean;
-    status: import('@dripnex/core').NoteStatus;
-    metadata: {
-      createdAt: string;
-      updatedAt: string;
-      tags: readonly string[];
-      wordCount: number;
-      archivedAt: string | null;
-    };
-  }) => {
-    id: string;
-    notebookId: string;
-    content: string;
-    title: string;
-    createdAt: string;
-    updatedAt: string;
-    tags: string[];
-    wordCount: number;
-    archivedAt: string | null;
-    isArchived: boolean;
-    isPinned: boolean;
-    isDeleted: boolean;
-    status: import('@dripnex/core').NoteStatus;
-  };
+  noteToSnapshot: NoteToSnapshotFn;
 }
 
 // ============================================================================

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -24,9 +24,12 @@ import {
   restoreDeletedNote,
   setNoteStatus,
   setBoardStage,
+  setNotePriority,
   BOARD_STAGES,
+  NOTE_PRIORITIES,
   type NoteStatus,
   type BoardStage,
+  type NotePriority,
 } from '@dripnex/core';
 import { createNoteId, createNotebookId, createTag } from '@dripnex/core';
 import { defineIpcHandler } from '../ipc/registry.js';
@@ -44,6 +47,7 @@ const ContentSchema = z.string().max(10 * 1024 * 1024); // 10 MiB cap on note co
 const TagSchema = z.string().min(1).max(64);
 const StatusSchema: z.ZodType<NoteStatus> = z.enum(['active', 'on_hold', 'completed', 'dropped']);
 const BoardStageSchema: z.ZodType<BoardStage | null> = z.enum(BOARD_STAGES).nullable();
+const PrioritySchema: z.ZodType<NotePriority> = z.enum(NOTE_PRIORITIES);
 
 export function registerNoteHandlers(deps: NoteHandlerDeps): void {
   const { noteRepository: repo, dataPaths, noteToSnapshot } = deps;
@@ -187,6 +191,18 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
       const note = await repo.get(createNoteId(id));
       if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
       const updatedNote = setBoardStage(note, boardStage);
+      await repo.save(updatedNote);
+      return { ok: true, data: noteToSnapshot(updatedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:setPriority',
+    args: z.tuple([IdSchema, PrioritySchema]),
+    handler: async (id, priority) => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const updatedNote = setNotePriority(note, priority);
       await repo.save(updatedNote);
       return { ok: true, data: noteToSnapshot(updatedNote) };
     },

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -24,6 +24,7 @@ import {
   restoreDeletedNote,
   setNoteStatus,
   setBoardStage,
+  BOARD_STAGES,
   type NoteStatus,
   type BoardStage,
 } from '@dripnex/core';
@@ -42,9 +43,7 @@ const TitleSchema = z.string().max(512);
 const ContentSchema = z.string().max(10 * 1024 * 1024); // 10 MiB cap on note content
 const TagSchema = z.string().min(1).max(64);
 const StatusSchema: z.ZodType<NoteStatus> = z.enum(['active', 'on_hold', 'completed', 'dropped']);
-const BoardStageSchema: z.ZodType<BoardStage | null> = z
-  .enum(['backlog', 'todo', 'in_progress', 'in_review', 'in_staging'])
-  .nullable();
+const BoardStageSchema: z.ZodType<BoardStage | null> = z.enum(BOARD_STAGES).nullable();
 
 export function registerNoteHandlers(deps: NoteHandlerDeps): void {
   const { noteRepository: repo, dataPaths, noteToSnapshot } = deps;

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -25,7 +25,7 @@ import {
   setNoteStatus,
   setBoardStage,
   setNotePriority,
-  setBoardPosition,
+  PLANNING_NOTEBOOK_ID,
   BOARD_STAGES,
   NOTE_PRIORITIES,
   type NoteStatus,
@@ -192,6 +192,10 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
     handler: async (id, boardStage) => {
       const note = await repo.get(createNoteId(id));
       if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      // Board metadata may only ever be set on Planning-notebook notes.
+      if (boardStage !== null && note.notebookId !== PLANNING_NOTEBOOK_ID) {
+        return { ok: true, data: noteToSnapshot(note) };
+      }
       const updatedNote = setBoardStage(note, boardStage);
       await repo.save(updatedNote);
       return { ok: true, data: noteToSnapshot(updatedNote) };
@@ -214,14 +218,9 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
     channel: 'notes:reorderColumn',
     args: z.tuple([BoardStageValueSchema, z.array(IdSchema).max(2000)]),
     handler: async (stage, orderedIds) => {
-      // Reindex the whole column: each note gets board_stage=stage and
-      // board_order=its position. Metadata-only; markdown untouched.
-      for (let i = 0; i < orderedIds.length; i++) {
-        const id = orderedIds[i];
-        if (!id) continue;
-        const note = await repo.get(createNoteId(id));
-        if (note) await repo.save(setBoardPosition(note, stage, i));
-      }
+      // Atomic reindex of the column (metadata-only; markdown untouched). The
+      // repo guards notebook membership so ids outside Planning are ignored.
+      repo.reorderBoard(stage, orderedIds);
       return { ok: true };
     },
   });
@@ -234,6 +233,7 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
           limit: z.number().int().positive().max(100000).optional(),
           offset: z.number().int().nonnegative().optional(),
           tag: TagSchema.optional(),
+          notebookId: IdSchema.optional(),
           sortBy: z.enum(['createdAt', 'updatedAt', 'title']).optional(),
           sortOrder: z.enum(['asc', 'desc']).optional(),
           archived: z.enum(['active', 'archived', 'all']).optional(),

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -23,7 +23,9 @@ import {
   softDeleteNote,
   restoreDeletedNote,
   setNoteStatus,
+  setBoardStage,
   type NoteStatus,
+  type BoardStage,
 } from '@dripnex/core';
 import { createNoteId, createNotebookId, createTag } from '@dripnex/core';
 import { defineIpcHandler } from '../ipc/registry.js';
@@ -40,6 +42,9 @@ const TitleSchema = z.string().max(512);
 const ContentSchema = z.string().max(10 * 1024 * 1024); // 10 MiB cap on note content
 const TagSchema = z.string().min(1).max(64);
 const StatusSchema: z.ZodType<NoteStatus> = z.enum(['active', 'on_hold', 'completed', 'dropped']);
+const BoardStageSchema: z.ZodType<BoardStage | null> = z
+  .enum(['backlog', 'todo', 'in_progress', 'in_review', 'in_staging'])
+  .nullable();
 
 export function registerNoteHandlers(deps: NoteHandlerDeps): void {
   const { noteRepository: repo, dataPaths, noteToSnapshot } = deps;
@@ -171,6 +176,18 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
       const note = await repo.get(createNoteId(id));
       if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
       const updatedNote = setNoteStatus(note, status);
+      await repo.save(updatedNote);
+      return { ok: true, data: noteToSnapshot(updatedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:setBoardStage',
+    args: z.tuple([IdSchema, BoardStageSchema]),
+    handler: async (id, boardStage) => {
+      const note = await repo.get(createNoteId(id));
+      if (!note) return { ok: false, error: { type: 'NOT_FOUND', id } };
+      const updatedNote = setBoardStage(note, boardStage);
       await repo.save(updatedNote);
       return { ok: true, data: noteToSnapshot(updatedNote) };
     },

--- a/apps/desktop/src/main/handlers/noteHandlers.ts
+++ b/apps/desktop/src/main/handlers/noteHandlers.ts
@@ -25,6 +25,7 @@ import {
   setNoteStatus,
   setBoardStage,
   setNotePriority,
+  setBoardPosition,
   BOARD_STAGES,
   NOTE_PRIORITIES,
   type NoteStatus,
@@ -46,7 +47,8 @@ const TitleSchema = z.string().max(512);
 const ContentSchema = z.string().max(10 * 1024 * 1024); // 10 MiB cap on note content
 const TagSchema = z.string().min(1).max(64);
 const StatusSchema: z.ZodType<NoteStatus> = z.enum(['active', 'on_hold', 'completed', 'dropped']);
-const BoardStageSchema: z.ZodType<BoardStage | null> = z.enum(BOARD_STAGES).nullable();
+const BoardStageValueSchema: z.ZodType<BoardStage> = z.enum(BOARD_STAGES);
+const BoardStageSchema: z.ZodType<BoardStage | null> = BoardStageValueSchema.nullable();
 const PrioritySchema: z.ZodType<NotePriority> = z.enum(NOTE_PRIORITIES);
 
 export function registerNoteHandlers(deps: NoteHandlerDeps): void {
@@ -205,6 +207,22 @@ export function registerNoteHandlers(deps: NoteHandlerDeps): void {
       const updatedNote = setNotePriority(note, priority);
       await repo.save(updatedNote);
       return { ok: true, data: noteToSnapshot(updatedNote) };
+    },
+  });
+
+  defineIpcHandler({
+    channel: 'notes:reorderColumn',
+    args: z.tuple([BoardStageValueSchema, z.array(IdSchema).max(2000)]),
+    handler: async (stage, orderedIds) => {
+      // Reindex the whole column: each note gets board_stage=stage and
+      // board_order=its position. Metadata-only; markdown untouched.
+      for (let i = 0; i < orderedIds.length; i++) {
+        const id = orderedIds[i];
+        if (!id) continue;
+        const note = await repo.get(createNoteId(id));
+        if (note) await repo.save(setBoardPosition(note, stage, i));
+      }
+      return { ok: true };
     },
   });
 

--- a/apps/desktop/src/main/handlers/types.ts
+++ b/apps/desktop/src/main/handlers/types.ts
@@ -27,6 +27,7 @@ export type NoteToSnapshotFn = (note: {
   isDeleted: boolean;
   status: import('@dripnex/core').NoteStatus;
   boardStage: import('@dripnex/core').BoardStage | null;
+  priority: import('@dripnex/core').NotePriority;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -49,6 +50,7 @@ export type NoteToSnapshotFn = (note: {
   isDeleted: boolean;
   status: import('@dripnex/core').NoteStatus;
   boardStage: import('@dripnex/core').BoardStage | null;
+  priority: import('@dripnex/core').NotePriority;
 };
 
 export type {

--- a/apps/desktop/src/main/handlers/types.ts
+++ b/apps/desktop/src/main/handlers/types.ts
@@ -28,6 +28,7 @@ export type NoteToSnapshotFn = (note: {
   status: import('@dripnex/core').NoteStatus;
   boardStage: import('@dripnex/core').BoardStage | null;
   priority: import('@dripnex/core').NotePriority;
+  boardOrder: number;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -51,6 +52,7 @@ export type NoteToSnapshotFn = (note: {
   status: import('@dripnex/core').NoteStatus;
   boardStage: import('@dripnex/core').BoardStage | null;
   priority: import('@dripnex/core').NotePriority;
+  boardOrder: number;
 };
 
 export type {

--- a/apps/desktop/src/main/handlers/types.ts
+++ b/apps/desktop/src/main/handlers/types.ts
@@ -17,43 +17,12 @@ export type Database = ReturnType<typeof import('@dripnex/storage-sqlite').creat
 /** Broadcast helper signature */
 export type BroadcastFn = (channel: string, ...args: unknown[]) => void;
 
-/** Helper to convert a Note to a snapshot for IPC */
-export type NoteToSnapshotFn = (note: {
-  id: string;
-  notebookId: string;
-  content: string;
-  title: string;
-  isPinned: boolean;
-  isDeleted: boolean;
-  status: import('@dripnex/core').NoteStatus;
-  boardStage: import('@dripnex/core').BoardStage | null;
-  priority: import('@dripnex/core').NotePriority;
-  boardOrder: number;
-  metadata: {
-    createdAt: string;
-    updatedAt: string;
-    tags: readonly string[];
-    wordCount: number;
-    archivedAt: string | null;
-  };
-}) => {
-  id: string;
-  notebookId: string;
-  content: string;
-  title: string;
-  createdAt: string;
-  updatedAt: string;
-  tags: string[];
-  wordCount: number;
-  archivedAt: string | null;
-  isArchived: boolean;
-  isPinned: boolean;
-  isDeleted: boolean;
-  status: import('@dripnex/core').NoteStatus;
-  boardStage: import('@dripnex/core').BoardStage | null;
-  priority: import('@dripnex/core').NotePriority;
-  boardOrder: number;
-};
+/**
+ * Helper to convert a domain Note to a snapshot for IPC. This is exactly
+ * @dripnex/core's `toSnapshot`, so the shape lives in one place (core) instead
+ * of being hand-mirrored here.
+ */
+export type NoteToSnapshotFn = typeof import('@dripnex/core').toSnapshot;
 
 export type {
   DataPaths,

--- a/apps/desktop/src/main/handlers/types.ts
+++ b/apps/desktop/src/main/handlers/types.ts
@@ -26,6 +26,7 @@ export type NoteToSnapshotFn = (note: {
   isPinned: boolean;
   isDeleted: boolean;
   status: import('@dripnex/core').NoteStatus;
+  boardStage: import('@dripnex/core').BoardStage | null;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -47,6 +48,7 @@ export type NoteToSnapshotFn = (note: {
   isPinned: boolean;
   isDeleted: boolean;
   status: import('@dripnex/core').NoteStatus;
+  boardStage: import('@dripnex/core').BoardStage | null;
 };
 
 export type {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -118,6 +118,7 @@ export function noteToSnapshot(note: {
   status: NoteStatus;
   boardStage: BoardStage | null;
   priority: NotePriority;
+  boardOrder: number;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -142,6 +143,7 @@ export function noteToSnapshot(note: {
     status: note.status,
     boardStage: note.boardStage,
     priority: note.priority,
+    boardOrder: note.boardOrder,
   };
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,7 +31,13 @@ import {
   SQLiteNoteRepository,
   SQLiteNotebookRepository,
 } from '@dripnex/storage-sqlite';
-import { createNoteId, createNoteOperation, type NoteStatus, type BoardStage } from '@dripnex/core';
+import {
+  createNoteId,
+  createNoteOperation,
+  type NoteStatus,
+  type BoardStage,
+  type NotePriority,
+} from '@dripnex/core';
 import { initLogger, getLogger, loggers } from './logger';
 import { TokenStorage } from './services/tokenStorage.js';
 import { AiKeyStorage } from './services/aiKeyStorage.js';
@@ -111,6 +117,7 @@ export function noteToSnapshot(note: {
   isDeleted: boolean;
   status: NoteStatus;
   boardStage: BoardStage | null;
+  priority: NotePriority;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -134,6 +141,7 @@ export function noteToSnapshot(note: {
     isDeleted: note.isDeleted,
     status: note.status,
     boardStage: note.boardStage,
+    priority: note.priority,
   };
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,7 +31,7 @@ import {
   SQLiteNoteRepository,
   SQLiteNotebookRepository,
 } from '@dripnex/storage-sqlite';
-import { createNoteId, createNoteOperation, type NoteStatus } from '@dripnex/core';
+import { createNoteId, createNoteOperation, type NoteStatus, type BoardStage } from '@dripnex/core';
 import { initLogger, getLogger, loggers } from './logger';
 import { TokenStorage } from './services/tokenStorage.js';
 import { AiKeyStorage } from './services/aiKeyStorage.js';
@@ -110,6 +110,7 @@ export function noteToSnapshot(note: {
   isPinned: boolean;
   isDeleted: boolean;
   status: NoteStatus;
+  boardStage: BoardStage | null;
   metadata: {
     createdAt: string;
     updatedAt: string;
@@ -132,6 +133,7 @@ export function noteToSnapshot(note: {
     isPinned: note.isPinned,
     isDeleted: note.isDeleted,
     status: note.status,
+    boardStage: note.boardStage,
   };
 }
 

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,13 +31,7 @@ import {
   SQLiteNoteRepository,
   SQLiteNotebookRepository,
 } from '@dripnex/storage-sqlite';
-import {
-  createNoteId,
-  createNoteOperation,
-  type NoteStatus,
-  type BoardStage,
-  type NotePriority,
-} from '@dripnex/core';
+import { createNoteId, createNoteOperation, toSnapshot } from '@dripnex/core';
 import { initLogger, getLogger, loggers } from './logger';
 import { TokenStorage } from './services/tokenStorage.js';
 import { AiKeyStorage } from './services/aiKeyStorage.js';
@@ -107,45 +101,12 @@ export function broadcastToWindows(channel: string, ...args: unknown[]): void {
   }
 }
 
-/** Helper to convert a Note to a snapshot for IPC */
-export function noteToSnapshot(note: {
-  id: string;
-  notebookId: string;
-  content: string;
-  title: string;
-  isPinned: boolean;
-  isDeleted: boolean;
-  status: NoteStatus;
-  boardStage: BoardStage | null;
-  priority: NotePriority;
-  boardOrder: number;
-  metadata: {
-    createdAt: string;
-    updatedAt: string;
-    tags: readonly string[];
-    wordCount: number;
-    archivedAt: string | null;
-  };
-}) {
-  return {
-    id: note.id,
-    notebookId: note.notebookId,
-    content: note.content,
-    title: note.title,
-    createdAt: note.metadata.createdAt,
-    updatedAt: note.metadata.updatedAt,
-    tags: [...note.metadata.tags],
-    wordCount: note.metadata.wordCount,
-    archivedAt: note.metadata.archivedAt,
-    isArchived: note.metadata.archivedAt !== null,
-    isPinned: note.isPinned,
-    isDeleted: note.isDeleted,
-    status: note.status,
-    boardStage: note.boardStage,
-    priority: note.priority,
-    boardOrder: note.boardOrder,
-  };
-}
+/**
+ * Convert a domain Note to a snapshot for IPC. Single source of truth is
+ * @dripnex/core's `toSnapshot` — re-exported here under the name the handler
+ * dependency wiring already uses.
+ */
+export const noteToSnapshot = toSnapshot;
 
 // File-based license storage and window state persistence live in
 // dedicated modules under ./services/. See:

--- a/apps/desktop/src/main/services/sync/SyncService.ts
+++ b/apps/desktop/src/main/services/sync/SyncService.ts
@@ -897,6 +897,7 @@ export class SyncService {
             isDeleted: false,
             status: 'active' as NoteStatus,
             boardStage: null, // Synced notes default to inbox, not on the board
+            priority: 'none',
             metadata: {
               title: newTitle,
               createdAt: createTimestamp(new Date(change.createdAt)),

--- a/apps/desktop/src/main/services/sync/SyncService.ts
+++ b/apps/desktop/src/main/services/sync/SyncService.ts
@@ -14,6 +14,7 @@ import {
   createNotebookId,
   createNotebook,
   createTimestamp,
+  DEFAULT_NOTE_PRIORITY,
   type NoteStatus,
 } from '@dripnex/core';
 import type {
@@ -897,7 +898,7 @@ export class SyncService {
             isDeleted: false,
             status: 'active' as NoteStatus,
             boardStage: null, // Synced notes default to inbox, not on the board
-            priority: 'none',
+            priority: DEFAULT_NOTE_PRIORITY,
             boardOrder: 0,
             metadata: {
               title: newTitle,

--- a/apps/desktop/src/main/services/sync/SyncService.ts
+++ b/apps/desktop/src/main/services/sync/SyncService.ts
@@ -898,6 +898,7 @@ export class SyncService {
             status: 'active' as NoteStatus,
             boardStage: null, // Synced notes default to inbox, not on the board
             priority: 'none',
+            boardOrder: 0,
             metadata: {
               title: newTitle,
               createdAt: createTimestamp(new Date(change.createdAt)),

--- a/apps/desktop/src/main/services/sync/SyncService.ts
+++ b/apps/desktop/src/main/services/sync/SyncService.ts
@@ -896,6 +896,7 @@ export class SyncService {
             isPinned: false,
             isDeleted: false,
             status: 'active' as NoteStatus,
+            boardStage: null, // Synced notes default to inbox, not on the board
             metadata: {
               title: newTitle,
               createdAt: createTimestamp(new Date(change.createdAt)),

--- a/apps/desktop/src/preload/api/notes.ts
+++ b/apps/desktop/src/preload/api/notes.ts
@@ -33,6 +33,7 @@ export interface NotesAPI {
   setStatus: (id: string, status: NoteStatus) => Promise<Result<NoteSnapshot>>;
   setBoardStage: (id: string, boardStage: BoardStage | null) => Promise<Result<NoteSnapshot>>;
   setPriority: (id: string, priority: NotePriority) => Promise<Result<NoteSnapshot>>;
+  reorderColumn: (stage: BoardStage, orderedIds: string[]) => Promise<{ ok: boolean }>;
   list: (options?: ListOptions) => Promise<NoteSnapshot[]>;
   search: (query: string, limit?: number) => Promise<NoteSnapshot[]>;
   tags: () => Promise<string[]>;
@@ -64,6 +65,8 @@ export function createNotesApi(): NotesAPI {
     setStatus: (id, status) => ipcRenderer.invoke('notes:setStatus', id, status),
     setBoardStage: (id, boardStage) => ipcRenderer.invoke('notes:setBoardStage', id, boardStage),
     setPriority: (id, priority) => ipcRenderer.invoke('notes:setPriority', id, priority),
+    reorderColumn: (stage, orderedIds) =>
+      ipcRenderer.invoke('notes:reorderColumn', stage, orderedIds),
     list: options => ipcRenderer.invoke('notes:list', options),
     search: (query, limit) => ipcRenderer.invoke('notes:search', query, limit),
     tags: () => ipcRenderer.invoke('notes:tags'),

--- a/apps/desktop/src/preload/api/notes.ts
+++ b/apps/desktop/src/preload/api/notes.ts
@@ -3,6 +3,7 @@ import type {
   Result,
   NoteSnapshot,
   NoteStatus,
+  BoardStage,
   ListOptions,
   NoteCounts,
   TagWithColor,
@@ -29,6 +30,7 @@ export interface NotesAPI {
   softDelete: (id: string) => Promise<Result<NoteSnapshot>>;
   restoreDeleted: (id: string) => Promise<Result<NoteSnapshot>>;
   setStatus: (id: string, status: NoteStatus) => Promise<Result<NoteSnapshot>>;
+  setBoardStage: (id: string, boardStage: BoardStage | null) => Promise<Result<NoteSnapshot>>;
   list: (options?: ListOptions) => Promise<NoteSnapshot[]>;
   search: (query: string, limit?: number) => Promise<NoteSnapshot[]>;
   tags: () => Promise<string[]>;
@@ -58,6 +60,7 @@ export function createNotesApi(): NotesAPI {
     softDelete: id => ipcRenderer.invoke('notes:softDelete', id),
     restoreDeleted: id => ipcRenderer.invoke('notes:restoreDeleted', id),
     setStatus: (id, status) => ipcRenderer.invoke('notes:setStatus', id, status),
+    setBoardStage: (id, boardStage) => ipcRenderer.invoke('notes:setBoardStage', id, boardStage),
     list: options => ipcRenderer.invoke('notes:list', options),
     search: (query, limit) => ipcRenderer.invoke('notes:search', query, limit),
     tags: () => ipcRenderer.invoke('notes:tags'),

--- a/apps/desktop/src/preload/api/notes.ts
+++ b/apps/desktop/src/preload/api/notes.ts
@@ -4,6 +4,7 @@ import type {
   NoteSnapshot,
   NoteStatus,
   BoardStage,
+  NotePriority,
   ListOptions,
   NoteCounts,
   TagWithColor,
@@ -31,6 +32,7 @@ export interface NotesAPI {
   restoreDeleted: (id: string) => Promise<Result<NoteSnapshot>>;
   setStatus: (id: string, status: NoteStatus) => Promise<Result<NoteSnapshot>>;
   setBoardStage: (id: string, boardStage: BoardStage | null) => Promise<Result<NoteSnapshot>>;
+  setPriority: (id: string, priority: NotePriority) => Promise<Result<NoteSnapshot>>;
   list: (options?: ListOptions) => Promise<NoteSnapshot[]>;
   search: (query: string, limit?: number) => Promise<NoteSnapshot[]>;
   tags: () => Promise<string[]>;
@@ -61,6 +63,7 @@ export function createNotesApi(): NotesAPI {
     restoreDeleted: id => ipcRenderer.invoke('notes:restoreDeleted', id),
     setStatus: (id, status) => ipcRenderer.invoke('notes:setStatus', id, status),
     setBoardStage: (id, boardStage) => ipcRenderer.invoke('notes:setBoardStage', id, boardStage),
+    setPriority: (id, priority) => ipcRenderer.invoke('notes:setPriority', id, priority),
     list: options => ipcRenderer.invoke('notes:list', options),
     search: (query, limit) => ipcRenderer.invoke('notes:search', query, limit),
     tags: () => ipcRenderer.invoke('notes:tags'),

--- a/apps/desktop/src/preload/api/types.ts
+++ b/apps/desktop/src/preload/api/types.ts
@@ -10,14 +10,12 @@ export type Result<T> =
   | { ok: true; data: T }
   | { ok: false; error: { type: string; error?: unknown } };
 
-/** Note status for workflow tracking */
-export type NoteStatus = 'active' | 'on_hold' | 'completed' | 'dropped';
-
-/** Kanban board stage for planning notes (null = not on the board) */
-export type BoardStage = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'in_staging';
-
-/** Linear-style priority for a note */
-export type NotePriority = 'none' | 'low' | 'medium' | 'high' | 'urgent';
+// Single source of truth: these unions live in @dripnex/core. Imported for local
+// use and re-exported (type-only, erased at build) so the renderer keeps
+// importing them from the preload barrel while adding a new value only ever
+// means editing core.
+import type { NoteStatus, BoardStage, NotePriority } from '@dripnex/core';
+export type { NoteStatus, BoardStage, NotePriority };
 
 /** Note snapshot from the API */
 export interface NoteSnapshot {

--- a/apps/desktop/src/preload/api/types.ts
+++ b/apps/desktop/src/preload/api/types.ts
@@ -16,6 +16,9 @@ export type NoteStatus = 'active' | 'on_hold' | 'completed' | 'dropped';
 /** Kanban board stage for planning notes (null = not on the board) */
 export type BoardStage = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'in_staging';
 
+/** Linear-style priority for a note */
+export type NotePriority = 'none' | 'low' | 'medium' | 'high' | 'urgent';
+
 /** Note snapshot from the API */
 export interface NoteSnapshot {
   id: string;
@@ -32,6 +35,7 @@ export interface NoteSnapshot {
   isDeleted: boolean;
   status: NoteStatus;
   boardStage: BoardStage | null;
+  priority: NotePriority;
 }
 
 /** Notebook snapshot from the API */

--- a/apps/desktop/src/preload/api/types.ts
+++ b/apps/desktop/src/preload/api/types.ts
@@ -70,6 +70,7 @@ export interface ListOptions {
   limit?: number;
   offset?: number;
   tag?: string;
+  notebookId?: string;
   sortBy?: 'createdAt' | 'updatedAt' | 'title';
   sortOrder?: 'asc' | 'desc';
   archived?: 'active' | 'archived' | 'all';

--- a/apps/desktop/src/preload/api/types.ts
+++ b/apps/desktop/src/preload/api/types.ts
@@ -13,6 +13,9 @@ export type Result<T> =
 /** Note status for workflow tracking */
 export type NoteStatus = 'active' | 'on_hold' | 'completed' | 'dropped';
 
+/** Kanban board stage for planning notes (null = not on the board) */
+export type BoardStage = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'in_staging';
+
 /** Note snapshot from the API */
 export interface NoteSnapshot {
   id: string;
@@ -28,6 +31,7 @@ export interface NoteSnapshot {
   isPinned: boolean;
   isDeleted: boolean;
   status: NoteStatus;
+  boardStage: BoardStage | null;
 }
 
 /** Notebook snapshot from the API */

--- a/apps/desktop/src/preload/api/types.ts
+++ b/apps/desktop/src/preload/api/types.ts
@@ -36,6 +36,7 @@ export interface NoteSnapshot {
   status: NoteStatus;
   boardStage: BoardStage | null;
   priority: NotePriority;
+  boardOrder: number;
 }
 
 /** Notebook snapshot from the API */

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -65,6 +65,7 @@ import type {
 export type {
   Result,
   NoteStatus,
+  BoardStage,
   NoteSnapshot,
   NotebookSnapshot,
   NotebookWithMetadata,

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -66,6 +66,7 @@ export type {
   Result,
   NoteStatus,
   BoardStage,
+  NotePriority,
   NoteSnapshot,
   NotebookSnapshot,
   NotebookWithMetadata,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -592,6 +592,7 @@ function NotesApp() {
               {navigation.kind === 'planning' ? (
                 <PlanningBoard
                   onOpenNote={noteId => {
+                    setIsGraphOpen(false); // else the editor pane may render GraphView, not the note
                     goToNotebook(PLANNING_NOTEBOOK_ID);
                     void handleSelectNote(noteId);
                   }}

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import {
 import type { EditorAPIWithEvents, AppAPIWithEvents, DataAPIWithEvents } from '@dripnex/plugin-api';
 import type { RegisteredCommand } from '@dripnex/command-registry';
 import { useStore } from 'zustand';
+import { PLANNING_NOTEBOOK_ID } from '@dripnex/core';
 import type { NoteSnapshot } from '../preload/index';
 import { UpdateBanner } from './components/UpdateBanner';
 import { NoteList } from './components/NoteList';
@@ -21,6 +22,7 @@ import { NoteEditor } from './components/NoteEditor';
 import { NoteWindow } from './components/NoteWindow';
 import { Sidebar } from './components/sidebar';
 import { GraphView } from './components/GraphView';
+import { PlanningBoard } from './components/planning/PlanningBoard';
 import { CommandPalette } from './components/CommandPalette';
 import { AiPanel } from './components/ai/AiPanel';
 import { LicenseProvider } from './contexts/LicenseContext';
@@ -120,7 +122,7 @@ function NotesApp() {
   const selectedTag = useSelectedTag();
   const sortBy = useSortBy();
   const sortOrder = useSortOrder();
-  const { goToTag, setSort } = useNavigationActions();
+  const { goToTag, goToNotebook, setSort } = useNavigationActions();
 
   // Load tag colors on mount (once)
   useEffect(() => {
@@ -581,7 +583,14 @@ function NotesApp() {
             />
 
             <main className="app__editor">
-              {isGraphOpen ? (
+              {navigation.kind === 'planning' ? (
+                <PlanningBoard
+                  onOpenNote={noteId => {
+                    goToNotebook(PLANNING_NOTEBOOK_ID);
+                    void handleSelectNote(noteId);
+                  }}
+                />
+              ) : isGraphOpen ? (
                 <GraphView
                   selectedNoteId={selectedNote?.id}
                   onNodeClick={noteId => {

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -553,34 +553,40 @@ function NotesApp() {
               aria-orientation="vertical"
             />
 
-            <section className="app__notelist" style={{ width: notelistWidth }}>
-              <NoteList
-                notes={displayedNotes}
-                selectedId={selectedNote?.id ?? null}
-                selectedNotebookId={selectedNotebookId}
-                selectedTag={selectedTag}
-                selectedQuickFilter={selectedQuickFilter}
-                sortBy={sortBy}
-                sortOrder={sortOrder}
-                onSelect={handleSelectNote}
-                onDelete={handleDeleteNote}
-                onArchive={handleArchiveNote}
-                onDuplicate={handleDuplicateNote}
-                onPin={handlePinNote}
-                onMove={handleMoveNote}
-                onSearch={handleSearch}
-                onNewNote={handleNewNote}
-                onSortChange={setSort}
-                onTagClick={goToTag}
-                isLoading={isLoading}
-              />
-            </section>
-            <div
-              className="resize-handle"
-              onMouseDown={startResizeNotelist}
-              role="separator"
-              aria-orientation="vertical"
-            />
+            {/* The note list is redundant on the Planning board (the board owns
+                its own notes), so hide it there and let the board fill the pane. */}
+            {navigation.kind !== 'planning' && (
+              <>
+                <section className="app__notelist" style={{ width: notelistWidth }}>
+                  <NoteList
+                    notes={displayedNotes}
+                    selectedId={selectedNote?.id ?? null}
+                    selectedNotebookId={selectedNotebookId}
+                    selectedTag={selectedTag}
+                    selectedQuickFilter={selectedQuickFilter}
+                    sortBy={sortBy}
+                    sortOrder={sortOrder}
+                    onSelect={handleSelectNote}
+                    onDelete={handleDeleteNote}
+                    onArchive={handleArchiveNote}
+                    onDuplicate={handleDuplicateNote}
+                    onPin={handlePinNote}
+                    onMove={handleMoveNote}
+                    onSearch={handleSearch}
+                    onNewNote={handleNewNote}
+                    onSortChange={setSort}
+                    onTagClick={goToTag}
+                    isLoading={isLoading}
+                  />
+                </section>
+                <div
+                  className="resize-handle"
+                  onMouseDown={startResizeNotelist}
+                  role="separator"
+                  aria-orientation="vertical"
+                />
+              </>
+            )}
 
             <main className="app__editor">
               {navigation.kind === 'planning' ? (

--- a/apps/desktop/src/renderer/components/GraphView.tsx
+++ b/apps/desktop/src/renderer/components/GraphView.tsx
@@ -18,6 +18,8 @@ interface GraphViewProps {
   onNodeClick?: (noteId: string) => void;
   /** Callback to close the graph view */
   onClose?: () => void;
+  /** When set, restrict the graph to notes in this notebook (and links between them) */
+  filterNotebookId?: string;
 }
 
 interface GraphNode {
@@ -31,7 +33,12 @@ interface GraphNode {
   vy?: number;
 }
 
-export function GraphView({ selectedNoteId, onNodeClick, onClose }: GraphViewProps) {
+export function GraphView({
+  selectedNoteId,
+  onNodeClick,
+  onClose,
+  filterNotebookId,
+}: GraphViewProps) {
   const { data, isLoading, error } = useGraphData();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const graphRef = useRef<any>(null);
@@ -40,18 +47,28 @@ export function GraphView({ selectedNoteId, onNodeClick, onClose }: GraphViewPro
   const graphData = useMemo(() => {
     if (!data) return { nodes: [], links: [] };
 
+    // Optionally restrict to a single notebook (e.g. the Planning board),
+    // keeping only links whose endpoints both remain in the filtered set.
+    const nodes = filterNotebookId
+      ? data.nodes.filter(n => n.notebookId === filterNotebookId)
+      : data.nodes;
+    const includedIds = new Set(nodes.map(n => n.id));
+    const edges = filterNotebookId
+      ? data.edges.filter(e => includedIds.has(e.source) && includedIds.has(e.target))
+      : data.edges;
+
     return {
-      nodes: data.nodes.map(n => ({
+      nodes: nodes.map(n => ({
         id: n.id,
         title: n.title,
         notebookId: n.notebookId,
       })),
-      links: data.edges.map(e => ({
+      links: edges.map(e => ({
         source: e.source,
         target: e.target,
       })),
     };
-  }, [data]);
+  }, [data, filterNotebookId]);
 
   // Node color based on selection (using hex - CSS vars don't work in canvas)
   const getNodeColor = useCallback(

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -173,6 +173,15 @@
   border-color: var(--accent-muted);
 }
 
+/* Reorder drop indicators */
+.planning-card--drop-above {
+  box-shadow: inset 0 2px 0 0 var(--accent);
+}
+
+.planning-card--drop-below {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
+}
+
 .planning-card__top {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -1,0 +1,186 @@
+.planning-board {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-base);
+}
+
+.planning-board__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.planning-board__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.planning-board__toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+
+.planning-board__toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.planning-board__toggle-btn.is-active {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.planning-board__columns {
+  display: flex;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 16px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.planning-board__graph {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+}
+
+/* Columns */
+.planning-column {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 280px;
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.planning-column--over {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.planning-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.planning-column__title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.planning-column__count {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+
+.planning-column__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Cards */
+.planning-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  cursor: pointer;
+  user-select: none;
+}
+
+.planning-card:hover {
+  border-color: var(--accent-muted);
+}
+
+.planning-card__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.planning-card__excerpt {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.planning-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.planning-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+}
+
+.planning-card__tag {
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
+.planning-card__tasks {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -107,6 +107,45 @@
   padding: 1px 8px;
 }
 
+.planning-column__add {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.planning-column__add:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.planning-column__empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.planning-column__empty:hover {
+  border-color: var(--accent-muted);
+  color: var(--text-secondary);
+}
+
 .planning-column__cards {
   display: flex;
   flex-direction: column;
@@ -134,14 +173,111 @@
   border-color: var(--accent-muted);
 }
 
+.planning-card__top {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+}
+
 .planning-card__title {
   margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Actions menu */
+.planning-card__menu {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.planning-card__menu-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+}
+
+.planning-card:hover .planning-card__menu-trigger,
+.planning-card__menu-trigger[aria-expanded='true'] {
+  opacity: 1;
+}
+
+.planning-card__menu-trigger:hover {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.planning-card__menu-list,
+.planning-card__submenu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 4px);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  min-width: 168px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  box-shadow: var(--glass-shadow, 0 8px 24px rgba(0, 0, 0, 0.3));
+}
+
+.planning-card__submenu {
+  position: static;
+  min-width: 0;
+  margin: 2px 0 2px 12px;
+  box-shadow: none;
+  background: var(--bg-surface);
+}
+
+.planning-card__menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.planning-card__menu-item:hover {
+  background: var(--bg-surface);
+  color: var(--text-primary);
+}
+
+.planning-card__menu-item.is-current {
+  color: var(--text-primary);
+  justify-content: space-between;
+}
+
+.planning-card__menu-item--danger {
+  color: var(--error);
+}
+
+.planning-card__menu-item--danger:hover {
+  background: var(--error);
+  color: #fff;
 }
 
 .planning-card__excerpt {
@@ -171,11 +307,27 @@
 }
 
 .planning-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   font-size: 11px;
-  color: var(--accent);
-  background: var(--accent-subtle);
+  color: var(--text-secondary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
   border-radius: 4px;
   padding: 0 5px;
+}
+
+.planning-card__tag-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
+
+.planning-card__date {
+  font-size: 11px;
+  color: var(--text-faint);
 }
 
 .planning-card__tasks {

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -191,13 +191,13 @@
   color: var(--text-primary);
 }
 
-.planning-column__empty {
+.planning-column__add-card {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
   width: 100%;
-  padding: 10px;
+  padding: 8px 10px;
   border: 1px dashed var(--border);
   border-radius: 8px;
   background: transparent;
@@ -206,7 +206,7 @@
   cursor: pointer;
 }
 
-.planning-column__empty:hover {
+.planning-column__add-card:hover {
   border-color: var(--accent-muted);
   color: var(--text-secondary);
 }

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -175,8 +175,28 @@
 
 .planning-card__top {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 6px;
+}
+
+.planning-card__priority {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+.planning-card__menu-swatch-wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.planning-card__menu-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex: 0 0 auto;
 }
 
 .planning-card__title {

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -50,6 +50,71 @@
   color: var(--text-primary);
 }
 
+.planning-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.planning-toolbar__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 0 1 260px;
+}
+
+.planning-toolbar__search-icon {
+  position: absolute;
+  left: 8px;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.planning-toolbar__input {
+  width: 100%;
+  padding: 5px 8px 5px 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.planning-toolbar__input::placeholder {
+  color: var(--text-faint);
+}
+
+.planning-toolbar__select {
+  padding: 5px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.planning-toolbar__clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.planning-toolbar__clear:hover {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
 .planning-board__columns {
   display: flex;
   gap: 12px;

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+import { KanbanSquare, Network } from 'lucide-react';
+import { BOARD_STAGES, PLANNING_NOTEBOOK_ID } from '@dripnex/core';
+import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import { useNotes, useNoteMutations } from '../../hooks/useNotes';
+import { GraphView } from '../GraphView';
+import { PlanningColumn } from './PlanningColumn';
+import './PlanningBoard.css';
+
+interface PlanningBoardProps {
+  /** Open a note in the editor (leaves the board). */
+  readonly onOpenNote: (id: string) => void;
+}
+
+type ViewMode = 'board' | 'graph';
+
+/**
+ * The Planning view: a Linear-style Kanban board over the notes in the
+ * reserved Planning notebook, plus a graph mode that reuses GraphView filtered
+ * to those same notes. Dragging a card persists its stage via boardStage
+ * (DB metadata only — never rewrites the note's markdown).
+ */
+export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
+  const [mode, setMode] = useState<ViewMode>('board');
+  const { data: allNotes } = useNotes({
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    archived: 'active',
+  });
+  const { setBoardStage } = useNoteMutations();
+
+  const planningNotes = useMemo(
+    () =>
+      (allNotes ?? []).filter(
+        n => n.notebookId === PLANNING_NOTEBOOK_ID && !n.isDeleted && !n.isArchived
+      ),
+    [allNotes]
+  );
+
+  const notesByStage = useMemo(() => {
+    const groups: Record<BoardStage, NoteSnapshot[]> = {
+      backlog: [],
+      todo: [],
+      in_progress: [],
+      in_review: [],
+      in_staging: [],
+    };
+    for (const note of planningNotes) {
+      // Notes with no explicit stage (e.g. moved into the notebook) land in Backlog.
+      const stage = note.boardStage ?? 'backlog';
+      groups[stage].push(note);
+    }
+    return groups;
+  }, [planningNotes]);
+
+  const handleDropNote = (noteId: string, stage: BoardStage) => {
+    setBoardStage.mutate({ id: noteId, boardStage: stage });
+  };
+
+  return (
+    <div className="planning-board">
+      <header className="planning-board__header">
+        <h2 className="planning-board__title">Planning</h2>
+        <div className="planning-board__toggle" role="tablist" aria-label="Planning view mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'board'}
+            className={`planning-board__toggle-btn ${mode === 'board' ? 'is-active' : ''}`}
+            onClick={() => setMode('board')}
+          >
+            <KanbanSquare size={14} /> Board
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'graph'}
+            className={`planning-board__toggle-btn ${mode === 'graph' ? 'is-active' : ''}`}
+            onClick={() => setMode('graph')}
+          >
+            <Network size={14} /> Graph
+          </button>
+        </div>
+      </header>
+
+      {mode === 'board' ? (
+        <div className="planning-board__columns">
+          {BOARD_STAGES.map(stage => (
+            <PlanningColumn
+              key={stage}
+              stage={stage}
+              notes={notesByStage[stage]}
+              onDropNote={handleDropNote}
+              onOpenNote={onOpenNote}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="planning-board__graph">
+          <GraphView filterNotebookId={PLANNING_NOTEBOOK_ID} onNodeClick={onOpenNote} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -27,7 +27,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     sortOrder: 'desc',
     archived: 'active',
   });
-  const { setBoardStage } = useNoteMutations();
+  const { setBoardStage, createNote, softDeleteNote } = useNoteMutations();
 
   const planningNotes = useMemo(
     () =>
@@ -55,6 +55,27 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
 
   const handleDropNote = (noteId: string, stage: BoardStage) => {
     setBoardStage.mutate({ id: noteId, boardStage: stage });
+  };
+
+  const handleRemoveFromBoard = (noteId: string) => {
+    setBoardStage.mutate({ id: noteId, boardStage: null });
+  };
+
+  const handleDeleteNote = (noteId: string) => {
+    softDeleteNote.mutate(noteId);
+  };
+
+  const handleAddCard = async (stage: BoardStage) => {
+    // Create an empty note in the Planning notebook (defaults to Backlog), move
+    // it to the requested column, then open it so the user can start typing.
+    const created = await createNote.mutateAsync({
+      content: '',
+      notebookId: PLANNING_NOTEBOOK_ID,
+    });
+    if (stage !== 'backlog') {
+      await setBoardStage.mutateAsync({ id: created.id, boardStage: stage });
+    }
+    onOpenNote(created.id);
   };
 
   return (
@@ -91,7 +112,11 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
               stage={stage}
               notes={notesByStage[stage]}
               onDropNote={handleDropNote}
+              onAddCard={handleAddCard}
               onOpenNote={onOpenNote}
+              onMoveStage={handleDropNote}
+              onRemoveFromBoard={handleRemoveFromBoard}
+              onDeleteNote={handleDeleteNote}
             />
           ))}
         </div>

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -52,7 +52,11 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
   const [search, setSearch] = useState('');
   const [tagFilter, setTagFilter] = useState<string | null>(null);
   const [priorityFilter, setPriorityFilter] = useState<NotePriority | null>(null);
+  // Scope the query to the Planning notebook in SQL, with no artificial cap, so
+  // the board never silently drops aged/high-count cards (repo default is 50).
   const { data: allNotes } = useNotes({
+    notebookId: PLANNING_NOTEBOOK_ID,
+    limit: 100000,
     sortBy: 'updatedAt',
     sortOrder: 'desc',
     archived: 'active',

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -87,7 +87,8 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     // Within each column, order by boardOrder, then newest-first as a tiebreak.
     for (const stage of Object.keys(groups) as BoardStage[]) {
       groups[stage].sort(
-        (a, b) => a.boardOrder - b.boardOrder || b.createdAt.localeCompare(a.createdAt)
+        (a, b) =>
+          (a.boardOrder ?? 0) - (b.boardOrder ?? 0) || b.createdAt.localeCompare(a.createdAt)
       );
     }
     return groups;

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -27,7 +27,8 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     sortOrder: 'desc',
     archived: 'active',
   });
-  const { setBoardStage, setPriority, createNote, softDeleteNote } = useNoteMutations();
+  const { setBoardStage, setPriority, reorderColumn, createNote, softDeleteNote } =
+    useNoteMutations();
 
   const planningNotes = useMemo(
     () =>
@@ -50,11 +51,34 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
       const stage = note.boardStage ?? 'backlog';
       groups[stage].push(note);
     }
+    // Within each column, order by boardOrder, then newest-first as a tiebreak.
+    for (const stage of Object.keys(groups) as BoardStage[]) {
+      groups[stage].sort(
+        (a, b) => a.boardOrder - b.boardOrder || b.createdAt.localeCompare(a.createdAt)
+      );
+    }
     return groups;
   }, [planningNotes]);
 
-  const handleDropNote = (noteId: string, stage: BoardStage) => {
-    setBoardStage.mutate({ id: noteId, boardStage: stage });
+  const handleReorder = (
+    draggedId: string,
+    stage: BoardStage,
+    targetId: string | null,
+    side: 'above' | 'below' | 'append'
+  ) => {
+    const ids = notesByStage[stage].map(n => n.id).filter(id => id !== draggedId);
+    let insertAt = ids.length;
+    if (targetId !== null) {
+      const ti = ids.indexOf(targetId);
+      if (ti !== -1) insertAt = side === 'below' ? ti + 1 : ti;
+    }
+    ids.splice(insertAt, 0, draggedId);
+    reorderColumn.mutate({ stage, orderedIds: ids });
+  };
+
+  // Menu "Move to <stage>": append to the end of the target column.
+  const handleMoveStage = (noteId: string, stage: BoardStage) => {
+    handleReorder(noteId, stage, null, 'append');
   };
 
   const handleSetPriority = (noteId: string, priority: NotePriority) => {
@@ -115,10 +139,10 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
               key={stage}
               stage={stage}
               notes={notesByStage[stage]}
-              onDropNote={handleDropNote}
+              onReorder={handleReorder}
               onAddCard={handleAddCard}
               onOpenNote={onOpenNote}
-              onMoveStage={handleDropNote}
+              onMoveStage={handleMoveStage}
               onSetPriority={handleSetPriority}
               onRemoveFromBoard={handleRemoveFromBoard}
               onDeleteNote={handleDeleteNote}

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -4,6 +4,7 @@ import { BOARD_STAGES, PLANNING_NOTEBOOK_ID, INBOX_NOTEBOOK_ID } from '@dripnex/
 import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { useNotes, useNoteMutations } from '../../hooks/useNotes';
 import { GraphView } from '../GraphView';
+import { toast } from '../../ui/primitives';
 import { PlanningColumn } from './PlanningColumn';
 import { PlanningToolbar } from './PlanningToolbar';
 import { computeReorderedIds } from './reorder';
@@ -129,12 +130,18 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     setPriority.mutate({ id: noteId, priority });
   };
 
-  const handleRemoveFromBoard = (noteId: string) => {
+  const handleRemoveFromBoard = async (noteId: string) => {
     // Board membership is notebook-based, so removing = moving the note out of
     // the Planning notebook (nulling the stage alone would just re-group it into
-    // Backlog). Also clear the stage so it isn't stale if moved back later.
-    setBoardStage.mutate({ id: noteId, boardStage: null });
-    moveNote.mutate({ noteId, notebookId: INBOX_NOTEBOOK_ID });
+    // Backlog). Sequence the two writes: move first (the authoritative removal),
+    // then clear the now-irrelevant stage, so a failure can't leave the note
+    // both cleared and still on the board.
+    try {
+      await moveNote.mutateAsync({ noteId, notebookId: INBOX_NOTEBOOK_ID });
+      await setBoardStage.mutateAsync({ id: noteId, boardStage: null });
+    } catch {
+      toast.error('Could not remove the card from the board');
+    }
   };
 
   const handleDeleteNote = (noteId: string) => {
@@ -144,14 +151,20 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
   const handleAddCard = async (stage: BoardStage) => {
     // Create an empty note in the Planning notebook (defaults to Backlog), move
     // it to the requested column, then open it so the user can start typing.
-    const created = await createNote.mutateAsync({
-      content: '',
-      notebookId: PLANNING_NOTEBOOK_ID,
-    });
-    if (stage !== 'backlog') {
-      await setBoardStage.mutateAsync({ id: created.id, boardStage: stage });
+    // Errors are handled here so the async call sites (column "+" buttons) stay
+    // safe fire-and-forget without leaking unhandled rejections.
+    try {
+      const created = await createNote.mutateAsync({
+        content: '',
+        notebookId: PLANNING_NOTEBOOK_ID,
+      });
+      if (stage !== 'backlog') {
+        await setBoardStage.mutateAsync({ id: created.id, boardStage: stage });
+      }
+      onOpenNote(created.id);
+    } catch {
+      toast.error('Could not add a card');
     }
-    onOpenNote(created.id);
   };
 
   return (

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { KanbanSquare, Network } from 'lucide-react';
 import { BOARD_STAGES, PLANNING_NOTEBOOK_ID } from '@dripnex/core';
-import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { useNotes, useNoteMutations } from '../../hooks/useNotes';
 import { GraphView } from '../GraphView';
 import { PlanningColumn } from './PlanningColumn';
@@ -27,7 +27,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     sortOrder: 'desc',
     archived: 'active',
   });
-  const { setBoardStage, createNote, softDeleteNote } = useNoteMutations();
+  const { setBoardStage, setPriority, createNote, softDeleteNote } = useNoteMutations();
 
   const planningNotes = useMemo(
     () =>
@@ -55,6 +55,10 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
 
   const handleDropNote = (noteId: string, stage: BoardStage) => {
     setBoardStage.mutate({ id: noteId, boardStage: stage });
+  };
+
+  const handleSetPriority = (noteId: string, priority: NotePriority) => {
+    setPriority.mutate({ id: noteId, priority });
   };
 
   const handleRemoveFromBoard = (noteId: string) => {
@@ -115,6 +119,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
               onAddCard={handleAddCard}
               onOpenNote={onOpenNote}
               onMoveStage={handleDropNote}
+              onSetPriority={handleSetPriority}
               onRemoveFromBoard={handleRemoveFromBoard}
               onDeleteNote={handleDeleteNote}
             />

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -1,12 +1,38 @@
 import { useMemo, useState } from 'react';
 import { KanbanSquare, Network } from 'lucide-react';
-import { BOARD_STAGES, PLANNING_NOTEBOOK_ID } from '@dripnex/core';
+import { BOARD_STAGES, PLANNING_NOTEBOOK_ID, INBOX_NOTEBOOK_ID } from '@dripnex/core';
 import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { useNotes, useNoteMutations } from '../../hooks/useNotes';
 import { GraphView } from '../GraphView';
 import { PlanningColumn } from './PlanningColumn';
 import { PlanningToolbar } from './PlanningToolbar';
+import { computeReorderedIds } from './reorder';
 import './PlanningBoard.css';
+
+/** Group notes into board columns (by stage) and sort each column. */
+function groupByStage(notes: readonly NoteSnapshot[]): Record<BoardStage, NoteSnapshot[]> {
+  const groups: Record<BoardStage, NoteSnapshot[]> = {
+    backlog: [],
+    todo: [],
+    in_progress: [],
+    in_review: [],
+    in_staging: [],
+  };
+  for (const note of notes) {
+    // Notes with no/unknown stage (legacy value, moved-in note) land in Backlog.
+    const raw = note.boardStage ?? 'backlog';
+    const stage: BoardStage = (BOARD_STAGES as readonly string[]).includes(raw)
+      ? (raw as BoardStage)
+      : 'backlog';
+    groups[stage].push(note);
+  }
+  for (const stage of BOARD_STAGES) {
+    groups[stage].sort(
+      (a, b) => (a.boardOrder ?? 0) - (b.boardOrder ?? 0) || b.createdAt.localeCompare(a.createdAt)
+    );
+  }
+  return groups;
+}
 
 interface PlanningBoardProps {
   /** Open a note in the editor (leaves the board). */
@@ -31,7 +57,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     sortOrder: 'desc',
     archived: 'active',
   });
-  const { setBoardStage, setPriority, reorderColumn, createNote, softDeleteNote } =
+  const { setBoardStage, setPriority, reorderColumn, createNote, softDeleteNote, moveNote } =
     useNoteMutations();
 
   const planningNotes = useMemo(
@@ -41,6 +67,10 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
       ),
     [allNotes]
   );
+
+  // Full (unfiltered) grouping — used so reordering keeps every card's order
+  // contiguous even when a search/tag/priority filter is hiding some cards.
+  const unfilteredByStage = useMemo(() => groupByStage(planningNotes), [planningNotes]);
 
   // Tags present across the board, for the filter dropdown.
   const availableTags = useMemo(() => {
@@ -71,28 +101,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     });
   }, [planningNotes, search, tagFilter, priorityFilter]);
 
-  const notesByStage = useMemo(() => {
-    const groups: Record<BoardStage, NoteSnapshot[]> = {
-      backlog: [],
-      todo: [],
-      in_progress: [],
-      in_review: [],
-      in_staging: [],
-    };
-    for (const note of filteredNotes) {
-      // Notes with no explicit stage (e.g. moved into the notebook) land in Backlog.
-      const stage = note.boardStage ?? 'backlog';
-      groups[stage].push(note);
-    }
-    // Within each column, order by boardOrder, then newest-first as a tiebreak.
-    for (const stage of Object.keys(groups) as BoardStage[]) {
-      groups[stage].sort(
-        (a, b) =>
-          (a.boardOrder ?? 0) - (b.boardOrder ?? 0) || b.createdAt.localeCompare(a.createdAt)
-      );
-    }
-    return groups;
-  }, [filteredNotes]);
+  const notesByStage = useMemo(() => groupByStage(filteredNotes), [filteredNotes]);
 
   const handleReorder = (
     draggedId: string,
@@ -100,14 +109,11 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     targetId: string | null,
     side: 'above' | 'below' | 'append'
   ) => {
-    const ids = notesByStage[stage].map(n => n.id).filter(id => id !== draggedId);
-    let insertAt = ids.length;
-    if (targetId !== null) {
-      const ti = ids.indexOf(targetId);
-      if (ti !== -1) insertAt = side === 'below' ? ti + 1 : ti;
-    }
-    ids.splice(insertAt, 0, draggedId);
-    reorderColumn.mutate({ stage, orderedIds: ids });
+    // Reindex over the FULL column (not the filtered view) so cards hidden by an
+    // active filter keep contiguous board_order values.
+    const fullIds = unfilteredByStage[stage].map(n => n.id);
+    const orderedIds = computeReorderedIds(fullIds, draggedId, targetId, side);
+    reorderColumn.mutate({ stage, orderedIds });
   };
 
   // Menu "Move to <stage>": append to the end of the target column.
@@ -120,7 +126,11 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
   };
 
   const handleRemoveFromBoard = (noteId: string) => {
+    // Board membership is notebook-based, so removing = moving the note out of
+    // the Planning notebook (nulling the stage alone would just re-group it into
+    // Backlog). Also clear the stage so it isn't stale if moved back later.
     setBoardStage.mutate({ id: noteId, boardStage: null });
+    moveNote.mutate({ noteId, notebookId: INBOX_NOTEBOOK_ID });
   };
 
   const handleDeleteNote = (noteId: string) => {

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -5,6 +5,7 @@ import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/in
 import { useNotes, useNoteMutations } from '../../hooks/useNotes';
 import { GraphView } from '../GraphView';
 import { PlanningColumn } from './PlanningColumn';
+import { PlanningToolbar } from './PlanningToolbar';
 import './PlanningBoard.css';
 
 interface PlanningBoardProps {
@@ -22,6 +23,9 @@ type ViewMode = 'board' | 'graph';
  */
 export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
   const [mode, setMode] = useState<ViewMode>('board');
+  const [search, setSearch] = useState('');
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [priorityFilter, setPriorityFilter] = useState<NotePriority | null>(null);
   const { data: allNotes } = useNotes({
     sortBy: 'updatedAt',
     sortOrder: 'desc',
@@ -38,6 +42,35 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
     [allNotes]
   );
 
+  // Tags present across the board, for the filter dropdown.
+  const availableTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const n of planningNotes) for (const t of n.tags) set.add(t);
+    return [...set].sort();
+  }, [planningNotes]);
+
+  const isFiltering = search.trim() !== '' || tagFilter !== null || priorityFilter !== null;
+
+  const clearFilters = () => {
+    setSearch('');
+    setTagFilter(null);
+    setPriorityFilter(null);
+  };
+
+  // Apply search + tag + priority filters before grouping into columns.
+  const filteredNotes = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return planningNotes.filter(n => {
+      if (priorityFilter && n.priority !== priorityFilter) return false;
+      if (tagFilter && !n.tags.includes(tagFilter)) return false;
+      if (q) {
+        const haystack = `${n.title}\n${n.content}\n${n.tags.join(' ')}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [planningNotes, search, tagFilter, priorityFilter]);
+
   const notesByStage = useMemo(() => {
     const groups: Record<BoardStage, NoteSnapshot[]> = {
       backlog: [],
@@ -46,7 +79,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
       in_review: [],
       in_staging: [],
     };
-    for (const note of planningNotes) {
+    for (const note of filteredNotes) {
       // Notes with no explicit stage (e.g. moved into the notebook) land in Backlog.
       const stage = note.boardStage ?? 'backlog';
       groups[stage].push(note);
@@ -58,7 +91,7 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
       );
     }
     return groups;
-  }, [planningNotes]);
+  }, [filteredNotes]);
 
   const handleReorder = (
     draggedId: string,
@@ -131,6 +164,20 @@ export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
           </button>
         </div>
       </header>
+
+      {mode === 'board' && (
+        <PlanningToolbar
+          search={search}
+          onSearch={setSearch}
+          tag={tagFilter}
+          onTag={setTagFilter}
+          priority={priorityFilter}
+          onPriority={setPriorityFilter}
+          tags={availableTags}
+          isFiltering={isFiltering}
+          onClear={clearFilters}
+        />
+      )}
 
       {mode === 'board' ? (
         <div className="planning-board__columns">

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -1,19 +1,38 @@
 import { memo, useCallback } from 'react';
 import { countMarkdownTasks } from '@dripnex/tasks';
-import type { NoteSnapshot } from '../../../preload/index';
+import type { NoteSnapshot, BoardStage } from '../../../preload/index';
 import { extractExcerpt } from '../../hooks/useNotes';
+import { useTagColorsStore } from '../../stores/tagColorsStore';
 import { NOTE_MIME } from './constants';
+import { PlanningCardMenu } from './PlanningCardMenu';
 
 interface PlanningCardProps {
   readonly note: NoteSnapshot;
   readonly onOpen: (id: string) => void;
+  readonly onMoveStage: (id: string, stage: BoardStage) => void;
+  readonly onRemoveFromBoard: (id: string) => void;
+  readonly onDelete: (id: string) => void;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
 /**
  * A draggable card on the Planning board. Dragging carries the note id via a
  * custom MIME type; dropping on a column updates the note's boardStage.
  */
-export const PlanningCard = memo(function PlanningCard({ note, onOpen }: PlanningCardProps) {
+export const PlanningCard = memo(function PlanningCard({
+  note,
+  onOpen,
+  onMoveStage,
+  onRemoveFromBoard,
+  onDelete,
+}: PlanningCardProps) {
+  const getColor = useTagColorsStore(state => state.getColor);
+
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
       e.dataTransfer.setData(NOTE_MIME, note.id);
@@ -25,6 +44,7 @@ export const PlanningCard = memo(function PlanningCard({ note, onOpen }: Plannin
 
   const tasks = countMarkdownTasks(note.content);
   const excerpt = extractExcerpt(note.content, 120);
+  const currentStage: BoardStage = note.boardStage ?? 'backlog';
 
   return (
     <article
@@ -38,26 +58,45 @@ export const PlanningCard = memo(function PlanningCard({ note, onOpen }: Plannin
       role="button"
       tabIndex={0}
     >
-      <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
+      <div className="planning-card__top">
+        <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
+        <PlanningCardMenu
+          currentStage={currentStage}
+          onOpen={() => onOpen(note.id)}
+          onMoveStage={stage => onMoveStage(note.id, stage)}
+          onRemoveFromBoard={() => onRemoveFromBoard(note.id)}
+          onDelete={() => onDelete(note.id)}
+        />
+      </div>
+
       {excerpt && <p className="planning-card__excerpt">{excerpt}</p>}
-      {(note.tags.length > 0 || tasks.total > 0) && (
-        <div className="planning-card__footer">
-          {note.tags.length > 0 && (
-            <div className="planning-card__tags">
-              {note.tags.slice(0, 3).map(tag => (
-                <span key={tag} className="planning-card__tag">
-                  #{tag}
-                </span>
-              ))}
-            </div>
-          )}
-          {tasks.total > 0 && (
-            <span className="planning-card__tasks" title="Task progress">
-              {tasks.completed}/{tasks.total}
-            </span>
-          )}
+
+      {note.tags.length > 0 && (
+        <div className="planning-card__tags">
+          {note.tags.slice(0, 4).map(tag => {
+            const color = getColor(tag);
+            return (
+              <span key={tag} className="planning-card__tag">
+                <span
+                  className="planning-card__tag-dot"
+                  style={{ backgroundColor: color ?? 'var(--text-faint)' }}
+                  aria-hidden="true"
+                />
+                {tag}
+              </span>
+            );
+          })}
         </div>
       )}
+
+      <div className="planning-card__footer">
+        <span className="planning-card__date">{formatDate(note.createdAt)}</span>
+        {tasks.total > 0 && (
+          <span className="planning-card__tasks" title="Task progress">
+            {tasks.completed}/{tasks.total}
+          </span>
+        )}
+      </div>
     </article>
   );
 });

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -99,7 +99,12 @@ export const PlanningCard = memo(function PlanningCard({
       // the menu button doesn't also open the note.
       onClick={() => onOpen(note.id)}
       onKeyDown={e => {
-        if (e.key === 'Enter' && e.target === e.currentTarget) onOpen(note.id);
+        // Enter/Space open the card, but only when the card itself is focused
+        // (not a nested control like the menu button).
+        if ((e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget) {
+          e.preventDefault();
+          onOpen(note.id);
+        }
       }}
       tabIndex={0}
       aria-label={`Open note: ${note.title || 'Untitled'}`}
@@ -119,7 +124,7 @@ export const PlanningCard = memo(function PlanningCard({
           currentPriority={priority}
           onOpen={() => onOpen(note.id)}
           onMoveStage={stage => onMoveStage(note.id, stage)}
-          onSetPriority={priority => onSetPriority(note.id, priority)}
+          onSetPriority={p => onSetPriority(note.id, p)}
           onRemoveFromBoard={() => onRemoveFromBoard(note.id)}
           onDelete={() => onDelete(note.id)}
         />

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -93,12 +93,16 @@ export const PlanningCard = memo(function PlanningCard({
       onDragOver={handleDragOver}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
+      // No role="button": the card contains interactive controls (the menu),
+      // which is invalid inside a button. Mouse clicks are safe because the menu
+      // stops propagation; Enter is gated to the card itself so pressing Enter on
+      // the menu button doesn't also open the note.
       onClick={() => onOpen(note.id)}
       onKeyDown={e => {
-        if (e.key === 'Enter') onOpen(note.id);
+        if (e.key === 'Enter' && e.target === e.currentTarget) onOpen(note.id);
       }}
-      role="button"
       tabIndex={0}
+      aria-label={`Open note: ${note.title || 'Untitled'}`}
     >
       <div className="planning-card__top">
         {priority !== 'none' && (

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -79,6 +79,10 @@ export const PlanningCard = memo(function PlanningCard({
   const tasks = countMarkdownTasks(note.content);
   const excerpt = extractExcerpt(note.content, 120);
   const currentStage: BoardStage = note.boardStage ?? 'backlog';
+  // Be resilient to snapshots missing/with unknown priority (e.g. a stale main
+  // process during dev HMR, or notes synced before the field existed).
+  const priority: NotePriority = note.priority ?? 'none';
+  const priorityConfig = PRIORITY_CONFIG[priority] ?? PRIORITY_CONFIG.none;
   const dropClass = dropSide ? `planning-card--drop-${dropSide}` : '';
 
   return (
@@ -97,18 +101,18 @@ export const PlanningCard = memo(function PlanningCard({
       tabIndex={0}
     >
       <div className="planning-card__top">
-        {note.priority !== 'none' && (
+        {priority !== 'none' && (
           <span
             className="planning-card__priority"
-            style={{ backgroundColor: PRIORITY_CONFIG[note.priority].color }}
-            title={`Priority: ${PRIORITY_CONFIG[note.priority].label}`}
-            aria-label={`Priority: ${PRIORITY_CONFIG[note.priority].label}`}
+            style={{ backgroundColor: priorityConfig.color }}
+            title={`Priority: ${priorityConfig.label}`}
+            aria-label={`Priority: ${priorityConfig.label}`}
           />
         )}
         <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
         <PlanningCardMenu
           currentStage={currentStage}
-          currentPriority={note.priority}
+          currentPriority={priority}
           onOpen={() => onOpen(note.id)}
           onMoveStage={stage => onMoveStage(note.id, stage)}
           onSetPriority={priority => onSetPriority(note.id, priority)}

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -1,15 +1,16 @@
 import { memo, useCallback } from 'react';
 import { countMarkdownTasks } from '@dripnex/tasks';
-import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { extractExcerpt } from '../../hooks/useNotes';
 import { useTagColorsStore } from '../../stores/tagColorsStore';
-import { NOTE_MIME } from './constants';
+import { NOTE_MIME, PRIORITY_CONFIG } from './constants';
 import { PlanningCardMenu } from './PlanningCardMenu';
 
 interface PlanningCardProps {
   readonly note: NoteSnapshot;
   readonly onOpen: (id: string) => void;
   readonly onMoveStage: (id: string, stage: BoardStage) => void;
+  readonly onSetPriority: (id: string, priority: NotePriority) => void;
   readonly onRemoveFromBoard: (id: string) => void;
   readonly onDelete: (id: string) => void;
 }
@@ -28,6 +29,7 @@ export const PlanningCard = memo(function PlanningCard({
   note,
   onOpen,
   onMoveStage,
+  onSetPriority,
   onRemoveFromBoard,
   onDelete,
 }: PlanningCardProps) {
@@ -59,11 +61,21 @@ export const PlanningCard = memo(function PlanningCard({
       tabIndex={0}
     >
       <div className="planning-card__top">
+        {note.priority !== 'none' && (
+          <span
+            className="planning-card__priority"
+            style={{ backgroundColor: PRIORITY_CONFIG[note.priority].color }}
+            title={`Priority: ${PRIORITY_CONFIG[note.priority].label}`}
+            aria-label={`Priority: ${PRIORITY_CONFIG[note.priority].label}`}
+          />
+        )}
         <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
         <PlanningCardMenu
           currentStage={currentStage}
+          currentPriority={note.priority}
           onOpen={() => onOpen(note.id)}
           onMoveStage={stage => onMoveStage(note.id, stage)}
+          onSetPriority={priority => onSetPriority(note.id, priority)}
           onRemoveFromBoard={() => onRemoveFromBoard(note.id)}
           onDelete={() => onDelete(note.id)}
         />

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -1,0 +1,63 @@
+import { memo, useCallback } from 'react';
+import { countMarkdownTasks } from '@dripnex/tasks';
+import type { NoteSnapshot } from '../../../preload/index';
+import { extractExcerpt } from '../../hooks/useNotes';
+import { NOTE_MIME } from './constants';
+
+interface PlanningCardProps {
+  readonly note: NoteSnapshot;
+  readonly onOpen: (id: string) => void;
+}
+
+/**
+ * A draggable card on the Planning board. Dragging carries the note id via a
+ * custom MIME type; dropping on a column updates the note's boardStage.
+ */
+export const PlanningCard = memo(function PlanningCard({ note, onOpen }: PlanningCardProps) {
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.setData(NOTE_MIME, note.id);
+      e.dataTransfer.setData('text/plain', note.id);
+      e.dataTransfer.effectAllowed = 'move';
+    },
+    [note.id]
+  );
+
+  const tasks = countMarkdownTasks(note.content);
+  const excerpt = extractExcerpt(note.content, 120);
+
+  return (
+    <article
+      className="planning-card"
+      draggable
+      onDragStart={handleDragStart}
+      onClick={() => onOpen(note.id)}
+      onKeyDown={e => {
+        if (e.key === 'Enter') onOpen(note.id);
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
+      {excerpt && <p className="planning-card__excerpt">{excerpt}</p>}
+      {(note.tags.length > 0 || tasks.total > 0) && (
+        <div className="planning-card__footer">
+          {note.tags.length > 0 && (
+            <div className="planning-card__tags">
+              {note.tags.slice(0, 3).map(tag => (
+                <span key={tag} className="planning-card__tag">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+          {tasks.total > 0 && (
+            <span className="planning-card__tasks" title="Task progress">
+              {tasks.completed}/{tasks.total}
+            </span>
+          )}
+        </div>
+      )}
+    </article>
+  );
+});

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -1,10 +1,12 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { countMarkdownTasks } from '@dripnex/tasks';
 import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { extractExcerpt } from '../../hooks/useNotes';
 import { useTagColorsStore } from '../../stores/tagColorsStore';
 import { NOTE_MIME, PRIORITY_CONFIG } from './constants';
 import { PlanningCardMenu } from './PlanningCardMenu';
+
+type DropSide = 'above' | 'below';
 
 interface PlanningCardProps {
   readonly note: NoteSnapshot;
@@ -13,6 +15,8 @@ interface PlanningCardProps {
   readonly onSetPriority: (id: string, priority: NotePriority) => void;
   readonly onRemoveFromBoard: (id: string) => void;
   readonly onDelete: (id: string) => void;
+  /** Reorder: drop `draggedId` above/below this card. */
+  readonly onDropCard: (draggedId: string, targetId: string, side: DropSide) => void;
 }
 
 function formatDate(iso: string): string {
@@ -22,8 +26,9 @@ function formatDate(iso: string): string {
 }
 
 /**
- * A draggable card on the Planning board. Dragging carries the note id via a
- * custom MIME type; dropping on a column updates the note's boardStage.
+ * A draggable card on the Planning board. It is also a drop target so cards can
+ * be reordered within a column (drop above/below the hovered card). Dragging
+ * carries the note id via a custom MIME type.
  */
 export const PlanningCard = memo(function PlanningCard({
   note,
@@ -32,8 +37,10 @@ export const PlanningCard = memo(function PlanningCard({
   onSetPriority,
   onRemoveFromBoard,
   onDelete,
+  onDropCard,
 }: PlanningCardProps) {
   const getColor = useTagColorsStore(state => state.getColor);
+  const [dropSide, setDropSide] = useState<DropSide | null>(null);
 
   const handleDragStart = useCallback(
     (e: React.DragEvent) => {
@@ -44,15 +51,44 @@ export const PlanningCard = memo(function PlanningCard({
     [note.id]
   );
 
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLElement>) => {
+    // Take over from the column so the drop lands at this precise position.
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'move';
+    const rect = e.currentTarget.getBoundingClientRect();
+    setDropSide(e.clientY < rect.top + rect.height / 2 ? 'above' : 'below');
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setDropSide(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const side = dropSide ?? 'above';
+      setDropSide(null);
+      const draggedId = e.dataTransfer.getData(NOTE_MIME);
+      if (draggedId && draggedId !== note.id) onDropCard(draggedId, note.id, side);
+    },
+    [dropSide, note.id, onDropCard]
+  );
+
   const tasks = countMarkdownTasks(note.content);
   const excerpt = extractExcerpt(note.content, 120);
   const currentStage: BoardStage = note.boardStage ?? 'backlog';
+  const dropClass = dropSide ? `planning-card--drop-${dropSide}` : '';
 
   return (
     <article
-      className="planning-card"
+      className={`planning-card ${dropClass}`}
       draggable
       onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
       onClick={() => onOpen(note.id)}
       onKeyDown={e => {
         if (e.key === 'Enter') onOpen(note.id);

--- a/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
@@ -1,0 +1,137 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  MoreHorizontal,
+  SquareArrowOutUpRight,
+  ArrowRightLeft,
+  EyeOff,
+  Trash2,
+  Check,
+} from 'lucide-react';
+import { BOARD_STAGES } from '@dripnex/core';
+import type { BoardStage } from '../../../preload/index';
+import { BOARD_STAGE_LABELS } from './constants';
+
+interface PlanningCardMenuProps {
+  readonly currentStage: BoardStage;
+  readonly onOpen: () => void;
+  readonly onMoveStage: (stage: BoardStage) => void;
+  readonly onRemoveFromBoard: () => void;
+  readonly onDelete: () => void;
+}
+
+/** The "…" actions menu on a Planning card. */
+export function PlanningCardMenu({
+  currentStage,
+  onOpen,
+  onMoveStage,
+  onRemoveFromBoard,
+  onDelete,
+}: PlanningCardMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showMove, setShowMove] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsOpen(false);
+        setShowMove(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isOpen]);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setShowMove(false);
+  }, []);
+
+  // Stop clicks from bubbling to the card (which would open the note or start a drag).
+  const stop = useCallback((e: React.MouseEvent) => e.stopPropagation(), []);
+
+  return (
+    <div className="planning-card__menu" ref={containerRef} onClick={stop}>
+      <button
+        type="button"
+        className="planning-card__menu-trigger"
+        onClick={() => setIsOpen(o => !o)}
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+        aria-label="Card actions"
+      >
+        <MoreHorizontal size={14} />
+      </button>
+
+      {isOpen && (
+        <div className="planning-card__menu-list" role="menu">
+          <button
+            type="button"
+            role="menuitem"
+            className="planning-card__menu-item"
+            onClick={() => {
+              onOpen();
+              close();
+            }}
+          >
+            <SquareArrowOutUpRight size={13} /> Open
+          </button>
+
+          <button
+            type="button"
+            role="menuitem"
+            className="planning-card__menu-item"
+            aria-expanded={showMove}
+            onClick={() => setShowMove(s => !s)}
+          >
+            <ArrowRightLeft size={13} /> Move to…
+          </button>
+          {showMove && (
+            <div className="planning-card__submenu" role="menu">
+              {BOARD_STAGES.map(stage => (
+                <button
+                  key={stage}
+                  type="button"
+                  role="menuitem"
+                  className={`planning-card__menu-item ${stage === currentStage ? 'is-current' : ''}`}
+                  onClick={() => {
+                    if (stage !== currentStage) onMoveStage(stage);
+                    close();
+                  }}
+                >
+                  <span>{BOARD_STAGE_LABELS[stage]}</span>
+                  {stage === currentStage && <Check size={12} />}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <button
+            type="button"
+            role="menuitem"
+            className="planning-card__menu-item"
+            onClick={() => {
+              onRemoveFromBoard();
+              close();
+            }}
+          >
+            <EyeOff size={13} /> Remove from board
+          </button>
+
+          <button
+            type="button"
+            role="menuitem"
+            className="planning-card__menu-item planning-card__menu-item--danger"
+            onClick={() => {
+              onDelete();
+              close();
+            }}
+          >
+            <Trash2 size={13} /> Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
@@ -3,18 +3,21 @@ import {
   MoreHorizontal,
   SquareArrowOutUpRight,
   ArrowRightLeft,
+  Flag,
   EyeOff,
   Trash2,
   Check,
 } from 'lucide-react';
 import { BOARD_STAGES } from '@dripnex/core';
-import type { BoardStage } from '../../../preload/index';
-import { BOARD_STAGE_LABELS } from './constants';
+import type { BoardStage, NotePriority } from '../../../preload/index';
+import { BOARD_STAGE_LABELS, PRIORITY_ORDER, PRIORITY_CONFIG } from './constants';
 
 interface PlanningCardMenuProps {
   readonly currentStage: BoardStage;
+  readonly currentPriority: NotePriority;
   readonly onOpen: () => void;
   readonly onMoveStage: (stage: BoardStage) => void;
+  readonly onSetPriority: (priority: NotePriority) => void;
   readonly onRemoveFromBoard: () => void;
   readonly onDelete: () => void;
 }
@@ -22,13 +25,16 @@ interface PlanningCardMenuProps {
 /** The "…" actions menu on a Planning card. */
 export function PlanningCardMenu({
   currentStage,
+  currentPriority,
   onOpen,
   onMoveStage,
+  onSetPriority,
   onRemoveFromBoard,
   onDelete,
 }: PlanningCardMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [showMove, setShowMove] = useState(false);
+  const [showPriority, setShowPriority] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -37,6 +43,7 @@ export function PlanningCardMenu({
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
         setIsOpen(false);
         setShowMove(false);
+        setShowPriority(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
@@ -46,6 +53,7 @@ export function PlanningCardMenu({
   const close = useCallback(() => {
     setIsOpen(false);
     setShowMove(false);
+    setShowPriority(false);
   }, []);
 
   // Stop clicks from bubbling to the card (which would open the note or start a drag).
@@ -102,6 +110,42 @@ export function PlanningCardMenu({
                 >
                   <span>{BOARD_STAGE_LABELS[stage]}</span>
                   {stage === currentStage && <Check size={12} />}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <button
+            type="button"
+            role="menuitem"
+            className="planning-card__menu-item"
+            aria-expanded={showPriority}
+            onClick={() => setShowPriority(s => !s)}
+          >
+            <Flag size={13} /> Priority…
+          </button>
+          {showPriority && (
+            <div className="planning-card__submenu" role="menu">
+              {PRIORITY_ORDER.map(priority => (
+                <button
+                  key={priority}
+                  type="button"
+                  role="menuitem"
+                  className={`planning-card__menu-item ${priority === currentPriority ? 'is-current' : ''}`}
+                  onClick={() => {
+                    if (priority !== currentPriority) onSetPriority(priority);
+                    close();
+                  }}
+                >
+                  <span className="planning-card__menu-swatch-wrap">
+                    <span
+                      className="planning-card__menu-swatch"
+                      style={{ backgroundColor: PRIORITY_CONFIG[priority].color }}
+                      aria-hidden="true"
+                    />
+                    {PRIORITY_CONFIG[priority].label}
+                  </span>
+                  {priority === currentPriority && <Check size={12} />}
                 </button>
               ))}
             </div>

--- a/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCardMenu.tsx
@@ -91,7 +91,10 @@ export function PlanningCardMenu({
             role="menuitem"
             className="planning-card__menu-item"
             aria-expanded={showMove}
-            onClick={() => setShowMove(s => !s)}
+            onClick={() => {
+              setShowMove(s => !s);
+              setShowPriority(false);
+            }}
           >
             <ArrowRightLeft size={13} /> Move to…
           </button>
@@ -120,7 +123,10 @@ export function PlanningCardMenu({
             role="menuitem"
             className="planning-card__menu-item"
             aria-expanded={showPriority}
-            onClick={() => setShowPriority(s => !s)}
+            onClick={() => {
+              setShowPriority(s => !s);
+              setShowMove(false);
+            }}
           >
             <Flag size={13} /> Priority…
           </button>

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -1,0 +1,65 @@
+import { memo, useCallback, useState } from 'react';
+import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import { PlanningCard } from './PlanningCard';
+import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
+
+interface PlanningColumnProps {
+  readonly stage: BoardStage;
+  readonly notes: readonly NoteSnapshot[];
+  readonly onDropNote: (noteId: string, stage: BoardStage) => void;
+  readonly onOpenNote: (id: string) => void;
+}
+
+/** A droppable Kanban column for a single board stage. */
+export const PlanningColumn = memo(function PlanningColumn({
+  stage,
+  notes,
+  onDropNote,
+  onOpenNote,
+}: PlanningColumnProps) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(NOTE_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setIsOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLElement>) => {
+    // Only clear when the pointer actually leaves the column (not a child).
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsOver(false);
+      const noteId = e.dataTransfer.getData(NOTE_MIME);
+      if (noteId) onDropNote(noteId, stage);
+    },
+    [onDropNote, stage]
+  );
+
+  return (
+    <section
+      className={`planning-column ${isOver ? 'planning-column--over' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      aria-label={BOARD_STAGE_LABELS[stage]}
+    >
+      <header className="planning-column__header">
+        <span className="planning-column__title">{BOARD_STAGE_LABELS[stage]}</span>
+        <span className="planning-column__count">{notes.length}</span>
+      </header>
+      <div className="planning-column__cards">
+        {notes.map(note => (
+          <PlanningCard key={note.id} note={note} onOpen={onOpenNote} />
+        ))}
+      </div>
+    </section>
+  );
+});

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useState } from 'react';
+import { Plus } from 'lucide-react';
 import type { NoteSnapshot, BoardStage } from '../../../preload/index';
 import { PlanningCard } from './PlanningCard';
 import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
@@ -7,7 +8,11 @@ interface PlanningColumnProps {
   readonly stage: BoardStage;
   readonly notes: readonly NoteSnapshot[];
   readonly onDropNote: (noteId: string, stage: BoardStage) => void;
+  readonly onAddCard: (stage: BoardStage) => void;
   readonly onOpenNote: (id: string) => void;
+  readonly onMoveStage: (id: string, stage: BoardStage) => void;
+  readonly onRemoveFromBoard: (id: string) => void;
+  readonly onDeleteNote: (id: string) => void;
 }
 
 /** A droppable Kanban column for a single board stage. */
@@ -15,7 +20,11 @@ export const PlanningColumn = memo(function PlanningColumn({
   stage,
   notes,
   onDropNote,
+  onAddCard,
   onOpenNote,
+  onMoveStage,
+  onRemoveFromBoard,
+  onDeleteNote,
 }: PlanningColumnProps) {
   const [isOver, setIsOver] = useState(false);
 
@@ -54,11 +63,33 @@ export const PlanningColumn = memo(function PlanningColumn({
       <header className="planning-column__header">
         <span className="planning-column__title">{BOARD_STAGE_LABELS[stage]}</span>
         <span className="planning-column__count">{notes.length}</span>
+        <button
+          type="button"
+          className="planning-column__add"
+          onClick={() => onAddCard(stage)}
+          aria-label={`Add card to ${BOARD_STAGE_LABELS[stage]}`}
+          title="Add card"
+        >
+          <Plus size={14} />
+        </button>
       </header>
       <div className="planning-column__cards">
-        {notes.map(note => (
-          <PlanningCard key={note.id} note={note} onOpen={onOpenNote} />
-        ))}
+        {notes.length === 0 ? (
+          <button type="button" className="planning-column__empty" onClick={() => onAddCard(stage)}>
+            <Plus size={14} /> Add a card
+          </button>
+        ) : (
+          notes.map(note => (
+            <PlanningCard
+              key={note.id}
+              note={note}
+              onOpen={onOpenNote}
+              onMoveStage={onMoveStage}
+              onRemoveFromBoard={onRemoveFromBoard}
+              onDelete={onDeleteNote}
+            />
+          ))
+        )}
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -4,10 +4,18 @@ import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/in
 import { PlanningCard } from './PlanningCard';
 import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
 
+type DropSide = 'above' | 'below' | 'append';
+
 interface PlanningColumnProps {
   readonly stage: BoardStage;
   readonly notes: readonly NoteSnapshot[];
-  readonly onDropNote: (noteId: string, stage: BoardStage) => void;
+  /** Move `draggedId` into this column relative to `targetId` (null = append). */
+  readonly onReorder: (
+    draggedId: string,
+    stage: BoardStage,
+    targetId: string | null,
+    side: DropSide
+  ) => void;
   readonly onAddCard: (stage: BoardStage) => void;
   readonly onOpenNote: (id: string) => void;
   readonly onMoveStage: (id: string, stage: BoardStage) => void;
@@ -20,7 +28,7 @@ interface PlanningColumnProps {
 export const PlanningColumn = memo(function PlanningColumn({
   stage,
   notes,
-  onDropNote,
+  onReorder,
   onAddCard,
   onOpenNote,
   onMoveStage,
@@ -30,10 +38,8 @@ export const PlanningColumn = memo(function PlanningColumn({
 }: PlanningColumnProps) {
   const [isOver, setIsOver] = useState(false);
 
-  // A card carries either our custom MIME or (as a fallback) text/plain. Some
-  // Chromium/Electron builds don't enumerate custom types in `types` during
-  // dragover, so we must not gate preventDefault() on that check — otherwise the
-  // drop event never fires. We allow the drop and only read the id on drop.
+  // preventDefault unconditionally so the drop always fires (some Chromium
+  // builds don't enumerate custom types in `types` during dragover).
   const allowDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
@@ -41,23 +47,25 @@ export const PlanningColumn = memo(function PlanningColumn({
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent<HTMLElement>) => {
-    // Only clear when the pointer actually leaves the column (not a child).
-    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-      setIsOver(false);
-    }
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) setIsOver(false);
   }, []);
 
+  // Drops that reach the column background (not a card) append to the end.
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
       setIsOver(false);
-      // getData reads custom types reliably on drop (the enumeration quirk only
-      // affects dragover). Reading our MIME avoids acting on notebook drags,
-      // which also set text/plain.
       const noteId = e.dataTransfer.getData(NOTE_MIME);
-      if (noteId) onDropNote(noteId, stage);
+      if (noteId) onReorder(noteId, stage, null, 'append');
     },
-    [onDropNote, stage]
+    [onReorder, stage]
+  );
+
+  const handleDropCard = useCallback(
+    (draggedId: string, targetId: string, side: 'above' | 'below') => {
+      onReorder(draggedId, stage, targetId, side);
+    },
+    [onReorder, stage]
   );
 
   return (
@@ -97,6 +105,7 @@ export const PlanningColumn = memo(function PlanningColumn({
               onSetPriority={onSetPriority}
               onRemoveFromBoard={onRemoveFromBoard}
               onDelete={onDeleteNote}
+              onDropCard={handleDropCard}
             />
           ))
         )}

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -28,8 +28,11 @@ export const PlanningColumn = memo(function PlanningColumn({
 }: PlanningColumnProps) {
   const [isOver, setIsOver] = useState(false);
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    if (!e.dataTransfer.types.includes(NOTE_MIME)) return;
+  // A card carries either our custom MIME or (as a fallback) text/plain. Some
+  // Chromium/Electron builds don't enumerate custom types in `types` during
+  // dragover, so we must not gate preventDefault() on that check — otherwise the
+  // drop event never fires. We allow the drop and only read the id on drop.
+  const allowDrop = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     e.dataTransfer.dropEffect = 'move';
     setIsOver(true);
@@ -46,6 +49,9 @@ export const PlanningColumn = memo(function PlanningColumn({
     (e: React.DragEvent) => {
       e.preventDefault();
       setIsOver(false);
+      // getData reads custom types reliably on drop (the enumeration quirk only
+      // affects dragover). Reading our MIME avoids acting on notebook drags,
+      // which also set text/plain.
       const noteId = e.dataTransfer.getData(NOTE_MIME);
       if (noteId) onDropNote(noteId, stage);
     },
@@ -55,7 +61,8 @@ export const PlanningColumn = memo(function PlanningColumn({
   return (
     <section
       className={`planning-column ${isOver ? 'planning-column--over' : ''}`}
-      onDragOver={handleDragOver}
+      onDragEnter={allowDrop}
+      onDragOver={allowDrop}
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       aria-label={BOARD_STAGE_LABELS[stage]}

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -91,24 +91,25 @@ export const PlanningColumn = memo(function PlanningColumn({
         </button>
       </header>
       <div className="planning-column__cards">
-        {notes.length === 0 ? (
-          <button type="button" className="planning-column__empty" onClick={() => onAddCard(stage)}>
-            <Plus size={14} /> Add a card
-          </button>
-        ) : (
-          notes.map(note => (
-            <PlanningCard
-              key={note.id}
-              note={note}
-              onOpen={onOpenNote}
-              onMoveStage={onMoveStage}
-              onSetPriority={onSetPriority}
-              onRemoveFromBoard={onRemoveFromBoard}
-              onDelete={onDeleteNote}
-              onDropCard={handleDropCard}
-            />
-          ))
-        )}
+        {notes.map(note => (
+          <PlanningCard
+            key={note.id}
+            note={note}
+            onOpen={onOpenNote}
+            onMoveStage={onMoveStage}
+            onSetPriority={onSetPriority}
+            onRemoveFromBoard={onRemoveFromBoard}
+            onDelete={onDeleteNote}
+            onDropCard={handleDropCard}
+          />
+        ))}
+        <button
+          type="button"
+          className="planning-column__add-card"
+          onClick={() => onAddCard(stage)}
+        >
+          <Plus size={14} /> Add card
+        </button>
       </div>
     </section>
   );

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useState } from 'react';
 import { Plus } from 'lucide-react';
-import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
 import { PlanningCard } from './PlanningCard';
 import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
 
@@ -11,6 +11,7 @@ interface PlanningColumnProps {
   readonly onAddCard: (stage: BoardStage) => void;
   readonly onOpenNote: (id: string) => void;
   readonly onMoveStage: (id: string, stage: BoardStage) => void;
+  readonly onSetPriority: (id: string, priority: NotePriority) => void;
   readonly onRemoveFromBoard: (id: string) => void;
   readonly onDeleteNote: (id: string) => void;
 }
@@ -23,6 +24,7 @@ export const PlanningColumn = memo(function PlanningColumn({
   onAddCard,
   onOpenNote,
   onMoveStage,
+  onSetPriority,
   onRemoveFromBoard,
   onDeleteNote,
 }: PlanningColumnProps) {
@@ -92,6 +94,7 @@ export const PlanningColumn = memo(function PlanningColumn({
               note={note}
               onOpen={onOpenNote}
               onMoveStage={onMoveStage}
+              onSetPriority={onSetPriority}
               onRemoveFromBoard={onRemoveFromBoard}
               onDelete={onDeleteNote}
             />

--- a/apps/desktop/src/renderer/components/planning/PlanningToolbar.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningToolbar.tsx
@@ -1,0 +1,84 @@
+import { Search, X } from 'lucide-react';
+import type { NotePriority } from '../../../preload/index';
+import { PRIORITY_ORDER, PRIORITY_CONFIG } from './constants';
+
+interface PlanningToolbarProps {
+  readonly search: string;
+  readonly onSearch: (value: string) => void;
+  readonly tag: string | null;
+  readonly onTag: (value: string | null) => void;
+  readonly priority: NotePriority | null;
+  readonly onPriority: (value: NotePriority | null) => void;
+  /** Tags available across the board's notes. */
+  readonly tags: readonly string[];
+  /** Whether any filter/search is active (to show the clear button). */
+  readonly isFiltering: boolean;
+  readonly onClear: () => void;
+}
+
+/** Search + tag/priority filters for the Planning board. */
+export function PlanningToolbar({
+  search,
+  onSearch,
+  tag,
+  onTag,
+  priority,
+  onPriority,
+  tags,
+  isFiltering,
+  onClear,
+}: PlanningToolbarProps) {
+  return (
+    <div className="planning-toolbar">
+      <div className="planning-toolbar__search">
+        <Search size={14} className="planning-toolbar__search-icon" />
+        <input
+          type="text"
+          className="planning-toolbar__input"
+          placeholder="Search cards…"
+          value={search}
+          onChange={e => onSearch(e.target.value)}
+        />
+      </div>
+
+      <select
+        className="planning-toolbar__select"
+        value={tag ?? ''}
+        onChange={e => onTag(e.target.value || null)}
+        aria-label="Filter by tag"
+      >
+        <option value="">All tags</option>
+        {tags.map(t => (
+          <option key={t} value={t}>
+            #{t}
+          </option>
+        ))}
+      </select>
+
+      <select
+        className="planning-toolbar__select"
+        value={priority ?? ''}
+        onChange={e => onPriority((e.target.value || null) as NotePriority | null)}
+        aria-label="Filter by priority"
+      >
+        <option value="">All priorities</option>
+        {PRIORITY_ORDER.map(p => (
+          <option key={p} value={p}>
+            {PRIORITY_CONFIG[p].label}
+          </option>
+        ))}
+      </select>
+
+      {isFiltering && (
+        <button
+          type="button"
+          className="planning-toolbar__clear"
+          onClick={onClear}
+          title="Clear filters"
+        >
+          <X size={14} /> Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/planning/__tests__/reorder.test.ts
+++ b/apps/desktop/src/renderer/components/planning/__tests__/reorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeReorderedIds } from '../reorder';
+import { computeReorderedIds, applyBoardReorder } from '../reorder';
 
 describe('computeReorderedIds', () => {
   const col = ['a', 'b', 'c', 'd'];
@@ -31,5 +31,30 @@ describe('computeReorderedIds', () => {
 
   it('appends an unknown target to the end', () => {
     expect(computeReorderedIds(col, 'a', 'zzz', 'below')).toEqual(['b', 'c', 'd', 'a']);
+  });
+});
+
+describe('applyBoardReorder', () => {
+  const notes = [
+    { id: 'a', boardStage: 'backlog' as const, boardOrder: 0 },
+    { id: 'b', boardStage: 'todo' as const, boardOrder: 3 },
+    { id: 'x', boardStage: 'in_review' as const, boardOrder: 9 }, // in another column
+  ];
+
+  it('assigns stage + contiguous order to the reordered ids', () => {
+    const out = applyBoardReorder(notes, 'todo', ['b', 'a']);
+    expect(out.find(n => n.id === 'b')).toMatchObject({ boardStage: 'todo', boardOrder: 0 });
+    expect(out.find(n => n.id === 'a')).toMatchObject({ boardStage: 'todo', boardOrder: 1 });
+  });
+
+  it('leaves notes not in the ordered list untouched', () => {
+    const out = applyBoardReorder(notes, 'todo', ['b', 'a']);
+    expect(out.find(n => n.id === 'x')).toEqual(notes[2]);
+  });
+
+  it('does not mutate the input array', () => {
+    const snapshot = JSON.parse(JSON.stringify(notes));
+    applyBoardReorder(notes, 'todo', ['b', 'a']);
+    expect(notes).toEqual(snapshot);
   });
 });

--- a/apps/desktop/src/renderer/components/planning/__tests__/reorder.test.ts
+++ b/apps/desktop/src/renderer/components/planning/__tests__/reorder.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { computeReorderedIds } from '../reorder';
+
+describe('computeReorderedIds', () => {
+  const col = ['a', 'b', 'c', 'd'];
+
+  it('moves a card above a target', () => {
+    expect(computeReorderedIds(col, 'd', 'b', 'above')).toEqual(['a', 'd', 'b', 'c']);
+  });
+
+  it('moves a card below a target', () => {
+    expect(computeReorderedIds(col, 'a', 'c', 'below')).toEqual(['b', 'c', 'a', 'd']);
+  });
+
+  it('appends when targetId is null', () => {
+    expect(computeReorderedIds(col, 'b', null, 'append')).toEqual(['a', 'c', 'd', 'b']);
+  });
+
+  it('handles dragging downward past its own slot (no off-by-one)', () => {
+    // 'b' dropped below 'c' should land between c and d, not stay put.
+    expect(computeReorderedIds(col, 'b', 'c', 'below')).toEqual(['a', 'c', 'b', 'd']);
+  });
+
+  it('is a no-op position when dropped above itself', () => {
+    expect(computeReorderedIds(col, 'b', 'b', 'above')).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('adds a card from another column at a position', () => {
+    expect(computeReorderedIds(col, 'x', 'a', 'above')).toEqual(['x', 'a', 'b', 'c', 'd']);
+  });
+
+  it('appends an unknown target to the end', () => {
+    expect(computeReorderedIds(col, 'a', 'zzz', 'below')).toEqual(['b', 'c', 'd', 'a']);
+  });
+});

--- a/apps/desktop/src/renderer/components/planning/constants.ts
+++ b/apps/desktop/src/renderer/components/planning/constants.ts
@@ -1,4 +1,4 @@
-import type { BoardStage } from '../../../preload/index';
+import type { BoardStage, NotePriority } from '../../../preload/index';
 
 /** Custom MIME type used to carry a note id during Kanban drag-and-drop. */
 export const NOTE_MIME = 'application/x-dripnex-note';
@@ -10,4 +10,16 @@ export const BOARD_STAGE_LABELS: Record<BoardStage, string> = {
   in_progress: 'In Progress',
   in_review: 'In Review',
   in_staging: 'In Staging',
+};
+
+/** Priorities in menu order (highest urgency first). */
+export const PRIORITY_ORDER: readonly NotePriority[] = ['urgent', 'high', 'medium', 'low', 'none'];
+
+/** Label + dot color for each priority. */
+export const PRIORITY_CONFIG: Record<NotePriority, { label: string; color: string }> = {
+  urgent: { label: 'Urgent', color: '#ef4444' },
+  high: { label: 'High', color: '#f97316' },
+  medium: { label: 'Medium', color: '#eab308' },
+  low: { label: 'Low', color: '#3b82f6' },
+  none: { label: 'No priority', color: 'var(--text-faint)' },
 };

--- a/apps/desktop/src/renderer/components/planning/constants.ts
+++ b/apps/desktop/src/renderer/components/planning/constants.ts
@@ -1,0 +1,13 @@
+import type { BoardStage } from '../../../preload/index';
+
+/** Custom MIME type used to carry a note id during Kanban drag-and-drop. */
+export const NOTE_MIME = 'application/x-dripnex-note';
+
+/** Human-readable column titles for each board stage. */
+export const BOARD_STAGE_LABELS: Record<BoardStage, string> = {
+  backlog: 'Backlog',
+  todo: 'Todo',
+  in_progress: 'In Progress',
+  in_review: 'In Review',
+  in_staging: 'In Staging',
+};

--- a/apps/desktop/src/renderer/components/planning/reorder.ts
+++ b/apps/desktop/src/renderer/components/planning/reorder.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure ordering helper for the Planning board — kept side-effect free so it can
+ * be unit-tested independently of React/DnD.
+ */
+
+export type ReorderSide = 'above' | 'below' | 'append';
+
+/**
+ * Compute the new ordered id list for a column after dropping `draggedId`
+ * relative to `targetId`.
+ *
+ * - Operates on the column's COMPLETE ordered id list (callers must pass the
+ *   unfiltered column so hidden cards keep contiguous order).
+ * - `targetId === null` or `side === 'append'` puts the card at the end.
+ * - Dragging a card downward past its own slot is handled correctly because the
+ *   dragged id is removed before the target index is computed.
+ */
+export function computeReorderedIds(
+  currentOrderedIds: readonly string[],
+  draggedId: string,
+  targetId: string | null,
+  side: ReorderSide
+): string[] {
+  // Dropping a card onto itself is a no-op (the UI also guards this).
+  if (targetId === draggedId) return [...currentOrderedIds];
+  const ids = currentOrderedIds.filter(id => id !== draggedId);
+  let insertAt = ids.length;
+  if (targetId !== null && side !== 'append') {
+    const ti = ids.indexOf(targetId);
+    if (ti !== -1) insertAt = side === 'below' ? ti + 1 : ti;
+  }
+  ids.splice(insertAt, 0, draggedId);
+  return ids;
+}

--- a/apps/desktop/src/renderer/components/planning/reorder.ts
+++ b/apps/desktop/src/renderer/components/planning/reorder.ts
@@ -3,7 +3,25 @@
  * be unit-tested independently of React/DnD.
  */
 
+import type { BoardStage } from '../../../preload/index';
+
 export type ReorderSide = 'above' | 'below' | 'append';
+
+/**
+ * Apply a column reorder to a list of notes for an optimistic cache update —
+ * mirrors what the repo's reorderBoard does server-side: notes whose id is in
+ * `orderedIds` get `boardStage = stage` and `boardOrder = their index`; every
+ * other note is returned unchanged. Pure and generic so it can be unit-tested.
+ */
+export function applyBoardReorder<
+  T extends { id: string; boardStage: BoardStage | null; boardOrder: number },
+>(notes: readonly T[], stage: BoardStage, orderedIds: readonly string[]): T[] {
+  const indexById = new Map(orderedIds.map((id, i) => [id, i]));
+  return notes.map(note => {
+    const index = indexById.get(note.id);
+    return index === undefined ? note : { ...note, boardStage: stage, boardOrder: index };
+  });
+}
 
 /**
  * Compute the new ordered id list for a column after dropping `draggedId`

--- a/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { LayoutZone } from '@dripnex/plugin-api';
 import {
   useIsNotebookContext,
+  useIsPlanningContext,
   useSelectedNotebookId,
   useGlobalFilter,
   useNavigationActions,
@@ -51,6 +52,7 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
 
   // Granular selectors
   const isNotebookContext = useIsNotebookContext();
+  const isPlanningContext = useIsPlanningContext();
   const selectedNotebookId = useSelectedNotebookId();
   const globalFilter = useGlobalFilter();
   const globalCounts = useGlobalCounts();
@@ -67,6 +69,7 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
     goToPinned,
     goToTrash,
     goToNotebook,
+    goToPlanning,
     clearNavigation,
     setStatusFilter,
     setTagFilter,
@@ -124,6 +127,8 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
           }}
           isNotebookContext={isNotebookContext}
           onOpenGraph={onOpenGraph}
+          onOpenPlanning={goToPlanning}
+          isPlanningSelected={isPlanningContext}
         />
 
         <SidebarSection title="Notebooks" collapsible onAdd={openCreateInContext}>

--- a/apps/desktop/src/renderer/components/sidebar/SidebarQuickFilters.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SidebarQuickFilters.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { FileText, Pin, Trash2, Network } from 'lucide-react';
+import { FileText, Pin, Trash2, Network, KanbanSquare } from 'lucide-react';
 
 export type QuickFilterType = 'all' | 'pinned' | 'trash';
 
@@ -11,6 +11,8 @@ interface SidebarQuickFiltersProps {
   readonly onSelectFilter: (filter: QuickFilterType) => void;
   readonly isNotebookContext?: boolean;
   readonly onOpenGraph?: () => void;
+  readonly onOpenPlanning?: () => void;
+  readonly isPlanningSelected?: boolean;
 }
 
 interface QuickFilterItemProps {
@@ -54,6 +56,8 @@ export const SidebarQuickFilters = memo(function SidebarQuickFilters({
   onSelectFilter,
   isNotebookContext = false,
   onOpenGraph,
+  onOpenPlanning,
+  isPlanningSelected = false,
 }: SidebarQuickFiltersProps) {
   return (
     <nav className="sidebar-quick-filters" aria-label="Quick filters">
@@ -81,6 +85,20 @@ export const SidebarQuickFilters = memo(function SidebarQuickFilters({
           isSelected={selectedFilter === 'trash'}
           onClick={() => onSelectFilter('trash')}
         />
+      )}
+      {onOpenPlanning && (
+        <button
+          type="button"
+          className={`sidebar-quick-filter ${isPlanningSelected ? 'selected' : ''}`}
+          onClick={onOpenPlanning}
+          aria-pressed={isPlanningSelected}
+          title="Open Planning board"
+        >
+          <span className="sidebar-quick-filter-icon" aria-hidden="true">
+            <KanbanSquare size={16} />
+          </span>
+          <span className="sidebar-quick-filter-label">Planning</span>
+        </button>
       )}
       {onOpenGraph && (
         <button

--- a/apps/desktop/src/renderer/hooks/useNavigation.ts
+++ b/apps/desktop/src/renderer/hooks/useNavigation.ts
@@ -6,6 +6,7 @@ import {
   selectStatusFilter,
   selectTagFilter,
   selectIsNotebookContext,
+  selectIsPlanningContext,
   selectSelectedNotebookId,
   selectGlobalFilter,
   selectSelectedTag,
@@ -51,6 +52,9 @@ export const useTagFilter = () => useNavigationStore(selectTagFilter);
 /** Check if in notebook context */
 export const useIsNotebookContext = () => useNavigationStore(selectIsNotebookContext);
 
+/** Check if in planning (Kanban board) context */
+export const useIsPlanningContext = () => useNavigationStore(selectIsPlanningContext);
+
 /** Get selected notebook ID (null if not in notebook view) */
 export const useSelectedNotebookId = () => useNavigationStore(selectSelectedNotebookId);
 
@@ -79,6 +83,7 @@ export function useNavigationActions() {
   const goToNotebook = useNavigationStore(s => s.goToNotebook);
   const goToTag = useNavigationStore(s => s.goToTag);
   const goToSearch = useNavigationStore(s => s.goToSearch);
+  const goToPlanning = useNavigationStore(s => s.goToPlanning);
   const clearNavigation = useNavigationStore(s => s.clearNavigation);
   const setStatusFilter = useNavigationStore(s => s.setStatusFilter);
   const setTagFilter = useNavigationStore(s => s.setTagFilter);
@@ -93,6 +98,7 @@ export function useNavigationActions() {
     goToNotebook,
     goToTag,
     goToSearch,
+    goToPlanning,
     clearNavigation,
     setStatusFilter,
     setTagFilter,
@@ -154,6 +160,12 @@ export function useFilteredNotes(): NoteWithExcerpt[] {
       case 'search':
         // Search is handled separately via useSearchNotes
         notes = notes.filter(n => !n.isDeleted && !n.isArchived);
+        break;
+
+      case 'planning':
+        // The Planning board fetches and groups its own notes by boardStage;
+        // the standard note list is empty in this view.
+        notes = [];
         break;
     }
 

--- a/apps/desktop/src/renderer/hooks/useNotes.ts
+++ b/apps/desktop/src/renderer/hooks/useNotes.ts
@@ -1,5 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import type { ListOptions, NoteStatus, BoardStage, NoteSnapshot } from '../../preload/index';
+import type {
+  ListOptions,
+  NoteStatus,
+  BoardStage,
+  NotePriority,
+  NoteSnapshot,
+} from '../../preload/index';
 
 // ============================================================================
 // Excerpt Helper (shared between filtered notes and search results)
@@ -243,6 +249,15 @@ export function useNoteMutations() {
     onSuccess: () => invalidateNotes(),
   });
 
+  const setPriority = useMutation({
+    mutationFn: async ({ id, priority }: { id: string; priority: NotePriority }) => {
+      const result = await window.dripnex.notes.setPriority(id, priority);
+      if (!result.ok) throw new Error(result.error.type);
+      return result.data;
+    },
+    onSuccess: () => invalidateNotes(),
+  });
+
   return {
     createNote,
     updateNote,
@@ -258,5 +273,6 @@ export function useNoteMutations() {
     restoreDeletedNote,
     setNoteStatus,
     setBoardStage,
+    setPriority,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useNotes.ts
+++ b/apps/desktop/src/renderer/hooks/useNotes.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import type { ListOptions, NoteStatus, NoteSnapshot } from '../../preload/index';
+import type { ListOptions, NoteStatus, BoardStage, NoteSnapshot } from '../../preload/index';
 
 // ============================================================================
 // Excerpt Helper (shared between filtered notes and search results)
@@ -234,6 +234,15 @@ export function useNoteMutations() {
     onSuccess: () => invalidateNotes(),
   });
 
+  const setBoardStage = useMutation({
+    mutationFn: async ({ id, boardStage }: { id: string; boardStage: BoardStage | null }) => {
+      const result = await window.dripnex.notes.setBoardStage(id, boardStage);
+      if (!result.ok) throw new Error(result.error.type);
+      return result.data;
+    },
+    onSuccess: () => invalidateNotes(),
+  });
+
   return {
     createNote,
     updateNote,
@@ -248,5 +257,6 @@ export function useNoteMutations() {
     softDeleteNote,
     restoreDeletedNote,
     setNoteStatus,
+    setBoardStage,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useNotes.ts
+++ b/apps/desktop/src/renderer/hooks/useNotes.ts
@@ -258,6 +258,15 @@ export function useNoteMutations() {
     onSuccess: () => invalidateNotes(),
   });
 
+  const reorderColumn = useMutation({
+    mutationFn: async ({ stage, orderedIds }: { stage: BoardStage; orderedIds: string[] }) => {
+      const result = await window.dripnex.notes.reorderColumn(stage, orderedIds);
+      if (!result.ok) throw new Error('REORDER_FAILED');
+      return result;
+    },
+    onSuccess: () => invalidateNotes(),
+  });
+
   return {
     createNote,
     updateNote,
@@ -274,5 +283,6 @@ export function useNoteMutations() {
     setNoteStatus,
     setBoardStage,
     setPriority,
+    reorderColumn,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useNotes.ts
+++ b/apps/desktop/src/renderer/hooks/useNotes.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { applyBoardReorder } from '../components/planning/reorder';
 import type {
   ListOptions,
   NoteStatus,
@@ -264,7 +265,22 @@ export function useNoteMutations() {
       if (!result.ok) throw new Error('REORDER_FAILED');
       return result;
     },
-    onSuccess: () => invalidateNotes(),
+    // Optimistic: patch every cached note list immediately so the drag doesn't
+    // flicker while the write round-trips; roll back on error, resync on settle.
+    onMutate: async ({ stage, orderedIds }) => {
+      await queryClient.cancelQueries({ queryKey: noteKeys.lists() });
+      const previous = queryClient.getQueriesData<NoteSnapshot[]>({ queryKey: noteKeys.lists() });
+      queryClient.setQueriesData<NoteSnapshot[]>({ queryKey: noteKeys.lists() }, old =>
+        old ? applyBoardReorder(old, stage, orderedIds) : old
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      context?.previous?.forEach(([key, data]) => queryClient.setQueryData(key, data));
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: noteKeys.lists() });
+    },
   });
 
   return {

--- a/apps/desktop/src/renderer/stores/navigationStore.ts
+++ b/apps/desktop/src/renderer/stores/navigationStore.ts
@@ -12,7 +12,8 @@ export type NavigationState =
   | { kind: 'global'; filter: 'all' | 'pinned' | 'trash' }
   | { kind: 'notebook'; id: string }
   | { kind: 'tag'; name: string }
-  | { kind: 'search'; query: string };
+  | { kind: 'search'; query: string }
+  | { kind: 'planning' };
 
 /**
  * Status filter - orthogonal to navigation, can combine with any view
@@ -50,6 +51,7 @@ interface NavigationStore {
   goToNotebook: (id: string) => void;
   goToTag: (name: string) => void;
   goToSearch: (query: string) => void;
+  goToPlanning: () => void;
   clearNavigation: () => void;
 
   // Actions - Filters
@@ -98,6 +100,8 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
   goToTag: name => set({ navigation: { kind: 'tag', name }, statusFilter: null, tagFilter: null }),
   goToSearch: query =>
     set({ navigation: { kind: 'search', query }, statusFilter: null, tagFilter: null }),
+  goToPlanning: () =>
+    set({ navigation: { kind: 'planning' }, statusFilter: null, tagFilter: null }),
   clearNavigation: () =>
     set({ navigation: DEFAULT_NAVIGATION, statusFilter: null, tagFilter: null }),
 
@@ -124,6 +128,9 @@ export const selectIsNotebookContext = (state: NavigationStore) =>
   state.navigation.kind === 'notebook';
 
 export const selectIsGlobalContext = (state: NavigationStore) => state.navigation.kind === 'global';
+
+export const selectIsPlanningContext = (state: NavigationStore) =>
+  state.navigation.kind === 'planning';
 
 export const selectIsTrashView = (state: NavigationStore) =>
   state.navigation.kind === 'global' && state.navigation.filter === 'trash';

--- a/packages/core/src/contracts/NoteSnapshot.ts
+++ b/packages/core/src/contracts/NoteSnapshot.ts
@@ -5,7 +5,14 @@
  */
 
 import type { Note } from '../domain/note.js';
-import type { NoteId, Tag, Timestamp, NoteStatus, BoardStage } from '../domain/types.js';
+import type {
+  NoteId,
+  Tag,
+  Timestamp,
+  NoteStatus,
+  BoardStage,
+  NotePriority,
+} from '../domain/types.js';
 
 /** A read-only snapshot of a note for the UI */
 export interface NoteSnapshot {
@@ -23,6 +30,7 @@ export interface NoteSnapshot {
   readonly isDeleted: boolean;
   readonly status: NoteStatus;
   readonly boardStage: BoardStage | null;
+  readonly priority: NotePriority;
 }
 
 /** Converts a Note entity to a NoteSnapshot */
@@ -42,6 +50,7 @@ export function toSnapshot(note: Note): NoteSnapshot {
     isDeleted: note.isDeleted,
     status: note.status,
     boardStage: note.boardStage,
+    priority: note.priority,
   };
 }
 
@@ -62,6 +71,7 @@ export interface NoteSummary {
   readonly isDeleted: boolean;
   readonly status: NoteStatus;
   readonly boardStage: BoardStage | null;
+  readonly priority: NotePriority;
 }
 
 /** Converts a Note to a NoteSummary */
@@ -86,5 +96,6 @@ export function toSummary(note: Note, excerptLength: number = 200): NoteSummary 
     isDeleted: note.isDeleted,
     status: note.status,
     boardStage: note.boardStage,
+    priority: note.priority,
   };
 }

--- a/packages/core/src/contracts/NoteSnapshot.ts
+++ b/packages/core/src/contracts/NoteSnapshot.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Note } from '../domain/note.js';
-import type { NoteId, Tag, Timestamp, NoteStatus } from '../domain/types.js';
+import type { NoteId, Tag, Timestamp, NoteStatus, BoardStage } from '../domain/types.js';
 
 /** A read-only snapshot of a note for the UI */
 export interface NoteSnapshot {
@@ -22,6 +22,7 @@ export interface NoteSnapshot {
   readonly isPinned: boolean;
   readonly isDeleted: boolean;
   readonly status: NoteStatus;
+  readonly boardStage: BoardStage | null;
 }
 
 /** Converts a Note entity to a NoteSnapshot */
@@ -40,6 +41,7 @@ export function toSnapshot(note: Note): NoteSnapshot {
     isPinned: note.isPinned,
     isDeleted: note.isDeleted,
     status: note.status,
+    boardStage: note.boardStage,
   };
 }
 
@@ -59,6 +61,7 @@ export interface NoteSummary {
   readonly isPinned: boolean;
   readonly isDeleted: boolean;
   readonly status: NoteStatus;
+  readonly boardStage: BoardStage | null;
 }
 
 /** Converts a Note to a NoteSummary */
@@ -82,5 +85,6 @@ export function toSummary(note: Note, excerptLength: number = 200): NoteSummary 
     isPinned: note.isPinned,
     isDeleted: note.isDeleted,
     status: note.status,
+    boardStage: note.boardStage,
   };
 }

--- a/packages/core/src/contracts/NoteSnapshot.ts
+++ b/packages/core/src/contracts/NoteSnapshot.ts
@@ -31,6 +31,7 @@ export interface NoteSnapshot {
   readonly status: NoteStatus;
   readonly boardStage: BoardStage | null;
   readonly priority: NotePriority;
+  readonly boardOrder: number;
 }
 
 /** Converts a Note entity to a NoteSnapshot */
@@ -51,6 +52,7 @@ export function toSnapshot(note: Note): NoteSnapshot {
     status: note.status,
     boardStage: note.boardStage,
     priority: note.priority,
+    boardOrder: note.boardOrder,
   };
 }
 
@@ -72,6 +74,7 @@ export interface NoteSummary {
   readonly status: NoteStatus;
   readonly boardStage: BoardStage | null;
   readonly priority: NotePriority;
+  readonly boardOrder: number;
 }
 
 /** Converts a Note to a NoteSummary */
@@ -97,5 +100,6 @@ export function toSummary(note: Note, excerptLength: number = 200): NoteSummary 
     status: note.status,
     boardStage: note.boardStage,
     priority: note.priority,
+    boardOrder: note.boardOrder,
   };
 }

--- a/packages/core/src/domain/note.ts
+++ b/packages/core/src/domain/note.ts
@@ -5,12 +5,14 @@
  * The Note entity wraps raw markdown with computed metadata
  */
 
-import type { NoteId, NotebookId, Tag, Timestamp, NoteStatus } from './types.js';
+import type { NoteId, NotebookId, Tag, Timestamp, NoteStatus, BoardStage } from './types.js';
 import {
   createTimestamp,
   generateNoteId,
   INBOX_NOTEBOOK_ID,
+  PLANNING_NOTEBOOK_ID,
   DEFAULT_NOTE_STATUS,
+  DEFAULT_BOARD_STAGE,
 } from './types.js';
 import { extractTitle, extractTags, countWords, type NoteMetadata } from './metadata.js';
 
@@ -36,6 +38,12 @@ export interface Note {
 
   /** Workflow status of the note */
   readonly status: NoteStatus;
+
+  /**
+   * Kanban board stage. Non-null only for notes on the Planning board;
+   * null means the note is not tracked on the board.
+   */
+  readonly boardStage: BoardStage | null;
 
   /** Computed metadata derived from content */
   readonly metadata: NoteMetadata;
@@ -66,6 +74,12 @@ export interface CreateNoteOptions {
 
   /** Workflow status (defaults to 'active') */
   status?: NoteStatus;
+
+  /**
+   * Kanban board stage. Defaults to 'backlog' when the note is created in the
+   * Planning notebook, otherwise null.
+   */
+  boardStage?: BoardStage | null;
 }
 
 /** Creates a new Note from markdown content */
@@ -84,14 +98,18 @@ export function createNote(options: CreateNoteOptions): Note {
     archivedAt: null,
   };
 
+  const notebookId = options.notebookId ?? INBOX_NOTEBOOK_ID;
+
   return {
     id: options.id ?? generateNoteId(),
-    notebookId: options.notebookId ?? INBOX_NOTEBOOK_ID,
+    notebookId,
     title,
     content: options.content,
     isPinned: options.isPinned ?? false,
     isDeleted: options.isDeleted ?? false,
     status: options.status ?? DEFAULT_NOTE_STATUS,
+    boardStage:
+      options.boardStage ?? (notebookId === PLANNING_NOTEBOOK_ID ? DEFAULT_BOARD_STAGE : null),
     metadata,
   };
 }
@@ -117,6 +135,7 @@ export function updateNoteContent(note: Note, newContent: string): Note {
     isPinned: note.isPinned,
     isDeleted: note.isDeleted,
     status: note.status,
+    boardStage: note.boardStage,
     metadata,
   };
 }
@@ -177,6 +196,7 @@ export function duplicateNote(note: Note): Note {
     isPinned: false, // Duplicates are never pinned
     isDeleted: false, // Duplicates are never in trash
     status: DEFAULT_NOTE_STATUS, // Reset status to active
+    boardStage: note.boardStage, // Duplicate stays on the board in the same column
     metadata: {
       ...note.metadata,
       title: duplicatedTitle,
@@ -266,6 +286,17 @@ export function setNoteStatus(note: Note, status: NoteStatus): Note {
   return {
     ...note,
     status,
+  };
+}
+
+/**
+ * Updates a note's Kanban board stage (metadata-only, doesn't change updatedAt).
+ * Pass null to remove the note from the board.
+ */
+export function setBoardStage(note: Note, boardStage: BoardStage | null): Note {
+  return {
+    ...note,
+    boardStage,
   };
 }
 

--- a/packages/core/src/domain/note.ts
+++ b/packages/core/src/domain/note.ts
@@ -5,7 +5,15 @@
  * The Note entity wraps raw markdown with computed metadata
  */
 
-import type { NoteId, NotebookId, Tag, Timestamp, NoteStatus, BoardStage } from './types.js';
+import type {
+  NoteId,
+  NotebookId,
+  Tag,
+  Timestamp,
+  NoteStatus,
+  BoardStage,
+  NotePriority,
+} from './types.js';
 import {
   createTimestamp,
   generateNoteId,
@@ -13,6 +21,7 @@ import {
   PLANNING_NOTEBOOK_ID,
   DEFAULT_NOTE_STATUS,
   DEFAULT_BOARD_STAGE,
+  DEFAULT_NOTE_PRIORITY,
 } from './types.js';
 import { extractTitle, extractTags, countWords, type NoteMetadata } from './metadata.js';
 
@@ -44,6 +53,9 @@ export interface Note {
    * null means the note is not tracked on the board.
    */
   readonly boardStage: BoardStage | null;
+
+  /** Priority of the note (defaults to 'none') */
+  readonly priority: NotePriority;
 
   /** Computed metadata derived from content */
   readonly metadata: NoteMetadata;
@@ -80,6 +92,9 @@ export interface CreateNoteOptions {
    * Planning notebook, otherwise null.
    */
   boardStage?: BoardStage | null;
+
+  /** Priority (defaults to 'none') */
+  priority?: NotePriority;
 }
 
 /** Creates a new Note from markdown content */
@@ -110,6 +125,7 @@ export function createNote(options: CreateNoteOptions): Note {
     status: options.status ?? DEFAULT_NOTE_STATUS,
     boardStage:
       options.boardStage ?? (notebookId === PLANNING_NOTEBOOK_ID ? DEFAULT_BOARD_STAGE : null),
+    priority: options.priority ?? DEFAULT_NOTE_PRIORITY,
     metadata,
   };
 }
@@ -136,6 +152,7 @@ export function updateNoteContent(note: Note, newContent: string): Note {
     isDeleted: note.isDeleted,
     status: note.status,
     boardStage: note.boardStage,
+    priority: note.priority,
     metadata,
   };
 }
@@ -197,6 +214,7 @@ export function duplicateNote(note: Note): Note {
     isDeleted: false, // Duplicates are never in trash
     status: DEFAULT_NOTE_STATUS, // Reset status to active
     boardStage: note.boardStage, // Duplicate stays on the board in the same column
+    priority: note.priority,
     metadata: {
       ...note.metadata,
       title: duplicatedTitle,
@@ -297,6 +315,14 @@ export function setBoardStage(note: Note, boardStage: BoardStage | null): Note {
   return {
     ...note,
     boardStage,
+  };
+}
+
+/** Updates a note's priority (metadata-only, doesn't change updatedAt) */
+export function setNotePriority(note: Note, priority: NotePriority): Note {
+  return {
+    ...note,
+    priority,
   };
 }
 

--- a/packages/core/src/domain/note.ts
+++ b/packages/core/src/domain/note.ts
@@ -57,6 +57,9 @@ export interface Note {
   /** Priority of the note (defaults to 'none') */
   readonly priority: NotePriority;
 
+  /** Sort order within its board column (ascending; lower = higher up) */
+  readonly boardOrder: number;
+
   /** Computed metadata derived from content */
   readonly metadata: NoteMetadata;
 }
@@ -95,6 +98,9 @@ export interface CreateNoteOptions {
 
   /** Priority (defaults to 'none') */
   priority?: NotePriority;
+
+  /** Sort order within its board column (defaults to 0) */
+  boardOrder?: number;
 }
 
 /** Creates a new Note from markdown content */
@@ -126,6 +132,7 @@ export function createNote(options: CreateNoteOptions): Note {
     boardStage:
       options.boardStage ?? (notebookId === PLANNING_NOTEBOOK_ID ? DEFAULT_BOARD_STAGE : null),
     priority: options.priority ?? DEFAULT_NOTE_PRIORITY,
+    boardOrder: options.boardOrder ?? 0,
     metadata,
   };
 }
@@ -153,6 +160,7 @@ export function updateNoteContent(note: Note, newContent: string): Note {
     status: note.status,
     boardStage: note.boardStage,
     priority: note.priority,
+    boardOrder: note.boardOrder,
     metadata,
   };
 }
@@ -215,6 +223,7 @@ export function duplicateNote(note: Note): Note {
     status: DEFAULT_NOTE_STATUS, // Reset status to active
     boardStage: note.boardStage, // Duplicate stays on the board in the same column
     priority: note.priority,
+    boardOrder: note.boardOrder,
     metadata: {
       ...note.metadata,
       title: duplicatedTitle,
@@ -323,6 +332,18 @@ export function setNotePriority(note: Note, priority: NotePriority): Note {
   return {
     ...note,
     priority,
+  };
+}
+
+/**
+ * Places a note on the board at a given stage and order (metadata-only,
+ * doesn't change updatedAt). Used for drag-to-reorder within/between columns.
+ */
+export function setBoardPosition(note: Note, boardStage: BoardStage, boardOrder: number): Note {
+  return {
+    ...note,
+    boardStage,
+    boardOrder,
   };
 }
 

--- a/packages/core/src/domain/notebook.ts
+++ b/packages/core/src/domain/notebook.ts
@@ -10,6 +10,7 @@ import {
   createTimestamp,
   generateNotebookId,
   INBOX_NOTEBOOK_ID,
+  PLANNING_NOTEBOOK_ID,
   MAX_NOTEBOOK_DEPTH,
 } from './types.js';
 
@@ -108,6 +109,21 @@ export function createInboxNotebook(): Notebook {
   };
 }
 
+/** Creates the special Planning notebook (backs the Kanban board) */
+export function createPlanningNotebook(): Notebook {
+  const now = createTimestamp();
+
+  return {
+    id: PLANNING_NOTEBOOK_ID,
+    name: 'Planning',
+    parentId: null,
+    depth: 0,
+    order: 1, // Right after Inbox
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
 /** Renames a notebook */
 export function renameNotebook(notebook: Notebook, newName: string): Notebook {
   if (isInbox(notebook)) {
@@ -179,9 +195,14 @@ export function isInbox(notebook: Notebook): boolean {
   return notebook.id === INBOX_NOTEBOOK_ID;
 }
 
-/** Checks if a notebook can be deleted (Inbox cannot) */
+/** Checks if this is the special Planning notebook (backs the Kanban board) */
+export function isPlanning(notebook: Notebook): boolean {
+  return notebook.id === PLANNING_NOTEBOOK_ID;
+}
+
+/** Checks if a notebook can be deleted (Inbox and Planning cannot) */
 export function canDelete(notebook: Notebook): boolean {
-  return !isInbox(notebook);
+  return !isInbox(notebook) && !isPlanning(notebook);
 }
 
 /** Builds a tree structure from a flat list of notebooks */

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -72,21 +72,15 @@ export const NOTE_STATUSES: readonly NoteStatus[] = [
 /** Default status for new notes */
 export const DEFAULT_NOTE_STATUS: NoteStatus = 'active';
 
+/** All valid board stages, in column order (single source of truth) */
+export const BOARD_STAGES = ['backlog', 'todo', 'in_progress', 'in_review', 'in_staging'] as const;
+
 /**
  * Kanban board stage for planning notes.
  * Independent from NoteStatus: this is the column a note occupies on the
  * Planning board. Only notes on the board carry a stage (others are null).
  */
-export type BoardStage = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'in_staging';
-
-/** All valid board stages, in column order */
-export const BOARD_STAGES: readonly BoardStage[] = [
-  'backlog',
-  'todo',
-  'in_progress',
-  'in_review',
-  'in_staging',
-] as const;
+export type BoardStage = (typeof BOARD_STAGES)[number];
 
 /** Default stage for a note that enters the board */
 export const DEFAULT_BOARD_STAGE: BoardStage = 'backlog';

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -84,3 +84,12 @@ export type BoardStage = (typeof BOARD_STAGES)[number];
 
 /** Default stage for a note that enters the board */
 export const DEFAULT_BOARD_STAGE: BoardStage = 'backlog';
+
+/** All valid note priorities, low→high (single source of truth) */
+export const NOTE_PRIORITIES = ['none', 'low', 'medium', 'high', 'urgent'] as const;
+
+/** Priority of a note (Linear-style), used to sort/flag work on the board */
+export type NotePriority = (typeof NOTE_PRIORITIES)[number];
+
+/** Default priority for new notes */
+export const DEFAULT_NOTE_PRIORITY: NotePriority = 'none';

--- a/packages/core/src/domain/types.ts
+++ b/packages/core/src/domain/types.ts
@@ -52,6 +52,9 @@ export function generateNotebookId(): NotebookId {
 /** Special Inbox notebook ID - all notes without a notebook go here */
 export const INBOX_NOTEBOOK_ID = createNotebookId('inbox');
 
+/** Special Planning notebook ID - notes here appear as cards on the Kanban board */
+export const PLANNING_NOTEBOOK_ID = createNotebookId('planning');
+
 /** Maximum allowed nesting depth for notebooks (0, 1, 2 = 3 levels) */
 export const MAX_NOTEBOOK_DEPTH = 2;
 
@@ -68,3 +71,22 @@ export const NOTE_STATUSES: readonly NoteStatus[] = [
 
 /** Default status for new notes */
 export const DEFAULT_NOTE_STATUS: NoteStatus = 'active';
+
+/**
+ * Kanban board stage for planning notes.
+ * Independent from NoteStatus: this is the column a note occupies on the
+ * Planning board. Only notes on the board carry a stage (others are null).
+ */
+export type BoardStage = 'backlog' | 'todo' | 'in_progress' | 'in_review' | 'in_staging';
+
+/** All valid board stages, in column order */
+export const BOARD_STAGES: readonly BoardStage[] = [
+  'backlog',
+  'todo',
+  'in_progress',
+  'in_review',
+  'in_staging',
+] as const;
+
+/** Default stage for a note that enters the board */
+export const DEFAULT_BOARD_STAGE: BoardStage = 'backlog';

--- a/packages/core/tests/boardStage.test.ts
+++ b/packages/core/tests/boardStage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createNote, setBoardStage } from '../src/domain/note.js';
+import { createNote, setBoardStage, setNotePriority } from '../src/domain/note.js';
 import {
   createInboxNotebook,
   createPlanningNotebook,
@@ -57,6 +57,26 @@ describe('Board stage (Kanban)', () => {
       const note = createNote({ content: '# Task', notebookId: PLANNING_NOTEBOOK_ID });
       expect(toSnapshot(note).boardStage).toBe('backlog');
     });
+  });
+});
+
+describe('Note priority', () => {
+  it("defaults to 'none'", () => {
+    expect(createNote({ content: '# Task' }).priority).toBe('none');
+  });
+
+  it('setNotePriority changes only the priority and preserves content/updatedAt', () => {
+    const original = createNote({ content: '# Task' });
+    const updated = setNotePriority(original, 'urgent');
+
+    expect(updated.priority).toBe('urgent');
+    expect(updated.content).toBe(original.content);
+    expect(updated.metadata.updatedAt).toBe(original.metadata.updatedAt);
+  });
+
+  it('is included in the snapshot', () => {
+    const note = setNotePriority(createNote({ content: '# Task' }), 'high');
+    expect(toSnapshot(note).priority).toBe('high');
   });
 });
 

--- a/packages/core/tests/boardStage.test.ts
+++ b/packages/core/tests/boardStage.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { createNote, setBoardStage } from '../src/domain/note.js';
+import {
+  createInboxNotebook,
+  createPlanningNotebook,
+  canDelete,
+  isPlanning,
+} from '../src/domain/notebook.js';
+import { toSnapshot } from '../src/contracts/NoteSnapshot.js';
+import { PLANNING_NOTEBOOK_ID, DEFAULT_BOARD_STAGE } from '../src/domain/types.js';
+
+describe('Board stage (Kanban)', () => {
+  describe('createNote board stage default', () => {
+    it('is null for a note outside the Planning notebook', () => {
+      const note = createNote({ content: '# Task' });
+      expect(note.boardStage).toBeNull();
+    });
+
+    it("defaults to 'backlog' for a note created in the Planning notebook", () => {
+      const note = createNote({ content: '# Task', notebookId: PLANNING_NOTEBOOK_ID });
+      expect(note.boardStage).toBe(DEFAULT_BOARD_STAGE);
+      expect(note.boardStage).toBe('backlog');
+    });
+
+    it('honors an explicit boardStage option', () => {
+      const note = createNote({ content: '# Task', boardStage: 'in_progress' });
+      expect(note.boardStage).toBe('in_progress');
+    });
+  });
+
+  describe('setBoardStage', () => {
+    it('changes only the stage and preserves content', () => {
+      const original = createNote({ content: '# Task', notebookId: PLANNING_NOTEBOOK_ID });
+      const moved = setBoardStage(original, 'in_review');
+
+      expect(moved.boardStage).toBe('in_review');
+      expect(moved.content).toBe(original.content);
+    });
+
+    it('does NOT update updatedAt (metadata-only)', () => {
+      const original = createNote({ content: '# Task', notebookId: PLANNING_NOTEBOOK_ID });
+      const moved = setBoardStage(original, 'todo');
+
+      expect(moved.metadata.updatedAt).toBe(original.metadata.updatedAt);
+    });
+
+    it('accepts null to remove the note from the board', () => {
+      const original = createNote({ content: '# Task', boardStage: 'todo' });
+      const off = setBoardStage(original, null);
+
+      expect(off.boardStage).toBeNull();
+    });
+  });
+
+  describe('toSnapshot', () => {
+    it('includes boardStage', () => {
+      const note = createNote({ content: '# Task', notebookId: PLANNING_NOTEBOOK_ID });
+      expect(toSnapshot(note).boardStage).toBe('backlog');
+    });
+  });
+});
+
+describe('Planning notebook', () => {
+  it('createPlanningNotebook uses the reserved id and name', () => {
+    const nb = createPlanningNotebook();
+    expect(nb.id).toBe(PLANNING_NOTEBOOK_ID);
+    expect(nb.name).toBe('Planning');
+    expect(isPlanning(nb)).toBe(true);
+  });
+
+  it('cannot be deleted', () => {
+    expect(canDelete(createPlanningNotebook())).toBe(false);
+  });
+
+  it('a regular notebook is not the Planning notebook', () => {
+    expect(isPlanning(createInboxNotebook())).toBe(false);
+  });
+});

--- a/packages/storage-core/src/types/ListNotesOptions.ts
+++ b/packages/storage-core/src/types/ListNotesOptions.ts
@@ -11,6 +11,8 @@ export interface ListNotesOptions {
   limit?: number;
   offset?: number;
   tag?: string;
+  /** Restrict results to a single notebook (filtered in SQL). */
+  notebookId?: string;
   sortBy?: 'createdAt' | 'updatedAt' | 'title';
   sortOrder?: 'asc' | 'desc';
   /** Filter by archived status. Defaults to 'active' (non-archived) */

--- a/packages/storage-sqlite/src/migrations/018_board_stage.ts
+++ b/packages/storage-sqlite/src/migrations/018_board_stage.ts
@@ -1,0 +1,27 @@
+/**
+ * Add board_stage column to notes for the Planning Kanban board.
+ *
+ * Nullable: only notes tracked on the Planning board carry a stage
+ * (backlog / todo / in_progress / in_review / in_staging). NULL means the
+ * note is not on the board. Persisted as DB metadata — the note's markdown
+ * is never modified when a card moves between columns.
+ */
+
+import type { Migration } from '@dripnex/storage-core';
+
+export const addBoardStage: Migration = {
+  version: 20260703000018,
+  name: 'add_board_stage',
+  up: `
+    -- Add board_stage column (nullable; NULL = not on the board)
+    ALTER TABLE notes ADD COLUMN board_stage TEXT;
+
+    -- Index for grouping notes into board columns
+    CREATE INDEX IF NOT EXISTS idx_notes_board_stage ON notes(board_stage);
+
+    -- Seed the special Planning notebook (backs the Kanban board; cannot be
+    -- deleted). Idempotent: INSERT OR IGNORE on the PRIMARY KEY.
+    INSERT OR IGNORE INTO notebooks (id, name, parent_id, depth, "order", created_at, updated_at)
+    VALUES ('planning', 'Planning', NULL, 0, 1, datetime('now'), datetime('now'));
+  `,
+};

--- a/packages/storage-sqlite/src/migrations/019_note_priority.ts
+++ b/packages/storage-sqlite/src/migrations/019_note_priority.ts
@@ -1,0 +1,21 @@
+/**
+ * Add priority column to notes (Linear-style priority for the Planning board).
+ *
+ * Non-null with a 'none' default, mirroring the existing `status` column.
+ * Persisted as DB metadata — setting a priority never modifies the note's
+ * markdown.
+ */
+
+import type { Migration } from '@dripnex/storage-core';
+
+export const addNotePriority: Migration = {
+  version: 20260703000019,
+  name: 'add_note_priority',
+  up: `
+    -- Add priority column (default 'none')
+    ALTER TABLE notes ADD COLUMN priority TEXT DEFAULT 'none';
+
+    -- Index for filtering/sorting by priority
+    CREATE INDEX IF NOT EXISTS idx_notes_priority ON notes(priority);
+  `,
+};

--- a/packages/storage-sqlite/src/migrations/020_board_order.ts
+++ b/packages/storage-sqlite/src/migrations/020_board_order.ts
@@ -1,0 +1,20 @@
+/**
+ * Add board_order column to notes for manual ordering within a Kanban column.
+ *
+ * Integer, default 0. Persisted as DB metadata — reordering cards never
+ * modifies the note's markdown.
+ */
+
+import type { Migration } from '@dripnex/storage-core';
+
+export const addBoardOrder: Migration = {
+  version: 20260703000020,
+  name: 'add_board_order',
+  up: `
+    -- Add board_order column (default 0)
+    ALTER TABLE notes ADD COLUMN board_order INTEGER NOT NULL DEFAULT 0;
+
+    -- Composite index for reading a column's cards in order
+    CREATE INDEX IF NOT EXISTS idx_notes_board_order ON notes(board_stage, board_order);
+  `,
+};

--- a/packages/storage-sqlite/src/migrations/021_fts_update_guard.ts
+++ b/packages/storage-sqlite/src/migrations/021_fts_update_guard.ts
@@ -1,0 +1,31 @@
+/**
+ * Guard the FTS update trigger so it only rebuilds the index when a
+ * searchable field actually changes.
+ *
+ * The original notes_fts_update trigger (migration 008) fired on ANY UPDATE,
+ * so metadata-only writes (board_stage, board_order, priority, status, pin…)
+ * pointlessly deleted+reinserted the note's FTS row. Reordering a Kanban column
+ * made this an N× churn. This recreates the trigger with a WHEN clause limiting
+ * it to title / content / is_deleted changes.
+ */
+
+import type { Migration } from '@dripnex/storage-core';
+
+export const addFtsUpdateGuard: Migration = {
+  version: 20260703000021,
+  name: 'fts_update_guard',
+  up: `
+    DROP TRIGGER IF EXISTS notes_fts_update;
+
+    CREATE TRIGGER notes_fts_update AFTER UPDATE ON notes
+    WHEN OLD.title IS NOT NEW.title
+      OR OLD.content IS NOT NEW.content
+      OR OLD.is_deleted IS NOT NEW.is_deleted
+    BEGIN
+      DELETE FROM notes_fts WHERE id = OLD.id;
+      INSERT INTO notes_fts(id, title, content)
+      SELECT NEW.id, NEW.title, NEW.content
+      WHERE NEW.is_deleted = 0 OR NEW.is_deleted IS NULL;
+    END;
+  `,
+};

--- a/packages/storage-sqlite/src/migrations/index.ts
+++ b/packages/storage-sqlite/src/migrations/index.ts
@@ -21,6 +21,7 @@ import { notebookSyncTracking } from './015_notebook_sync_tracking.js';
 import { tagSyncTracking } from './016_tag_sync_tracking.js';
 import { syncHistory } from './017_sync_history.js';
 import { addBoardStage } from './018_board_stage.js';
+import { addNotePriority } from './019_note_priority.js';
 
 /** All migrations in order */
 export const allMigrations: Migration[] = [
@@ -42,6 +43,7 @@ export const allMigrations: Migration[] = [
   tagSyncTracking,
   syncHistory,
   addBoardStage,
+  addNotePriority,
 ];
 
 export {
@@ -63,4 +65,5 @@ export {
   tagSyncTracking,
   syncHistory,
   addBoardStage,
+  addNotePriority,
 };

--- a/packages/storage-sqlite/src/migrations/index.ts
+++ b/packages/storage-sqlite/src/migrations/index.ts
@@ -22,6 +22,7 @@ import { tagSyncTracking } from './016_tag_sync_tracking.js';
 import { syncHistory } from './017_sync_history.js';
 import { addBoardStage } from './018_board_stage.js';
 import { addNotePriority } from './019_note_priority.js';
+import { addBoardOrder } from './020_board_order.js';
 
 /** All migrations in order */
 export const allMigrations: Migration[] = [
@@ -44,6 +45,7 @@ export const allMigrations: Migration[] = [
   syncHistory,
   addBoardStage,
   addNotePriority,
+  addBoardOrder,
 ];
 
 export {
@@ -66,4 +68,5 @@ export {
   syncHistory,
   addBoardStage,
   addNotePriority,
+  addBoardOrder,
 };

--- a/packages/storage-sqlite/src/migrations/index.ts
+++ b/packages/storage-sqlite/src/migrations/index.ts
@@ -23,6 +23,7 @@ import { syncHistory } from './017_sync_history.js';
 import { addBoardStage } from './018_board_stage.js';
 import { addNotePriority } from './019_note_priority.js';
 import { addBoardOrder } from './020_board_order.js';
+import { addFtsUpdateGuard } from './021_fts_update_guard.js';
 
 /** All migrations in order */
 export const allMigrations: Migration[] = [
@@ -46,6 +47,7 @@ export const allMigrations: Migration[] = [
   addBoardStage,
   addNotePriority,
   addBoardOrder,
+  addFtsUpdateGuard,
 ];
 
 export {
@@ -69,4 +71,5 @@ export {
   addBoardStage,
   addNotePriority,
   addBoardOrder,
+  addFtsUpdateGuard,
 };

--- a/packages/storage-sqlite/src/migrations/index.ts
+++ b/packages/storage-sqlite/src/migrations/index.ts
@@ -20,6 +20,7 @@ import { pluginRegistry } from './014_plugin_registry.js';
 import { notebookSyncTracking } from './015_notebook_sync_tracking.js';
 import { tagSyncTracking } from './016_tag_sync_tracking.js';
 import { syncHistory } from './017_sync_history.js';
+import { addBoardStage } from './018_board_stage.js';
 
 /** All migrations in order */
 export const allMigrations: Migration[] = [
@@ -40,6 +41,7 @@ export const allMigrations: Migration[] = [
   notebookSyncTracking,
   tagSyncTracking,
   syncHistory,
+  addBoardStage,
 ];
 
 export {
@@ -60,4 +62,5 @@ export {
   notebookSyncTracking,
   tagSyncTracking,
   syncHistory,
+  addBoardStage,
 };

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -48,7 +48,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
   async get(id: NoteId): Promise<Note | null> {
     const stmt = this.db.prepare<NoteRow>(`
       SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-             is_pinned, is_deleted, status
+             is_pinned, is_deleted, status, board_stage
       FROM notes
       WHERE id = ?
     `);
@@ -66,8 +66,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       // Upsert note
       const stmt = this.db.prepare(`
         INSERT INTO notes (id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-                           is_pinned, is_deleted, status)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           is_pinned, is_deleted, status, board_stage)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           notebook_id = excluded.notebook_id,
           content = excluded.content,
@@ -77,7 +77,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
           archived_at = excluded.archived_at,
           is_pinned = excluded.is_pinned,
           is_deleted = excluded.is_deleted,
-          status = excluded.status
+          status = excluded.status,
+          board_stage = excluded.board_stage
       `);
 
       stmt.run(
@@ -91,7 +92,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
         note.metadata.archivedAt,
         note.isPinned ? 1 : 0,
         note.isDeleted ? 1 : 0,
-        note.status
+        note.status,
+        note.boardStage
       );
 
       // Update content-extracted tags (preserves manual tags)
@@ -130,7 +132,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     if (tag) {
       sql = `
         SELECT DISTINCT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at, n.word_count, n.archived_at,
-               n.is_pinned, n.is_deleted, n.status
+               n.is_pinned, n.is_deleted, n.status, n.board_stage
         FROM notes n
         JOIN note_tags nt ON n.id = nt.note_id
         JOIN tags t ON nt.tag_id = t.id
@@ -142,7 +144,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     } else {
       sql = `
         SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-               is_pinned, is_deleted, status
+               is_pinned, is_deleted, status, board_stage
         FROM notes n
         WHERE 1=1 ${archivedCondition}
         ORDER BY ${sortColumn} ${sortOrder.toUpperCase()}
@@ -178,7 +180,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
 
     const stmt = this.db.prepare<NoteRow>(`
       SELECT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at,
-             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status
+             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage
       FROM notes_fts fts
       JOIN notes n ON fts.id = n.id
       WHERE notes_fts MATCH ? ${archivedCondition}
@@ -619,6 +621,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       is_pinned: number;
       is_deleted: number;
       status: string;
+      board_stage: string | null;
       local_version: number;
       last_synced_at: string | null;
     }>(`
@@ -641,6 +644,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       is_pinned: number;
       is_deleted: number;
       status: string;
+      board_stage: string | null;
       local_version: number;
       last_synced_at: string | null;
     }>;

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -48,7 +48,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
   async get(id: NoteId): Promise<Note | null> {
     const stmt = this.db.prepare<NoteRow>(`
       SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-             is_pinned, is_deleted, status, board_stage
+             is_pinned, is_deleted, status, board_stage, priority
       FROM notes
       WHERE id = ?
     `);
@@ -66,8 +66,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       // Upsert note
       const stmt = this.db.prepare(`
         INSERT INTO notes (id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-                           is_pinned, is_deleted, status, board_stage)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           is_pinned, is_deleted, status, board_stage, priority)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           notebook_id = excluded.notebook_id,
           content = excluded.content,
@@ -78,7 +78,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
           is_pinned = excluded.is_pinned,
           is_deleted = excluded.is_deleted,
           status = excluded.status,
-          board_stage = excluded.board_stage
+          board_stage = excluded.board_stage,
+          priority = excluded.priority
       `);
 
       stmt.run(
@@ -93,7 +94,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
         note.isPinned ? 1 : 0,
         note.isDeleted ? 1 : 0,
         note.status,
-        note.boardStage
+        note.boardStage,
+        note.priority
       );
 
       // Update content-extracted tags (preserves manual tags)
@@ -132,7 +134,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     if (tag) {
       sql = `
         SELECT DISTINCT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at, n.word_count, n.archived_at,
-               n.is_pinned, n.is_deleted, n.status, n.board_stage
+               n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority
         FROM notes n
         JOIN note_tags nt ON n.id = nt.note_id
         JOIN tags t ON nt.tag_id = t.id
@@ -144,7 +146,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     } else {
       sql = `
         SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-               is_pinned, is_deleted, status, board_stage
+               is_pinned, is_deleted, status, board_stage, priority
         FROM notes n
         WHERE 1=1 ${archivedCondition}
         ORDER BY ${sortColumn} ${sortOrder.toUpperCase()}
@@ -180,7 +182,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
 
     const stmt = this.db.prepare<NoteRow>(`
       SELECT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at,
-             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage
+             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority
       FROM notes_fts fts
       JOIN notes n ON fts.id = n.id
       WHERE notes_fts MATCH ? ${archivedCondition}
@@ -622,6 +624,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       is_deleted: number;
       status: string;
       board_stage: string | null;
+      priority: string | null;
       local_version: number;
       last_synced_at: string | null;
     }>(`
@@ -645,6 +648,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       is_deleted: number;
       status: string;
       board_stage: string | null;
+      priority: string | null;
       local_version: number;
       last_synced_at: string | null;
     }>;

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -5,7 +5,15 @@
  */
 
 import type { ExtendedNoteRepository, ListNotesOptions } from '@dripnex/storage-core';
-import { type Note, type NoteId, type Tag, createNoteId, createTag } from '@dripnex/core';
+import {
+  type Note,
+  type NoteId,
+  type Tag,
+  type BoardStage,
+  createNoteId,
+  createTag,
+  PLANNING_NOTEBOOK_ID,
+} from '@dripnex/core';
 import { extractWikilinks } from '@dripnex/wikilinks';
 import type { DatabaseConnection } from '../database.js';
 import {
@@ -112,12 +120,30 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     // Tags are cleaned up via ON DELETE CASCADE
   }
 
+  /**
+   * Reindex a Planning board column in one atomic transaction: every id gets
+   * board_stage=stage and board_order=its position. Direct metadata UPDATEs
+   * (no content change, so no tag re-extraction). The `notebook_id` guard means
+   * board metadata can only ever land on Planning-notebook notes.
+   */
+  reorderBoard(stage: BoardStage, orderedIds: readonly string[]): void {
+    const update = this.db.prepare(
+      'UPDATE notes SET board_stage = ?, board_order = ? WHERE id = ? AND notebook_id = ?'
+    );
+    this.db.transaction(() => {
+      orderedIds.forEach((id, index) => {
+        update.run(stage, index, id, PLANNING_NOTEBOOK_ID);
+      });
+    });
+  }
+
   /** List notes with optional filtering and pagination */
   async list(options: ListNotesOptions = {}): Promise<Note[]> {
     const {
       limit = 50,
       offset = 0,
       tag,
+      notebookId,
       sortBy = 'updatedAt',
       sortOrder = 'desc',
       archived = 'active',
@@ -130,6 +156,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     }[sortBy];
 
     const archivedCondition = archivedConditionSql(archived, 'n');
+    const notebookCondition = notebookId ? 'AND n.notebook_id = ?' : '';
     let sql: string;
     let params: (string | number)[];
 
@@ -140,21 +167,23 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
         FROM notes n
         JOIN note_tags nt ON n.id = nt.note_id
         JOIN tags t ON nt.tag_id = t.id
-        WHERE t.name = ? ${archivedCondition}
+        WHERE t.name = ? ${archivedCondition} ${notebookCondition}
         ORDER BY n.${sortColumn} ${sortOrder.toUpperCase()}
         LIMIT ? OFFSET ?
       `;
-      params = [tag.toLowerCase(), limit, offset];
+      params = notebookId
+        ? [tag.toLowerCase(), notebookId, limit, offset]
+        : [tag.toLowerCase(), limit, offset];
     } else {
       sql = `
         SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
                is_pinned, is_deleted, status, board_stage, priority, board_order
         FROM notes n
-        WHERE 1=1 ${archivedCondition}
+        WHERE 1=1 ${archivedCondition} ${notebookCondition}
         ORDER BY ${sortColumn} ${sortOrder.toUpperCase()}
         LIMIT ? OFFSET ?
       `;
-      params = [limit, offset];
+      params = notebookId ? [notebookId, limit, offset] : [limit, offset];
     }
 
     const stmt = this.db.prepare<NoteRow>(sql);

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -123,11 +123,14 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
    * board metadata can only ever land on Planning-notebook notes.
    */
   reorderBoard(stage: BoardStage, orderedIds: readonly string[]): void {
+    // Dedupe defensively: duplicate ids would otherwise assign the same note
+    // two positions (last wins) and leave a gap in the sequence.
+    const uniqueIds = [...new Set(orderedIds)];
     const update = this.db.prepare(
       'UPDATE notes SET board_stage = ?, board_order = ? WHERE id = ? AND notebook_id = ?'
     );
     this.db.transaction(() => {
-      orderedIds.forEach((id, index) => {
+      uniqueIds.forEach((id, index) => {
         update.run(stage, index, id, PLANNING_NOTEBOOK_ID);
       });
     });

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -48,7 +48,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
   async get(id: NoteId): Promise<Note | null> {
     const stmt = this.db.prepare<NoteRow>(`
       SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-             is_pinned, is_deleted, status, board_stage, priority
+             is_pinned, is_deleted, status, board_stage, priority, board_order
       FROM notes
       WHERE id = ?
     `);
@@ -66,8 +66,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       // Upsert note
       const stmt = this.db.prepare(`
         INSERT INTO notes (id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-                           is_pinned, is_deleted, status, board_stage, priority)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           is_pinned, is_deleted, status, board_stage, priority, board_order)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
           notebook_id = excluded.notebook_id,
           content = excluded.content,
@@ -79,7 +79,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
           is_deleted = excluded.is_deleted,
           status = excluded.status,
           board_stage = excluded.board_stage,
-          priority = excluded.priority
+          priority = excluded.priority,
+          board_order = excluded.board_order
       `);
 
       stmt.run(
@@ -95,7 +96,8 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
         note.isDeleted ? 1 : 0,
         note.status,
         note.boardStage,
-        note.priority
+        note.priority,
+        note.boardOrder
       );
 
       // Update content-extracted tags (preserves manual tags)
@@ -134,7 +136,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     if (tag) {
       sql = `
         SELECT DISTINCT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at, n.word_count, n.archived_at,
-               n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority
+               n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority, n.board_order
         FROM notes n
         JOIN note_tags nt ON n.id = nt.note_id
         JOIN tags t ON nt.tag_id = t.id
@@ -146,7 +148,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     } else {
       sql = `
         SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-               is_pinned, is_deleted, status, board_stage, priority
+               is_pinned, is_deleted, status, board_stage, priority, board_order
         FROM notes n
         WHERE 1=1 ${archivedCondition}
         ORDER BY ${sortColumn} ${sortOrder.toUpperCase()}
@@ -182,7 +184,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
 
     const stmt = this.db.prepare<NoteRow>(`
       SELECT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at,
-             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority
+             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority, n.board_order
       FROM notes_fts fts
       JOIN notes n ON fts.id = n.id
       WHERE notes_fts MATCH ? ${archivedCondition}
@@ -625,6 +627,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       status: string;
       board_stage: string | null;
       priority: string | null;
+      board_order: number;
       local_version: number;
       last_synced_at: string | null;
     }>(`
@@ -649,6 +652,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
       status: string;
       board_stage: string | null;
       priority: string | null;
+      board_order: number;
       local_version: number;
       last_synced_at: string | null;
     }>;

--- a/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
+++ b/packages/storage-sqlite/src/repositories/SQLiteNoteRepository.ts
@@ -20,6 +20,9 @@ import {
   rowToNote,
   prepareFtsQuery,
   archivedConditionSql,
+  noteColumns,
+  NOTE_COLUMNS,
+  NOTE_UPDATABLE_COLUMNS,
   type NoteRow,
   type TagRow,
   type TagWithColorRow,
@@ -55,8 +58,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
   /** Get a note by ID (includes archived notes) */
   async get(id: NoteId): Promise<Note | null> {
     const stmt = this.db.prepare<NoteRow>(`
-      SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-             is_pinned, is_deleted, status, board_stage, priority, board_order
+      SELECT ${noteColumns()}
       FROM notes
       WHERE id = ?
     `);
@@ -71,42 +73,36 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
   /** Save a note (insert or update) */
   async save(note: Note): Promise<void> {
     this.db.transaction(() => {
-      // Upsert note
+      // Upsert note. Columns/values/SET are all derived from NOTE_COLUMNS, and
+      // bound by name, so adding a column can't silently misalign positions.
+      const cols = NOTE_COLUMNS.join(', ');
+      const values = NOTE_COLUMNS.map(c => `@${c}`).join(', ');
+      const setClause = NOTE_UPDATABLE_COLUMNS.map(c => `${c} = excluded.${c}`).join(
+        ',\n          '
+      );
       const stmt = this.db.prepare(`
-        INSERT INTO notes (id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-                           is_pinned, is_deleted, status, board_stage, priority, board_order)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO notes (${cols})
+        VALUES (${values})
         ON CONFLICT(id) DO UPDATE SET
-          notebook_id = excluded.notebook_id,
-          content = excluded.content,
-          title = excluded.title,
-          updated_at = excluded.updated_at,
-          word_count = excluded.word_count,
-          archived_at = excluded.archived_at,
-          is_pinned = excluded.is_pinned,
-          is_deleted = excluded.is_deleted,
-          status = excluded.status,
-          board_stage = excluded.board_stage,
-          priority = excluded.priority,
-          board_order = excluded.board_order
+          ${setClause}
       `);
 
-      stmt.run(
-        note.id,
-        note.notebookId,
-        note.content,
-        note.title, // Use structural title
-        note.metadata.createdAt,
-        note.metadata.updatedAt,
-        note.metadata.wordCount,
-        note.metadata.archivedAt,
-        note.isPinned ? 1 : 0,
-        note.isDeleted ? 1 : 0,
-        note.status,
-        note.boardStage,
-        note.priority,
-        note.boardOrder
-      );
+      stmt.run({
+        id: note.id,
+        notebook_id: note.notebookId,
+        content: note.content,
+        title: note.title, // Use structural title
+        created_at: note.metadata.createdAt,
+        updated_at: note.metadata.updatedAt,
+        word_count: note.metadata.wordCount,
+        archived_at: note.metadata.archivedAt,
+        is_pinned: note.isPinned ? 1 : 0,
+        is_deleted: note.isDeleted ? 1 : 0,
+        status: note.status,
+        board_stage: note.boardStage,
+        priority: note.priority,
+        board_order: note.boardOrder,
+      });
 
       // Update content-extracted tags (preserves manual tags)
       this.syncExtractedTags(note.id, note.metadata.tags);
@@ -162,8 +158,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
 
     if (tag) {
       sql = `
-        SELECT DISTINCT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at, n.word_count, n.archived_at,
-               n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority, n.board_order
+        SELECT DISTINCT ${noteColumns('n')}
         FROM notes n
         JOIN note_tags nt ON n.id = nt.note_id
         JOIN tags t ON nt.tag_id = t.id
@@ -176,8 +171,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
         : [tag.toLowerCase(), limit, offset];
     } else {
       sql = `
-        SELECT id, notebook_id, content, title, created_at, updated_at, word_count, archived_at,
-               is_pinned, is_deleted, status, board_stage, priority, board_order
+        SELECT ${noteColumns('n')}
         FROM notes n
         WHERE 1=1 ${archivedCondition} ${notebookCondition}
         ORDER BY ${sortColumn} ${sortOrder.toUpperCase()}
@@ -212,8 +206,7 @@ export class SQLiteNoteRepository implements ExtendedNoteRepository {
     const ftsQuery = prepareFtsQuery(trimmedQuery);
 
     const stmt = this.db.prepare<NoteRow>(`
-      SELECT n.id, n.notebook_id, n.content, n.title, n.created_at, n.updated_at,
-             n.word_count, n.archived_at, n.is_pinned, n.is_deleted, n.status, n.board_stage, n.priority, n.board_order
+      SELECT ${noteColumns('n')}
       FROM notes_fts fts
       JOIN notes n ON fts.id = n.id
       WHERE notes_fts MATCH ? ${archivedCondition}

--- a/packages/storage-sqlite/src/repositories/noteMapping.ts
+++ b/packages/storage-sqlite/src/repositories/noteMapping.ts
@@ -36,6 +36,7 @@ export interface NoteRow {
   status: string;
   board_stage: string | null;
   priority: string | null;
+  board_order: number;
 }
 
 /** Row shape for tag joins (just the tag name) */
@@ -85,6 +86,7 @@ export function rowToNote(row: NoteRow, tags: Tag[]): Note {
     status: (row.status as NoteStatus) || DEFAULT_NOTE_STATUS,
     boardStage: (row.board_stage as BoardStage | null) ?? null,
     priority: (row.priority as NotePriority) || DEFAULT_NOTE_PRIORITY,
+    boardOrder: row.board_order ?? 0,
     metadata: {
       ...note.metadata,
       title: row.title,

--- a/packages/storage-sqlite/src/repositories/noteMapping.ts
+++ b/packages/storage-sqlite/src/repositories/noteMapping.ts
@@ -21,6 +21,36 @@ import {
 } from '@dripnex/core';
 import type { ArchivedFilter } from '@dripnex/storage-core';
 
+/**
+ * The full ordered column list for the `notes` table — the single source of
+ * truth for SELECT lists and the upsert. Adding a note column means editing
+ * this array (plus the row type below and a migration), not 8 SQL statements.
+ */
+export const NOTE_COLUMNS = [
+  'id',
+  'notebook_id',
+  'content',
+  'title',
+  'created_at',
+  'updated_at',
+  'word_count',
+  'archived_at',
+  'is_pinned',
+  'is_deleted',
+  'status',
+  'board_stage',
+  'priority',
+  'board_order',
+] as const;
+
+/** Columns rewritten on an upsert conflict (everything except id/created_at). */
+export const NOTE_UPDATABLE_COLUMNS = NOTE_COLUMNS.filter(c => c !== 'id' && c !== 'created_at');
+
+/** Render the note column list for a SELECT, optionally alias-prefixed (e.g. `n`). */
+export function noteColumns(alias?: string): string {
+  return alias ? NOTE_COLUMNS.map(c => `${alias}.${c}`).join(', ') : NOTE_COLUMNS.join(', ');
+}
+
 /** Row shape returned by `SELECT * FROM notes` */
 export interface NoteRow {
   id: string;

--- a/packages/storage-sqlite/src/repositories/noteMapping.ts
+++ b/packages/storage-sqlite/src/repositories/noteMapping.ts
@@ -9,6 +9,7 @@
 import {
   type Note,
   type NoteStatus,
+  type BoardStage,
   type Tag,
   type Timestamp,
   createNote,
@@ -31,6 +32,7 @@ export interface NoteRow {
   is_pinned: number; // SQLite stores booleans as 0/1
   is_deleted: number;
   status: string;
+  board_stage: string | null;
 }
 
 /** Row shape for tag joins (just the tag name) */
@@ -78,6 +80,7 @@ export function rowToNote(row: NoteRow, tags: Tag[]): Note {
     isPinned: row.is_pinned === 1,
     isDeleted: row.is_deleted === 1,
     status: (row.status as NoteStatus) || DEFAULT_NOTE_STATUS,
+    boardStage: (row.board_stage as BoardStage | null) ?? null,
     metadata: {
       ...note.metadata,
       title: row.title,

--- a/packages/storage-sqlite/src/repositories/noteMapping.ts
+++ b/packages/storage-sqlite/src/repositories/noteMapping.ts
@@ -10,12 +10,14 @@ import {
   type Note,
   type NoteStatus,
   type BoardStage,
+  type NotePriority,
   type Tag,
   type Timestamp,
   createNote,
   createNoteId,
   createNotebookId,
   DEFAULT_NOTE_STATUS,
+  DEFAULT_NOTE_PRIORITY,
 } from '@dripnex/core';
 import type { ArchivedFilter } from '@dripnex/storage-core';
 
@@ -33,6 +35,7 @@ export interface NoteRow {
   is_deleted: number;
   status: string;
   board_stage: string | null;
+  priority: string | null;
 }
 
 /** Row shape for tag joins (just the tag name) */
@@ -81,6 +84,7 @@ export function rowToNote(row: NoteRow, tags: Tag[]): Note {
     isDeleted: row.is_deleted === 1,
     status: (row.status as NoteStatus) || DEFAULT_NOTE_STATUS,
     boardStage: (row.board_stage as BoardStage | null) ?? null,
+    priority: (row.priority as NotePriority) || DEFAULT_NOTE_PRIORITY,
     metadata: {
       ...note.metadata,
       title: row.title,

--- a/packages/storage-sqlite/tests/repository.test.ts
+++ b/packages/storage-sqlite/tests/repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { runMigrations } from '@dripnex/storage-core';
-import { createNote, createNoteId } from '@dripnex/core';
+import { createNote, createNoteId, setBoardStage, PLANNING_NOTEBOOK_ID } from '@dripnex/core';
 import { createInMemoryDatabase, type DatabaseConnection } from '../src/database.js';
 import { allMigrations } from '../src/migrations/index.js';
 import { SQLiteNoteRepository } from '../src/repositories/SQLiteNoteRepository.js';
@@ -57,6 +57,42 @@ describe('SQLiteNoteRepository', () => {
 
       const retrieved = await repository.get(note.id);
       expect(retrieved!.metadata.title).toBe('Updated Content');
+    });
+  });
+
+  describe('board stage (Kanban)', () => {
+    it('defaults to null for a regular note and round-trips through save/get', async () => {
+      const note = createNote({ id: createNoteId('board-1'), content: '# Task' });
+      expect(note.boardStage).toBeNull();
+
+      await repository.save(note);
+      const retrieved = await repository.get(note.id);
+      expect(retrieved!.boardStage).toBeNull();
+    });
+
+    it('persists an updated board stage', async () => {
+      const note = createNote({
+        id: createNoteId('board-2'),
+        content: '# Task',
+        notebookId: PLANNING_NOTEBOOK_ID,
+      });
+      await repository.save(note);
+
+      const moved = setBoardStage(note, 'in_progress');
+      await repository.save(moved);
+
+      const retrieved = await repository.get(note.id);
+      expect(retrieved!.boardStage).toBe('in_progress');
+      // Moving a card must not touch the markdown content
+      expect(retrieved!.content).toBe(note.content);
+    });
+
+    it('seeds the special Planning notebook (idempotent migration)', () => {
+      const row = db
+        .prepare('SELECT id, name FROM notebooks WHERE id = ?')
+        .get(PLANNING_NOTEBOOK_ID) as { id: string; name: string } | undefined;
+      expect(row).toBeDefined();
+      expect(row!.name).toBe('Planning');
     });
   });
 

--- a/packages/storage-sqlite/tests/repository.test.ts
+++ b/packages/storage-sqlite/tests/repository.test.ts
@@ -94,6 +94,27 @@ describe('SQLiteNoteRepository', () => {
       expect(row).toBeDefined();
       expect(row!.name).toBe('Planning');
     });
+
+    it('list() carries board fields and honors the notebookId filter', async () => {
+      const planned = createNote({
+        id: createNoteId('l1'),
+        content: '# L',
+        notebookId: PLANNING_NOTEBOOK_ID,
+        priority: 'high',
+      });
+      const other = createNote({ id: createNoteId('l2'), content: '# Other' }); // Inbox
+      await repository.save(planned);
+      await repository.save(other);
+
+      const rows = await repository.list({ notebookId: PLANNING_NOTEBOOK_ID, limit: 100 });
+
+      expect(rows.some(r => r.id === other.id)).toBe(false); // notebook filter works
+      const found = rows.find(r => r.id === planned.id);
+      expect(found).toBeDefined();
+      expect(found!.boardStage).toBe('backlog'); // created in the Planning notebook
+      expect(found!.priority).toBe('high');
+      expect(typeof found!.boardOrder).toBe('number');
+    });
   });
 
   describe('reorderBoard', () => {

--- a/packages/storage-sqlite/tests/repository.test.ts
+++ b/packages/storage-sqlite/tests/repository.test.ts
@@ -96,6 +96,53 @@ describe('SQLiteNoteRepository', () => {
     });
   });
 
+  describe('reorderBoard', () => {
+    it('reindexes a column atomically and only touches Planning notes', async () => {
+      const a = createNote({
+        id: createNoteId('a'),
+        content: '# A',
+        notebookId: PLANNING_NOTEBOOK_ID,
+      });
+      const b = createNote({
+        id: createNoteId('b'),
+        content: '# B',
+        notebookId: PLANNING_NOTEBOOK_ID,
+      });
+      const outsider = createNote({ id: createNoteId('out'), content: '# Out' }); // Inbox
+      await repository.save(a);
+      await repository.save(b);
+      await repository.save(outsider);
+
+      repository.reorderBoard('todo', ['b', 'a', 'out']);
+
+      const ra = await repository.get(a.id);
+      const rb = await repository.get(b.id);
+      const ro = await repository.get(outsider.id);
+
+      expect(rb!.boardStage).toBe('todo');
+      expect(rb!.boardOrder).toBe(0);
+      expect(ra!.boardStage).toBe('todo');
+      expect(ra!.boardOrder).toBe(1);
+      // A non-Planning note is ignored by the notebook_id guard.
+      expect(ro!.boardStage).toBeNull();
+    });
+
+    it('does not modify note content (markdown is sacred)', async () => {
+      const note = createNote({
+        id: createNoteId('c'),
+        content: '# Keep me\n\nbody',
+        notebookId: PLANNING_NOTEBOOK_ID,
+      });
+      await repository.save(note);
+
+      repository.reorderBoard('in_progress', ['c']);
+
+      const r = await repository.get(note.id);
+      expect(r!.content).toBe('# Keep me\n\nbody');
+      expect(r!.boardStage).toBe('in_progress');
+    });
+  });
+
   describe('tags', () => {
     it('saves and retrieves tags', async () => {
       const note = createNote({

--- a/packages/storage-sqlite/tests/repository.test.ts
+++ b/packages/storage-sqlite/tests/repository.test.ts
@@ -148,19 +148,22 @@ describe('SQLiteNoteRepository', () => {
       expect(ro!.boardStage).toBeNull();
     });
 
-    it('does not modify note content (markdown is sacred)', async () => {
+    it('does not modify note content or updatedAt (markdown is sacred)', async () => {
       const note = createNote({
         id: createNoteId('c'),
         content: '# Keep me\n\nbody',
         notebookId: PLANNING_NOTEBOOK_ID,
       });
       await repository.save(note);
+      const before = await repository.get(note.id);
 
       repository.reorderBoard('in_progress', ['c']);
 
       const r = await repository.get(note.id);
       expect(r!.content).toBe('# Keep me\n\nbody');
       expect(r!.boardStage).toBe('in_progress');
+      // Reordering is metadata-only; it must not touch content-derived timestamps.
+      expect(r!.metadata.updatedAt).toBe(before!.metadata.updatedAt);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a **Planning Kanban board** reachable from the sidebar — a Linear-style board over the notes in a reserved "Planning" notebook, with a Board↔Graph toggle. This PR now contains **both layers** (the UI PR #445 was auto-merged into this branch, so #444 is the single combined PR to `develop`).

> ⚠️ Held as **draft** until CodeRabbit review is complete and its comments are resolved (per our CodeRabbit-first rule). Auto-merge intentionally disabled.

Two product decisions (agreed with the user):
- A note is a board card if it lives in a reserved **Planning notebook** (mirrors the Inbox pattern: fixed id, auto-seeded, undeletable).
- Board columns are **Linear-style** (`backlog / todo / in_progress / in_review / in_staging`) via a new `boardStage` field.

**Markdown is sacred:** `boardStage` is DB metadata, changed via `setBoardStage` (no content/`updatedAt` change) — moving a card never rewrites markdown.

## Data layer (core / storage / IPC / preload)
- `BoardStage`, `BOARD_STAGES`, `DEFAULT_BOARD_STAGE`, `PLANNING_NOTEBOOK_ID`
- `Note.boardStage` + `setBoardStage()`; `createNote` defaults to `backlog` in the Planning notebook else `null`
- `createPlanningNotebook()` + `isPlanning()`; Planning notebook undeletable
- `boardStage` on `NoteSnapshot`/`NoteSummary`
- Migration `018`: `board_stage` column + index, idempotent Planning-notebook seed
- `notes:setBoardStage` IPC handler; `window.dripnex.notes.setBoardStage`; `noteToSnapshot` carries it; `SyncService` new-note literal sets `null`

## UI (renderer)
- `NavigationState` `planning` kind + `goToPlanning` + `selectIsPlanningContext`
- Sidebar **Planning** item (`KanbanSquare`)
- `PlanningBoard` (5 columns + Board/Graph toggle), `PlanningColumn` (droppable), `PlanningCard` (draggable; title, excerpt, tags, `countMarkdownTasks` progress; click opens note)
- Native HTML5 DnD (`application/x-dripnex-note`), no new deps
- Graph mode reuses `GraphView` via a new optional `filterNotebookId` prop
- `useNoteMutations.setBoardStage`

## Testing
- `pnpm typecheck` / `pnpm test` / `pnpm lint` — green
- `pnpm --filter @dripnex/desktop build` — bundles OK
- New core + storage tests (boardStage semantics, round-trip persistence, idempotent seed) pass
- ⚠️ 2 pre-existing FTS `search-by-title` tests fail on `develop` too (verified via stash) — untouched
- Manual smoke test on `pnpm dev` pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Planning (Kanban) board with draggable columns, stage changes, priority labels, search/tag/priority filtering, and board-specific note actions (move/remove/delete).
  * Added Planning navigation in the sidebar and a dedicated Planning view, including a graph mode filtered to the Planning notebook.
  * Extended note listing to optionally filter by notebook.

* **Bug Fixes**
  * Improved board-stage persistence across create/update/duplicate/sync and ensured note snapshots always include board-stage data and metadata stays stable during stage-only updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->