### PR TITLE
feat(planning): Planning Kanban board UI + graph toggle

### DIFF
--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -65,6 +65,7 @@ import type {
 export type {
   Result,
   NoteStatus,
+  BoardStage,
   NoteSnapshot,
   NotebookSnapshot,
   NotebookWithMetadata,

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import {
 import type { EditorAPIWithEvents, AppAPIWithEvents, DataAPIWithEvents } from '@dripnex/plugin-api';
 import type { RegisteredCommand } from '@dripnex/command-registry';
 import { useStore } from 'zustand';
+import { PLANNING_NOTEBOOK_ID } from '@dripnex/core';
 import type { NoteSnapshot } from '../preload/index';
 import { UpdateBanner } from './components/UpdateBanner';
 import { NoteList } from './components/NoteList';
@@ -21,6 +22,7 @@ import { NoteEditor } from './components/NoteEditor';
 import { NoteWindow } from './components/NoteWindow';
 import { Sidebar } from './components/sidebar';
 import { GraphView } from './components/GraphView';
+import { PlanningBoard } from './components/planning/PlanningBoard';
 import { CommandPalette } from './components/CommandPalette';
 import { AiPanel } from './components/ai/AiPanel';
 import { LicenseProvider } from './contexts/LicenseContext';
@@ -120,7 +122,7 @@ function NotesApp() {
   const selectedTag = useSelectedTag();
   const sortBy = useSortBy();
   const sortOrder = useSortOrder();
-  const { goToTag, setSort } = useNavigationActions();
+  const { goToTag, goToNotebook, setSort } = useNavigationActions();
 
   // Load tag colors on mount (once)
   useEffect(() => {
@@ -581,7 +583,14 @@ function NotesApp() {
             />
 
             <main className="app__editor">
-              {isGraphOpen ? (
+              {navigation.kind === 'planning' ? (
+                <PlanningBoard
+                  onOpenNote={noteId => {
+                    goToNotebook(PLANNING_NOTEBOOK_ID);
+                    void handleSelectNote(noteId);
+                  }}
+                />
+              ) : isGraphOpen ? (
                 <GraphView
                   selectedNoteId={selectedNote?.id}
                   onNodeClick={noteId => {

--- a/apps/desktop/src/renderer/components/GraphView.tsx
+++ b/apps/desktop/src/renderer/components/GraphView.tsx
@@ -18,6 +18,8 @@ interface GraphViewProps {
   onNodeClick?: (noteId: string) => void;
   /** Callback to close the graph view */
   onClose?: () => void;
+  /** When set, restrict the graph to notes in this notebook (and links between them) */
+  filterNotebookId?: string;
 }
 
 interface GraphNode {
@@ -31,7 +33,12 @@ interface GraphNode {
   vy?: number;
 }
 
-export function GraphView({ selectedNoteId, onNodeClick, onClose }: GraphViewProps) {
+export function GraphView({
+  selectedNoteId,
+  onNodeClick,
+  onClose,
+  filterNotebookId,
+}: GraphViewProps) {
   const { data, isLoading, error } = useGraphData();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const graphRef = useRef<any>(null);
@@ -40,18 +47,28 @@ export function GraphView({ selectedNoteId, onNodeClick, onClose }: GraphViewPro
   const graphData = useMemo(() => {
     if (!data) return { nodes: [], links: [] };
 
+    // Optionally restrict to a single notebook (e.g. the Planning board),
+    // keeping only links whose endpoints both remain in the filtered set.
+    const nodes = filterNotebookId
+      ? data.nodes.filter(n => n.notebookId === filterNotebookId)
+      : data.nodes;
+    const includedIds = new Set(nodes.map(n => n.id));
+    const edges = filterNotebookId
+      ? data.edges.filter(e => includedIds.has(e.source) && includedIds.has(e.target))
+      : data.edges;
+
     return {
-      nodes: data.nodes.map(n => ({
+      nodes: nodes.map(n => ({
         id: n.id,
         title: n.title,
         notebookId: n.notebookId,
       })),
-      links: data.edges.map(e => ({
+      links: edges.map(e => ({
         source: e.source,
         target: e.target,
       })),
     };
-  }, [data]);
+  }, [data, filterNotebookId]);
 
   // Node color based on selection (using hex - CSS vars don't work in canvas)
   const getNodeColor = useCallback(

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -1,0 +1,186 @@
+.planning-board {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  background: var(--bg-base);
+}
+
+.planning-board__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex: 0 0 auto;
+}
+
+.planning-board__title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.planning-board__toggle {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-surface);
+}
+
+.planning-board__toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.planning-board__toggle-btn.is-active {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.planning-board__columns {
+  display: flex;
+  gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 16px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.planning-board__graph {
+  flex: 1 1 auto;
+  min-height: 0;
+  position: relative;
+}
+
+/* Columns */
+.planning-column {
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 280px;
+  min-height: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.planning-column--over {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.planning-column__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.planning-column__title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.planning-column__count {
+  font-size: 11px;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+
+.planning-column__cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Cards */
+.planning-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elevated);
+  cursor: pointer;
+  user-select: none;
+}
+
+.planning-card:hover {
+  border-color: var(--accent-muted);
+}
+
+.planning-card__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.planning-card__excerpt {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.planning-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.planning-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  min-width: 0;
+}
+
+.planning-card__tag {
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-subtle);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
+.planning-card__tasks {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+import { KanbanSquare, Network } from 'lucide-react';
+import { BOARD_STAGES, PLANNING_NOTEBOOK_ID } from '@dripnex/core';
+import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import { useNotes, useNoteMutations } from '../../hooks/useNotes';
+import { GraphView } from '../GraphView';
+import { PlanningColumn } from './PlanningColumn';
+import './PlanningBoard.css';
+
+interface PlanningBoardProps {
+  /** Open a note in the editor (leaves the board). */
+  readonly onOpenNote: (id: string) => void;
+}
+
+type ViewMode = 'board' | 'graph';
+
+/**
+ * The Planning view: a Linear-style Kanban board over the notes in the
+ * reserved Planning notebook, plus a graph mode that reuses GraphView filtered
+ * to those same notes. Dragging a card persists its stage via boardStage
+ * (DB metadata only — never rewrites the note's markdown).
+ */
+export function PlanningBoard({ onOpenNote }: PlanningBoardProps) {
+  const [mode, setMode] = useState<ViewMode>('board');
+  const { data: allNotes } = useNotes({
+    sortBy: 'updatedAt',
+    sortOrder: 'desc',
+    archived: 'active',
+  });
+  const { setBoardStage } = useNoteMutations();
+
+  const planningNotes = useMemo(
+    () =>
+      (allNotes ?? []).filter(
+        n => n.notebookId === PLANNING_NOTEBOOK_ID && !n.isDeleted && !n.isArchived
+      ),
+    [allNotes]
+  );
+
+  const notesByStage = useMemo(() => {
+    const groups: Record<BoardStage, NoteSnapshot[]> = {
+      backlog: [],
+      todo: [],
+      in_progress: [],
+      in_review: [],
+      in_staging: [],
+    };
+    for (const note of planningNotes) {
+      // Notes with no explicit stage (e.g. moved into the notebook) land in Backlog.
+      const stage = note.boardStage ?? 'backlog';
+      groups[stage].push(note);
+    }
+    return groups;
+  }, [planningNotes]);
+
+  const handleDropNote = (noteId: string, stage: BoardStage) => {
+    setBoardStage.mutate({ id: noteId, boardStage: stage });
+  };
+
+  return (
+    <div className="planning-board">
+      <header className="planning-board__header">
+        <h2 className="planning-board__title">Planning</h2>
+        <div className="planning-board__toggle" role="tablist" aria-label="Planning view mode">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'board'}
+            className={`planning-board__toggle-btn ${mode === 'board' ? 'is-active' : ''}`}
+            onClick={() => setMode('board')}
+          >
+            <KanbanSquare size={14} /> Board
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'graph'}
+            className={`planning-board__toggle-btn ${mode === 'graph' ? 'is-active' : ''}`}
+            onClick={() => setMode('graph')}
+          >
+            <Network size={14} /> Graph
+          </button>
+        </div>
+      </header>
+
+      {mode === 'board' ? (
+        <div className="planning-board__columns">
+          {BOARD_STAGES.map(stage => (
+            <PlanningColumn
+              key={stage}
+              stage={stage}
+              notes={notesByStage[stage]}
+              onDropNote={handleDropNote}
+              onOpenNote={onOpenNote}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="planning-board__graph">
+          <GraphView filterNotebookId={PLANNING_NOTEBOOK_ID} onNodeClick={onOpenNote} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningCard.tsx
@@ -1,0 +1,63 @@
+import { memo, useCallback } from 'react';
+import { countMarkdownTasks } from '@dripnex/tasks';
+import type { NoteSnapshot } from '../../../preload/index';
+import { extractExcerpt } from '../../hooks/useNotes';
+import { NOTE_MIME } from './constants';
+
+interface PlanningCardProps {
+  readonly note: NoteSnapshot;
+  readonly onOpen: (id: string) => void;
+}
+
+/**
+ * A draggable card on the Planning board. Dragging carries the note id via a
+ * custom MIME type; dropping on a column updates the note's boardStage.
+ */
+export const PlanningCard = memo(function PlanningCard({ note, onOpen }: PlanningCardProps) {
+  const handleDragStart = useCallback(
+    (e: React.DragEvent) => {
+      e.dataTransfer.setData(NOTE_MIME, note.id);
+      e.dataTransfer.setData('text/plain', note.id);
+      e.dataTransfer.effectAllowed = 'move';
+    },
+    [note.id]
+  );
+
+  const tasks = countMarkdownTasks(note.content);
+  const excerpt = extractExcerpt(note.content, 120);
+
+  return (
+    <article
+      className="planning-card"
+      draggable
+      onDragStart={handleDragStart}
+      onClick={() => onOpen(note.id)}
+      onKeyDown={e => {
+        if (e.key === 'Enter') onOpen(note.id);
+      }}
+      role="button"
+      tabIndex={0}
+    >
+      <h4 className="planning-card__title">{note.title || 'Untitled'}</h4>
+      {excerpt && <p className="planning-card__excerpt">{excerpt}</p>}
+      {(note.tags.length > 0 || tasks.total > 0) && (
+        <div className="planning-card__footer">
+          {note.tags.length > 0 && (
+            <div className="planning-card__tags">
+              {note.tags.slice(0, 3).map(tag => (
+                <span key={tag} className="planning-card__tag">
+                  #{tag}
+                </span>
+              ))}
+            </div>
+          )}
+          {tasks.total > 0 && (
+            <span className="planning-card__tasks" title="Task progress">
+              {tasks.completed}/{tasks.total}
+            </span>
+          )}
+        </div>
+      )}
+    </article>
+  );
+});

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -1,0 +1,65 @@
+import { memo, useCallback, useState } from 'react';
+import type { NoteSnapshot, BoardStage } from '../../../preload/index';
+import { PlanningCard } from './PlanningCard';
+import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
+
+interface PlanningColumnProps {
+  readonly stage: BoardStage;
+  readonly notes: readonly NoteSnapshot[];
+  readonly onDropNote: (noteId: string, stage: BoardStage) => void;
+  readonly onOpenNote: (id: string) => void;
+}
+
+/** A droppable Kanban column for a single board stage. */
+export const PlanningColumn = memo(function PlanningColumn({
+  stage,
+  notes,
+  onDropNote,
+  onOpenNote,
+}: PlanningColumnProps) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes(NOTE_MIME)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setIsOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLElement>) => {
+    // Only clear when the pointer actually leaves the column (not a child).
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsOver(false);
+      const noteId = e.dataTransfer.getData(NOTE_MIME);
+      if (noteId) onDropNote(noteId, stage);
+    },
+    [onDropNote, stage]
+  );
+
+  return (
+    <section
+      className={`planning-column ${isOver ? 'planning-column--over' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      aria-label={BOARD_STAGE_LABELS[stage]}
+    >
+      <header className="planning-column__header">
+        <span className="planning-column__title">{BOARD_STAGE_LABELS[stage]}</span>
+        <span className="planning-column__count">{notes.length}</span>
+      </header>
+      <div className="planning-column__cards">
+        {notes.map(note => (
+          <PlanningCard key={note.id} note={note} onOpen={onOpenNote} />
+        ))}
+      </div>
+    </section>
+  );
+});

--- a/apps/desktop/src/renderer/components/planning/constants.ts
+++ b/apps/desktop/src/renderer/components/planning/constants.ts
@@ -1,0 +1,13 @@
+import type { BoardStage } from '../../../preload/index';
+
+/** Custom MIME type used to carry a note id during Kanban drag-and-drop. */
+export const NOTE_MIME = 'application/x-dripnex-note';
+
+/** Human-readable column titles for each board stage. */
+export const BOARD_STAGE_LABELS: Record<BoardStage, string> = {
+  backlog: 'Backlog',
+  todo: 'Todo',
+  in_progress: 'In Progress',
+  in_review: 'In Review',
+  in_staging: 'In Staging',
+};

--- a/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { LayoutZone } from '@dripnex/plugin-api';
 import {
   useIsNotebookContext,
+  useIsPlanningContext,
   useSelectedNotebookId,
   useGlobalFilter,
   useNavigationActions,
@@ -51,6 +52,7 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
 
   // Granular selectors
   const isNotebookContext = useIsNotebookContext();
+  const isPlanningContext = useIsPlanningContext();
   const selectedNotebookId = useSelectedNotebookId();
   const globalFilter = useGlobalFilter();
   const globalCounts = useGlobalCounts();
@@ -67,6 +69,7 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
     goToPinned,
     goToTrash,
     goToNotebook,
+    goToPlanning,
     clearNavigation,
     setStatusFilter,
     setTagFilter,
@@ -124,6 +127,8 @@ export function Sidebar({ onOpenGraph }: SidebarProps) {
           }}
           isNotebookContext={isNotebookContext}
           onOpenGraph={onOpenGraph}
+          onOpenPlanning={goToPlanning}
+          isPlanningSelected={isPlanningContext}
         />
 
         <SidebarSection title="Notebooks" collapsible onAdd={openCreateInContext}>

--- a/apps/desktop/src/renderer/components/sidebar/SidebarQuickFilters.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SidebarQuickFilters.tsx
@@ -1,5 +1,5 @@
 import { memo } from 'react';
-import { FileText, Pin, Trash2, Network } from 'lucide-react';
+import { FileText, Pin, Trash2, Network, KanbanSquare } from 'lucide-react';
 
 export type QuickFilterType = 'all' | 'pinned' | 'trash';
 
@@ -11,6 +11,8 @@ interface SidebarQuickFiltersProps {
   readonly onSelectFilter: (filter: QuickFilterType) => void;
   readonly isNotebookContext?: boolean;
   readonly onOpenGraph?: () => void;
+  readonly onOpenPlanning?: () => void;
+  readonly isPlanningSelected?: boolean;
 }
 
 interface QuickFilterItemProps {
@@ -54,6 +56,8 @@ export const SidebarQuickFilters = memo(function SidebarQuickFilters({
   onSelectFilter,
   isNotebookContext = false,
   onOpenGraph,
+  onOpenPlanning,
+  isPlanningSelected = false,
 }: SidebarQuickFiltersProps) {
   return (
     <nav className="sidebar-quick-filters" aria-label="Quick filters">
@@ -81,6 +85,20 @@ export const SidebarQuickFilters = memo(function SidebarQuickFilters({
           isSelected={selectedFilter === 'trash'}
           onClick={() => onSelectFilter('trash')}
         />
+      )}
+      {onOpenPlanning && (
+        <button
+          type="button"
+          className={`sidebar-quick-filter ${isPlanningSelected ? 'selected' : ''}`}
+          onClick={onOpenPlanning}
+          aria-pressed={isPlanningSelected}
+          title="Open Planning board"
+        >
+          <span className="sidebar-quick-filter-icon" aria-hidden="true">
+            <KanbanSquare size={16} />
+          </span>
+          <span className="sidebar-quick-filter-label">Planning</span>
+        </button>
       )}
       {onOpenGraph && (
         <button

--- a/apps/desktop/src/renderer/hooks/useNavigation.ts
+++ b/apps/desktop/src/renderer/hooks/useNavigation.ts
@@ -6,6 +6,7 @@ import {
   selectStatusFilter,
   selectTagFilter,
   selectIsNotebookContext,
+  selectIsPlanningContext,
   selectSelectedNotebookId,
   selectGlobalFilter,
   selectSelectedTag,
@@ -51,6 +52,9 @@ export const useTagFilter = () => useNavigationStore(selectTagFilter);
 /** Check if in notebook context */
 export const useIsNotebookContext = () => useNavigationStore(selectIsNotebookContext);
 
+/** Check if in planning (Kanban board) context */
+export const useIsPlanningContext = () => useNavigationStore(selectIsPlanningContext);
+
 /** Get selected notebook ID (null if not in notebook view) */
 export const useSelectedNotebookId = () => useNavigationStore(selectSelectedNotebookId);
 
@@ -79,6 +83,7 @@ export function useNavigationActions() {
   const goToNotebook = useNavigationStore(s => s.goToNotebook);
   const goToTag = useNavigationStore(s => s.goToTag);
   const goToSearch = useNavigationStore(s => s.goToSearch);
+  const goToPlanning = useNavigationStore(s => s.goToPlanning);
   const clearNavigation = useNavigationStore(s => s.clearNavigation);
   const setStatusFilter = useNavigationStore(s => s.setStatusFilter);
   const setTagFilter = useNavigationStore(s => s.setTagFilter);
@@ -93,6 +98,7 @@ export function useNavigationActions() {
     goToNotebook,
     goToTag,
     goToSearch,
+    goToPlanning,
     clearNavigation,
     setStatusFilter,
     setTagFilter,
@@ -154,6 +160,12 @@ export function useFilteredNotes(): NoteWithExcerpt[] {
       case 'search':
         // Search is handled separately via useSearchNotes
         notes = notes.filter(n => !n.isDeleted && !n.isArchived);
+        break;
+
+      case 'planning':
+        // The Planning board fetches and groups its own notes by boardStage;
+        // the standard note list is empty in this view.
+        notes = [];
         break;
     }
 

--- a/apps/desktop/src/renderer/hooks/useNotes.ts
+++ b/apps/desktop/src/renderer/hooks/useNotes.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import type { ListOptions, NoteStatus, NoteSnapshot } from '../../preload/index';
+import type { ListOptions, NoteStatus, BoardStage, NoteSnapshot } from '../../preload/index';
 
 // ============================================================================
 // Excerpt Helper (shared between filtered notes and search results)
@@ -234,6 +234,15 @@ export function useNoteMutations() {
     onSuccess: () => invalidateNotes(),
   });
 
+  const setBoardStage = useMutation({
+    mutationFn: async ({ id, boardStage }: { id: string; boardStage: BoardStage | null }) => {
+      const result = await window.dripnex.notes.setBoardStage(id, boardStage);
+      if (!result.ok) throw new Error(result.error.type);
+      return result.data;
+    },
+    onSuccess: () => invalidateNotes(),
+  });
+
   return {
     createNote,
     updateNote,
@@ -248,5 +257,6 @@ export function useNoteMutations() {
     softDeleteNote,
     restoreDeletedNote,
     setNoteStatus,
+    setBoardStage,
   };
 }

--- a/apps/desktop/src/renderer/stores/navigationStore.ts
+++ b/apps/desktop/src/renderer/stores/navigationStore.ts
@@ -12,7 +12,8 @@ export type NavigationState =
   | { kind: 'global'; filter: 'all' | 'pinned' | 'trash' }
   | { kind: 'notebook'; id: string }
   | { kind: 'tag'; name: string }
-  | { kind: 'search'; query: string };
+  | { kind: 'search'; query: string }
+  | { kind: 'planning' };
 
 /**
  * Status filter - orthogonal to navigation, can combine with any view
@@ -50,6 +51,7 @@ interface NavigationStore {
   goToNotebook: (id: string) => void;
   goToTag: (name: string) => void;
   goToSearch: (query: string) => void;
+  goToPlanning: () => void;
   clearNavigation: () => void;
 
   // Actions - Filters
@@ -98,6 +100,8 @@ export const useNavigationStore = create<NavigationStore>((set, get) => ({
   goToTag: name => set({ navigation: { kind: 'tag', name }, statusFilter: null, tagFilter: null }),
   goToSearch: query =>
     set({ navigation: { kind: 'search', query }, statusFilter: null, tagFilter: null }),
+  goToPlanning: () =>
+    set({ navigation: { kind: 'planning' }, statusFilter: null, tagFilter: null }),
   clearNavigation: () =>
     set({ navigation: DEFAULT_NAVIGATION, statusFilter: null, tagFilter: null }),
 
@@ -124,6 +128,9 @@ export const selectIsNotebookContext = (state: NavigationStore) =>
   state.navigation.kind === 'notebook';
 
 export const selectIsGlobalContext = (state: NavigationStore) => state.navigation.kind === 'global';
+
+export const selectIsPlanningContext = (state: NavigationStore) =>
+  state.navigation.kind === 'planning';
 
 export const selectIsTrashView = (state: NavigationStore) =>
   state.navigation.kind === 'global' && state.navigation.filter === 'trash';


### PR DESCRIPTION
## Summary

The UI half of the Planning Kanban feature. **Stacked on #444** (the data layer) — this PR's base is `feature/planning-kanban-data` and will auto-retarget to `develop` once #444 merges. Review #444 first.

Adds the **"Planning" sidebar item** and the **Kanban board** it opens. Columns are the 5 Linear-style stages; dragging a card persists via `notes.setBoardStage` — **DB metadata only, the note's markdown is never rewritten** ("markdown is sacred").

## What's included

**Navigation**
- `NavigationState` gains a `planning` kind + `goToPlanning` action + `selectIsPlanningContext`
- Sidebar **Planning** quick-filter item (`KanbanSquare`), active-state aware
- `App.tsx` renders `<PlanningBoard>` in the editor pane when `navigation.kind === 'planning'`

**Board** (`components/planning/`)
- `PlanningBoard` — groups Planning-notebook notes into Backlog/Todo/In Progress/In Review/In Staging; **Board ↔ Graph** toggle
- `PlanningColumn` — droppable column (native HTML5 DnD, custom `application/x-dripnex-note` MIME — the app's DnD convention, no new dep)
- `PlanningCard` — draggable card: title, excerpt, tags, task progress via `countMarkdownTasks`; click opens the note
- Graph mode reuses `GraphView` via a new optional `filterNotebookId` prop that restricts nodes/edges to the Planning notebook

**Hooks**: `useNoteMutations.setBoardStage`; `BoardStage` re-exported from preload.

## Testing
- `pnpm typecheck` (all desktop projects) — green
- `pnpm test` — green; `pnpm lint` — green
- `pnpm --filter @dripnex/desktop build` — bundles successfully
- Manual smoke test pending on `pnpm dev` (Planning item → board → drag persists → markdown unchanged → graph toggle)

## How it connects to the graph
No new graph infra — the existing `GraphView` / `useGraphData` / `window.dripnex.links` are reused; `filterNotebookId` scopes them to the board's notes (nodes already carry `notebookId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)