### PR TITLE
ci: make owner auto-merge opt-in via automerge label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,18 +2,25 @@ name: Auto-merge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
+  # Owner PRs are auto-merged ONLY when explicitly opted in with the `automerge`
+  # label. This prevents PRs from merging before review (e.g. before CodeRabbit
+  # comments are resolved) and prevents stacked PRs targeting an unprotected
+  # feature branch from merging the instant CI passes. Add the label when the PR
+  # is actually ready to merge; don't add it (or remove it) to hold.
   automerge-owner:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'tomymaritano'
+    if: >-
+      github.event.pull_request.user.login == 'tomymaritano' &&
+      contains(github.event.pull_request.labels.*.name, 'automerge')
     steps:
-      - name: Enable auto-merge for owner PRs
+      - name: Enable auto-merge for opted-in owner PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Problem

The Auto-merge workflow enabled auto-merge on **every** owner PR on `opened`/`synchronize`/`reopened`/`ready_for_review`. Consequences:

- PRs to `develop` had auto-merge enabled automatically, so they merged the moment branch protection was satisfied — **before CodeRabbit review was resolved** (the exact CodeRabbit-first violation we keep hitting).
- **Stacked PRs targeting an unprotected feature branch merged instantly** (no protection to hold them). This is what collapsed the stacked UI PR (#445) into its base branch before review.

## Fix

Owner auto-merge is now **opt-in via the `automerge` label**:
- The `automerge-owner` job only runs when the PR carries the `automerge` label, and the workflow now also reacts to the `labeled` event.
- Add the label when a PR is genuinely ready to merge; leave it off (or remove it) to hold — no more surprise merges.
- Dependabot auto-merge is unchanged.

The `automerge` label has been created in the repo.

## Testing
Workflow-only change (YAML). Verified the `if:` uses `contains(github.event.pull_request.labels.*.name, 'automerge')` and the `labeled` trigger is present so applying the label enables auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated merge behavior to require both a matching PR author and an automation label before merging.
  * Expanded event handling so labeled pull requests are evaluated for auto-merge eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->