### PR TITLE
feat(planning): per-column WIP limits

### DIFF
--- a/apps/desktop/src/renderer/components/planning/PlanningBoard.css
+++ b/apps/desktop/src/renderer/components/planning/PlanningBoard.css
@@ -168,8 +168,32 @@
   font-size: 11px;
   color: var(--text-muted);
   background: var(--bg-elevated);
+  border: 1px solid transparent;
   border-radius: 10px;
   padding: 1px 8px;
+  cursor: pointer;
+  font-variant-numeric: tabular-nums;
+}
+
+.planning-column__count:hover {
+  border-color: var(--border);
+  color: var(--text-secondary);
+}
+
+/* Over the WIP limit */
+.planning-column__count.is-over {
+  color: #fff;
+  background: var(--error);
+}
+
+.planning-column__wip-input {
+  width: 52px;
+  font-size: 11px;
+  padding: 1px 6px;
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  background: var(--bg-surface);
+  color: var(--text-primary);
 }
 
 .planning-column__add {

--- a/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
+++ b/apps/desktop/src/renderer/components/planning/PlanningColumn.tsx
@@ -1,8 +1,10 @@
 import { memo, useCallback, useState } from 'react';
 import { Plus } from 'lucide-react';
 import type { NoteSnapshot, BoardStage, NotePriority } from '../../../preload/index';
+import { usePlanningStore } from '../../stores/planningStore';
 import { PlanningCard } from './PlanningCard';
 import { NOTE_MIME, BOARD_STAGE_LABELS } from './constants';
+import { isOverWipLimit, parseWipLimit } from './wip';
 
 type DropSide = 'above' | 'below' | 'append';
 
@@ -37,6 +39,19 @@ export const PlanningColumn = memo(function PlanningColumn({
   onDeleteNote,
 }: PlanningColumnProps) {
   const [isOver, setIsOver] = useState(false);
+
+  const wipLimit = usePlanningStore(s => s.wipLimits[stage]);
+  const setWipLimit = usePlanningStore(s => s.setWipLimit);
+  const [editingLimit, setEditingLimit] = useState(false);
+  const overLimit = isOverWipLimit(notes.length, wipLimit);
+
+  const commitLimit = useCallback(
+    (raw: string) => {
+      setWipLimit(stage, parseWipLimit(raw));
+      setEditingLimit(false);
+    },
+    [setWipLimit, stage]
+  );
 
   // preventDefault unconditionally so the drop always fires (some Chromium
   // builds don't enumerate custom types in `types` during dragover).
@@ -79,7 +94,31 @@ export const PlanningColumn = memo(function PlanningColumn({
     >
       <header className="planning-column__header">
         <span className="planning-column__title">{BOARD_STAGE_LABELS[stage]}</span>
-        <span className="planning-column__count">{notes.length}</span>
+        {editingLimit ? (
+          <input
+            type="number"
+            min={1}
+            className="planning-column__wip-input"
+            defaultValue={wipLimit ?? ''}
+            placeholder="∞"
+            autoFocus
+            aria-label={`WIP limit for ${BOARD_STAGE_LABELS[stage]}`}
+            onBlur={e => commitLimit(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') commitLimit((e.target as HTMLInputElement).value);
+              else if (e.key === 'Escape') setEditingLimit(false);
+            }}
+          />
+        ) : (
+          <button
+            type="button"
+            className={`planning-column__count ${overLimit ? 'is-over' : ''}`}
+            onClick={() => setEditingLimit(true)}
+            title={wipLimit ? `WIP limit ${wipLimit} — click to edit` : 'Set a WIP limit'}
+          >
+            {wipLimit ? `${notes.length} / ${wipLimit}` : notes.length}
+          </button>
+        )}
         <button
           type="button"
           className="planning-column__add"

--- a/apps/desktop/src/renderer/components/planning/__tests__/wip.test.ts
+++ b/apps/desktop/src/renderer/components/planning/__tests__/wip.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { isOverWipLimit, parseWipLimit } from '../wip';
+
+describe('isOverWipLimit', () => {
+  it('is false when no limit is set', () => {
+    expect(isOverWipLimit(10, null)).toBe(false);
+    expect(isOverWipLimit(10, undefined)).toBe(false);
+    expect(isOverWipLimit(10, 0)).toBe(false);
+  });
+
+  it('is false at or under the limit', () => {
+    expect(isOverWipLimit(3, 3)).toBe(false);
+    expect(isOverWipLimit(2, 3)).toBe(false);
+  });
+
+  it('is true over the limit', () => {
+    expect(isOverWipLimit(4, 3)).toBe(true);
+  });
+});
+
+describe('parseWipLimit', () => {
+  it('parses a positive integer', () => {
+    expect(parseWipLimit('5')).toBe(5);
+    expect(parseWipLimit('  12 ')).toBe(12);
+  });
+
+  it('returns null for empty/zero/negative/non-numeric', () => {
+    expect(parseWipLimit('')).toBeNull();
+    expect(parseWipLimit('0')).toBeNull();
+    expect(parseWipLimit('-3')).toBeNull();
+    expect(parseWipLimit('abc')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/planning/wip.ts
+++ b/apps/desktop/src/renderer/components/planning/wip.ts
@@ -1,0 +1,14 @@
+/**
+ * Pure WIP-limit helpers for the Planning board — side-effect free for testing.
+ */
+
+/** A column is over its WIP limit when a positive limit is set and exceeded. */
+export function isOverWipLimit(count: number, limit: number | null | undefined): boolean {
+  return typeof limit === 'number' && limit > 0 && count > limit;
+}
+
+/** Parse a raw WIP-limit input into a stored value: a positive int, or null (no limit). */
+export function parseWipLimit(raw: string): number | null {
+  const n = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}

--- a/apps/desktop/src/renderer/stores/planningStore.ts
+++ b/apps/desktop/src/renderer/stores/planningStore.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import type { BoardStage } from '../../preload/index';
+
+// ============================================================================
+// Store Interface
+// ============================================================================
+
+interface PlanningStore {
+  /** Per-column WIP limit. Absent/0 = no limit. */
+  wipLimits: Partial<Record<BoardStage, number>>;
+  setWipLimit: (stage: BoardStage, limit: number | null) => void;
+}
+
+// ============================================================================
+// Store Implementation (persisted to localStorage)
+// ============================================================================
+
+export const usePlanningStore = create<PlanningStore>()(
+  persist(
+    set => ({
+      wipLimits: {},
+      setWipLimit: (stage, limit) =>
+        set(state => {
+          const next = { ...state.wipLimits };
+          if (limit === null || !Number.isFinite(limit) || limit <= 0) {
+            delete next[stage];
+          } else {
+            next[stage] = Math.floor(limit);
+          }
+          return { wipLimits: next };
+        }),
+    }),
+    { name: 'dripnex-planning' }
+  )
+);


### PR DESCRIPTION
## Summary

Adds **per-column WIP limits** to the Planning board (follow-up #1). **Stacked on #444** — base is `feature/planning-kanban-data`; will retarget to `develop` once #444 merges.

- Click a column's count badge to set a **WIP limit** (persisted per stage in `localStorage` via a small zustand store).
- When a limit is set the badge shows `count / limit`; it turns **red** when the column exceeds its limit.
- Empty / 0 clears the limit (∞).

## Files
- `stores/planningStore.ts` — persisted per-stage WIP limits (zustand + `persist`)
- `components/planning/wip.ts` — pure `isOverWipLimit` / `parseWipLimit` helpers
- `components/planning/PlanningColumn.tsx` — inline limit editor + over-limit styling
- `components/planning/__tests__/wip.test.ts` — unit tests for the helpers

## Testing
- `pnpm typecheck` / `pnpm lint` — green
- `pnpm --filter @dripnex/desktop test` — 66 passing (+5 new WIP tests)
- `pnpm --filter @dripnex/desktop build` — bundles OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)